### PR TITLE
Diligence Machine, Hub pages, and site-wide improvements

### DIFF
--- a/src/data/diligence-machine/attention-areas.ts
+++ b/src/data/diligence-machine/attention-areas.ts
@@ -54,7 +54,7 @@ export const ATTENTION_AREAS: AttentionArea[] = [
     id: 'attention-key-person',
     title: 'Key-Person Technical Dependencies',
     description:
-      'Small engineering teams (under 50) in on-premise or self-managed environments often concentrate critical knowledge in 1-2 individuals. Assess bus factor and knowledge transfer exposure before close.',
+      'Small engineering teams (under 50) in on-premise or self-managed environments often concentrate critical knowledge in 1-2 individuals. Assess key person dependencies, risks and knowledge gaps before close.',
     relevance: 'high',
     conditions: {
       techArchetypes: ['on-premise-enterprise', 'self-managed-infra'],

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,4 +1,58 @@
 [
+   {
+    "id": "project-atlas",
+    "codeName": "Project Atlas",
+    "industry": "Healthcare Revenue Cycle Management",
+    "theme": "Healthcare",
+    "summary": "Cloud-augmented platform providing accounts receivable management, medical revenue recovery, insurance follow-up, and collection services using core collections workflow system with modern peripheral integrations.",
+    "arr": "$67M",
+    "arrNumeric": 67000000,
+    "currency": "USD",
+    "growthStage": "Mature / Expansion",
+    "year": 2026,
+    "technologies": [
+      "FACS",
+      "Caché",
+      ".NET",
+      "C#",
+      "AWS",
+      "SQL Server",
+      "QuickBooks Online",
+      "Python",
+      "Fortra Automate RPA",
+      "VMware"
+    ],
+    "engagementType": "Buy-Side Technical Diligence",
+    "engagementTypeTag": "buy-side-diligence",
+    "engagementTypeDescription": "Pre-acquisition technology assessment for PE investors",
+    "challenge": "Assessing technology readiness for revenue growth and integration compatibility of a healthcare collections platform built on legacy FACS system.",
+    "solution": "Validated strong operational foundation with SOC 2 Type 2 compliance, efficient service delivery through pragmatic commercial platforms, and identified long-range platform transition planning needs while confirming scalability without disproportionate investment.",
+    "engagementCategory": "Buy-Side Technical Due Diligence"
+  },
+  {
+    "id": "atlas-arrow",
+    "codeName": "Atlas-Arrow",
+    "industry": "Healthcare Revenue Cycle Management",
+    "theme": "Healthcare",
+    "summary": "Post-acquisition integration combining two healthcare revenue cycle platforms to optimize margin through automation-driven insurance follow-up, consolidate bad debt operations, and unify foundational IT infrastructure.",
+    "arr": "$50M",
+    "arrNumeric": 50000000,
+    "currency": "USD",
+    "growthStage": "Mature",
+    "year": 2026,
+    "technologies": [
+      "AS-400",
+      "Azure AD",
+      "FACS",
+      ".NET"
+    ],
+    "engagementType": "Value Creation - Integration",
+    "engagementTypeTag": "value-creation-integration",
+    "engagementTypeDescription": "Post-acquisition platform and system integration",
+    "challenge": "Integrating two healthcare revenue cycle platforms while capturing margin opportunities through VARR automation and consolidating foundational IT operations.",
+    "solution": "Developed phased integration strategy prioritizing Insurance Follow-Up migration to Arrow for VARR automation, Bad Debt consolidation to Atlas for capacity optimization, and foundational IT consolidation for efficiency gains of $290-480k OTC and $250-375k annual savings.",
+    "engagementCategory": "Value Creation & Strategy"
+  },
   {
     "id": "project-eclipse",
     "codeName": "Project Eclipse",

--- a/src/pages/hub/tools/diligence-machine/index.astro
+++ b/src/pages/hub/tools/diligence-machine/index.astro
@@ -559,7 +559,6 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
                 .map((area) => `
                     <div class="doc-attention-card relevance-${escapeHtml(area.relevance)}">
                         <div class="doc-attention-header">
-                            <span class="doc-attention-badge">${escapeHtml(area.relevance)}</span>
                             <h3 class="doc-attention-title">${escapeHtml(area.title)}</h3>
                         </div>
                         <div class="doc-attention-divider"></div>
@@ -1783,34 +1782,6 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
         gap: var(--spacing-sm);
     }
 
-    .doc-attention-grid :global(.doc-attention-badge) {
-        display: inline-block;
-        font-size: 0.7rem;
-        font-weight: var(--font-weight-bold);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        padding: 2px var(--spacing-sm);
-        border-radius: 2px;
-        flex-shrink: 0;
-    }
-
-    .doc-attention-grid :global(.relevance-high .doc-attention-badge) {
-        background: rgba(91, 122, 157, 0.15);
-        color: #5b7a9d;
-        border: 1px solid rgba(91, 122, 157, 0.3);
-    }
-
-    .doc-attention-grid :global(.relevance-medium .doc-attention-badge) {
-        background: rgba(140, 122, 107, 0.15);
-        color: #8c7a6b;
-        border: 1px solid rgba(140, 122, 107, 0.3);
-    }
-
-    .doc-attention-grid :global(.relevance-low .doc-attention-badge) {
-        background: rgba(5, 205, 153, 0.15);
-        color: var(--color-primary);
-        border: 1px solid rgba(5, 205, 153, 0.3);
-    }
 
     .doc-attention-grid :global(.doc-attention-title) {
         font-size: var(--text-base);
@@ -2511,12 +2482,6 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
             page-break-inside: avoid;
         }
 
-        .doc-attention-grid :global(.doc-attention-badge) {
-            font-size: 0.6rem;
-            padding: 1px 6px;
-            display: inline-block;
-            flex-shrink: 0;
-        }
 
         .doc-attention-grid :global(.doc-attention-title) {
             font-size: 13px;

--- a/src/pages/hub/tools/diligence-machine/index.astro
+++ b/src/pages/hub/tools/diligence-machine/index.astro
@@ -20,7 +20,7 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
             <header class="dm-header">
                 <span class="section-label">Tools</span>
                 <h1>The Diligence Machine</h1>
-                <p class="dm-subtitle">Generate a customized, prescriptive technology due diligence agenda.</p>
+                <p class="dm-subtitle">Generate a customized, prescriptive technology discovery agenda.</p>
             </header>
 
             <!-- Wizard Container -->

--- a/tests/e2e/diligence-machine.test.ts
+++ b/tests/e2e/diligence-machine.test.ts
@@ -681,12 +681,6 @@ test.describe('Diligence Machine E2E', () => {
       // Verify first anchor structure
       const firstAnchor = page.locator('.doc-attention-card').first();
 
-      // Has relevance badge
-      const badge = firstAnchor.locator('.doc-attention-badge');
-      await expect(badge).toBeVisible();
-      const relevance = await badge.textContent();
-      expect(['high', 'medium', 'low']).toContain(relevance);
-
       // Has title
       const title = firstAnchor.locator('.doc-attention-title');
       await expect(title).toBeVisible();


### PR DESCRIPTION
## Summary
- **The Diligence Machine**: Full-featured tech diligence wizard with attention areas engine, question framework, and PDF-ready document generation
- **Hub pages**: New hub landing, tools, library, and radar section pages with production-gated teaser cards
- **Site-wide**: SEO component, design system (variables, typography, interactions CSS), favicon/manifest, privacy page, engagement flow, and portfolio updates
- **Testing**: Comprehensive E2E and unit test coverage for all new features (diligence engine, wizard navigation, portfolio filtering, mobile nav)
- **Copy refinements**: Removed AI-telltale emdashes from attention areas, removed presumptive relevance badges, updated disclaimers

## Test plan
- [ ] Verify Diligence Machine wizard flow end-to-end in all browsers
- [ ] Confirm attention areas render without relevance badges
- [ ] Validate PDF/print output formatting
- [ ] Check hub pages display correctly with teaser cards hidden in production
- [ ] Verify SEO meta tags and JSON-LD structured data
- [ ] Run full test suite (`npm run test:all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)