### PR TITLE
Fix Playwright config to skip webServer when no E2E tests exist

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:4321',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -32,9 +32,8 @@ export default defineConfig({
   // Start dev server for E2E tests
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:4321',
     reuseExistingServer: !process.env.CI,
-    timeout: 180 * 1000,  // 3 minutes - increased for CI environment
-    ignoreHTTPSErrors: true,
+    timeout: 120 * 1000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,4 @@
 import { defineConfig, devices } from '@playwright/test';
-import * as fs from 'fs';
-import * as path from 'path';
-
-// Check if there are any E2E test files
-const e2eDir = './tests/e2e';
-const hasE2ETests = fs.existsSync(e2eDir) &&
-  fs.readdirSync(e2eDir).some(file => file.endsWith('.test.ts'));
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -36,11 +29,12 @@ export default defineConfig({
     },
   ],
 
-  // Only start webServer if there are E2E tests to run
-  webServer: hasE2ETests ? {
+  // Start dev server for E2E tests
+  webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  } : undefined,
+    timeout: 180 * 1000,  // 3 minutes - increased for CI environment
+    ignoreHTTPSErrors: true,
+  },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Check if there are any E2E test files
+const e2eDir = './tests/e2e';
+const hasE2ETests = fs.existsSync(e2eDir) &&
+  fs.readdirSync(e2eDir).some(file => file.endsWith('.test.ts'));
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -29,10 +36,11 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
+  // Only start webServer if there are E2E tests to run
+  webServer: hasE2ETests ? {
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
-  },
+  } : undefined,
 });

--- a/tests/e2e/homepage.test.ts
+++ b/tests/e2e/homepage.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test('should load the homepage', async ({ page }) => {
+    await page.goto('/');
+
+    // Verify the page loaded
+    const pageTitle = page.locator('title');
+    await expect(pageTitle).toBeTruthy();
+
+    // Verify body exists
+    const body = page.locator('body');
+    await expect(body).toBeVisible();
+  });
+
+  test('should have main content', async ({ page }) => {
+    await page.goto('/');
+
+    // Basic check that page has some content
+    const html = await page.content();
+    expect(html.length).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
Playwright was trying to start the dev server even with no E2E test files, causing a timeout. Now it only starts the server if E2E tests are present.