### PR TITLE
Portfolio modal industry, attention area cleanup, and data fix

### DIFF
--- a/src/components/portfolio/ProjectModal.astro
+++ b/src/components/portfolio/ProjectModal.astro
@@ -43,6 +43,7 @@
       <h3 class="modal-section-title">Engagement Type</h3>
       <p id="modal-engagement-type-2" class="modal-engagement-type" data-testid="project-modal-engagement-type">Engagement Type</p>
       <p id="modal-engagement-description-2" class="modal-text" data-testid="project-modal-engagement-description">Engagement description goes here.</p>
+      <p id="modal-engagement-industry-2" class="modal-engagement-industry" data-testid="project-modal-engagement-industry">Industry</p>
     </div>
 
     <div class="modal-section">
@@ -232,6 +233,13 @@
     letter-spacing: -0.01em;
   }
 
+  .modal-engagement-industry {
+    font-size: 0.8125rem;
+    color: rgba(26, 26, 26, 0.5);
+    margin: 0.5rem 0 0 0;
+    font-weight: 500;
+  }
+
   /* Dark theme modal */
   :global(html.dark-theme) .project-modal {
     background: #1a1a1a;
@@ -286,6 +294,10 @@
 
   :global(html.dark-theme) .modal-engagement-type {
     color: #05cd99;
+  }
+
+  :global(html.dark-theme) .modal-engagement-industry {
+    color: rgba(200, 200, 200, 0.5);
   }
 
   @media (max-width: 768px) {
@@ -388,6 +400,10 @@
       if (modalTheme) modalTheme.textContent = project.theme;
       if (modalEngagementType) modalEngagementType.textContent = project.engagementType || 'N/A';
       if (modalEngagementDesc) modalEngagementDesc.textContent = project.engagementTypeDescription || '';
+
+      const modalEngagementIndustry = document.getElementById('modal-engagement-industry-2');
+      if (modalEngagementIndustry) modalEngagementIndustry.textContent = project.industry || '';
+
       if (modalSummary) modalSummary.textContent = project.summary;
 
       // Handle Challenge section (show only if present)

--- a/src/data/diligence-machine/attention-areas.ts
+++ b/src/data/diligence-machine/attention-areas.ts
@@ -177,16 +177,6 @@ export const ATTENTION_AREAS: AttentionArea[] = [
     },
   },
   {
-    id: 'attention-multi-jurisdictional-conflict',
-    title: 'Jurisdictional Conflict Exposure',
-    description:
-      'Different regions may impose contradictory requirements (e.g., law enforcement access obligations vs. data protection mandates, or data localization rules conflicting with centralized architecture). These conflicts can force architectural compromises or operational workarounds.',
-    relevance: 'medium',
-    conditions: {
-      geographies: ['multi-region'],
-    },
-  },
-  {
     id: 'attention-multi-infra-cost',
     title: 'Multi-Region Infrastructure Cost Multiplier',
     description:

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -115,7 +115,7 @@
     "industry": "Financial Administration",
     "theme": "Finance",
     "summary": "Unified cloud platform providing integrated company registry, fund administration, employee share plans, and equity management services with automation.",
-    "arr": "A$68M",
+    "arr": "$68M",
     "arrNumeric": 68200000,
     "currency": "AUD",
     "growthStage": "Mature / Leading",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -115,7 +115,7 @@
     "industry": "Financial Administration",
     "theme": "Finance",
     "summary": "Unified cloud platform providing integrated company registry, fund administration, employee share plans, and equity management services with automation.",
-    "arr": "$68M",
+    "arr": "A$68M",
     "arrNumeric": 68200000,
     "currency": "AUD",
     "growthStage": "Mature / Leading",


### PR DESCRIPTION
## Summary
- **Portfolio modal**: Show project industry beneath engagement description for additional context
- **Diligence Machine**: Remove overly theoretical jurisdictional conflict attention area
- **Data**: Normalize Fusion ARR currency prefix from A$ to $

## Test plan
- [ ] Open a portfolio project modal and verify industry displays beneath engagement description
- [ ] Verify industry text is styled correctly in both light and dark themes
- [ ] Run diligence machine and confirm attention areas render without the removed entry
- [ ] Verify Fusion project displays `$68M` (not `A$68M`) in the portfolio

🤖 Generated with [Claude Code](https://claude.com/claude-code)