### PR TITLE
feat(hub/library): add VDR Structure Guide and Library section

### DIFF
--- a/src/pages/hub/library/index.astro
+++ b/src/pages/hub/library/index.astro
@@ -34,7 +34,7 @@ trackPageView('hub-library', 'The Library - Resources | GST');
                 <ul class="tool-features">
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Guidance for organizing a technology-focused VDR</li>
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Folder taxonomy & content recommendations</li>
-                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Common best practices drawn from 100+ buy-side and sell-side due diligence engagements</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Best practices from 100+ buy-side and sell-side engagements</li>
                 </ul>
                 <a href="/hub/library/vdr-structure" class="cta-button primary resource-launch-button">Read Guide</a>
             </article>

--- a/src/pages/hub/library/index.astro
+++ b/src/pages/hub/library/index.astro
@@ -24,7 +24,7 @@ trackPageView('hub-library', 'The Library - Resources | GST');
                 <line x1="16" y1="28" x2="32" y2="28" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 <line x1="16" y1="34" x2="28" y2="34" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
             </svg>
-            <p class="placeholder-description">Strategic intelligence for technical due diligence frameworks and value creation blueprints.</p>
+            <p class="placeholder-description">Useful information for technical due diligence frameworks and value creation blueprints.</p>
             <p class="content-type-label">Downloadable PDF resources, diligence checklists, and case studies</p>
 
             <article class="teaser-card teaser-card--live">

--- a/src/pages/hub/library/index.astro
+++ b/src/pages/hub/library/index.astro
@@ -34,7 +34,7 @@ trackPageView('hub-library', 'The Library - Resources | GST');
                 <ul class="tool-features">
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Guidance for organizing a technology-focused VDR</li>
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Folder taxonomy & content recommendations</li>
-                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Common best practices drawn from 100+ due diligence engagements</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Common best practices drawn from 100+ buy-side and sell-side due diligence engagements</li>
                 </ul>
                 <a href="/hub/library/vdr-structure" class="cta-button primary resource-launch-button">Read Guide</a>
             </article>

--- a/src/pages/hub/library/index.astro
+++ b/src/pages/hub/library/index.astro
@@ -24,8 +24,21 @@ trackPageView('hub-library', 'The Library - Resources | GST');
                 <line x1="16" y1="28" x2="32" y2="28" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 <line x1="16" y1="34" x2="28" y2="34" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
             </svg>
-            <p class="placeholder-description">Coming soon. Strategic intelligence for technical due diligence frameworks and value creation blueprints.</p>
+            <p class="placeholder-description">Strategic intelligence for technical due diligence frameworks and value creation blueprints.</p>
             <p class="content-type-label">Downloadable PDF resources, diligence checklists, and case studies</p>
+
+            <article class="teaser-card teaser-card--live">
+                <div class="teaser-header">
+                    <h2>Virtual Data Room (VDR) Structure Guide</h2>
+                </div>
+                <ul class="tool-features">
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Guidance for organizing a technology-focused VDR</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Folder taxonomy & content recommendations</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Common best practices drawn from 100+ due diligence engagements</li>
+                </ul>
+                <a href="/hub/library/vdr-structure" class="cta-button primary resource-launch-button">Read Guide</a>
+            </article>
+
             <a href="/hub" class="cta-button secondary">Return to Hub</a>
         </div>
     </section>
@@ -91,6 +104,70 @@ trackPageView('hub-library', 'The Library - Resources | GST');
         color: rgba(200, 200, 200, 0.6);
     }
 
+    .teaser-card {
+        max-width: 600px;
+        margin: 0 auto var(--spacing-3xl);
+        padding: 2rem;
+        background: rgba(5, 205, 153, 0.03);
+        border: 1px solid rgba(5, 205, 153, 0.15);
+        border-radius: 8px;
+        text-align: center;
+    }
+
+    :global(html.dark-theme) .teaser-card {
+        background: rgba(5, 205, 153, 0.05);
+        border-color: rgba(5, 205, 153, 0.2);
+    }
+
+    .teaser-card--live {
+        border-color: rgba(5, 205, 153, 0.3);
+    }
+
+    .teaser-header {
+        margin-bottom: var(--spacing-md);
+    }
+
+    .teaser-card h2 {
+        font-size: 1.3rem;
+        font-weight: 700;
+        color: rgba(26, 26, 26, 0.95);
+        margin: 0;
+    }
+
+    :global(html.dark-theme) .teaser-card h2 {
+        color: rgba(245, 245, 245, 0.95);
+    }
+
+    .tool-features {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+    }
+
+    .tool-features li {
+        font-size: var(--text-base);
+        color: var(--text-light-secondary);
+        line-height: 1.7;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+    }
+
+    .bullet-icon {
+        flex-shrink: 0;
+        margin-top: 0.35em;
+        opacity: 0.8;
+    }
+
+    .resource-launch-button {
+        margin-top: var(--spacing-lg);
+        display: inline-block;
+    }
+
     @media (max-width: 768px) {
         .placeholder-hero {
             padding: 3rem 0;
@@ -102,6 +179,14 @@ trackPageView('hub-library', 'The Library - Resources | GST');
 
         .placeholder-description {
             font-size: 1rem;
+        }
+
+        .teaser-card {
+            padding: 1.5rem;
+        }
+
+        .teaser-card h2 {
+            font-size: 1.15rem;
         }
     }
 
@@ -116,6 +201,10 @@ trackPageView('hub-library', 'The Library - Resources | GST');
 
         .placeholder-description {
             font-size: 0.9rem;
+        }
+
+        .teaser-card {
+            padding: 1.25rem;
         }
     }
 </style>

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -31,6 +31,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <li><a href="#why-it-matters">Why VDR Structure Matters</a></li>
                     <li><a href="#folder-taxonomy">Recommended Folder Taxonomy</a></li>
                     <li><a href="#software-architecture">Software Architecture</a></li>
+                    <li><a href="#sdlc">Software Development Lifecycle</a></li>
                     <li><a href="#product">Product</a></li>
                     <li><a href="#infrastructure-operations">Infrastructure & Operations</a></li>
                     <li><a href="#people-organization">People & Organization</a></li>
@@ -78,26 +79,31 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">02</span>
+                            <h3 class="vdr-folder-name">SDLC</h3>
+                            <p class="vdr-folder-desc">Development methodology, branching strategy, code review, testing practices, and release process.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">03</span>
                             <h3 class="vdr-folder-name">Product</h3>
                             <p class="vdr-folder-desc">Roadmap, release history, feature analytics, UX research, and backlog health.</p>
                         </div>
                         <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">03</span>
+                            <span class="vdr-folder-number">04</span>
                             <h3 class="vdr-folder-name">Infrastructure & Operations</h3>
                             <p class="vdr-folder-desc">Cloud architecture, CI/CD pipelines, monitoring, SLA history, and capacity planning.</p>
                         </div>
                         <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">04</span>
+                            <span class="vdr-folder-number">05</span>
                             <h3 class="vdr-folder-name">People & Organization</h3>
                             <p class="vdr-folder-desc">Org charts, key personnel, headcount census, retention risk, and hiring plan.</p>
                         </div>
                         <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">05</span>
+                            <span class="vdr-folder-number">06</span>
                             <h3 class="vdr-folder-name">Security</h3>
                             <p class="vdr-folder-desc">Security policies, pen test results, incident history, access controls, and BCP/DR plans.</p>
                         </div>
                         <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">06</span>
+                            <span class="vdr-folder-number">07</span>
                             <h3 class="vdr-folder-name">Governance & Compliance</h3>
                             <p class="vdr-folder-desc">Certifications, audit reports, data privacy controls, regulatory correspondence, and licensing.</p>
                         </div>
@@ -120,6 +126,25 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technical debt assessment or code quality reports (SonarQube, CodeClimate, etc.)</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party dependency inventory with license types and update cadence</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Test coverage reports and QA process documentation</li>
+                    </ul>
+                </section>
+
+                <!-- Software Development Lifecycle -->
+                <section class="vdr-section" id="sdlc">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Software Development Lifecycle
+                    </h2>
+                    <p class="vdr-body">How software gets built reveals more about engineering maturity than the software itself. Buyers look for repeatable processes that will survive a change in ownership.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Development methodology: Agile, Scrum, Kanban, or hybrid — including sprint cadence and ceremonies</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Branching and merging strategy: trunk-based, Gitflow, or feature-branch workflow</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Code review process: tooling, approval requirements, average review turnaround</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Testing strategy: unit, integration, end-to-end coverage targets and enforcement</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Release and deployment process: manual vs. automated, gating criteria, rollback procedures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Environment management: development, staging, production parity and provisioning</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Incident and bug triage: severity classification, SLA targets, and escalation paths</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Developer onboarding: time-to-first-commit, documentation quality, and tooling setup</li>
                     </ul>
                 </section>
 
@@ -437,6 +462,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
         font-weight: 700;
         color: var(--text-light-primary);
         margin: var(--spacing-xs) 0;
+        white-space: nowrap;
     }
 
     .vdr-folder-desc {

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -400,6 +400,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
 
     /* Table of Contents */
     .vdr-toc {
+        display: block;
         max-width: 800px;
         margin: 0 auto var(--spacing-3xl);
         padding: var(--spacing-xl);
@@ -560,7 +561,6 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
         font-weight: 700;
         color: var(--text-light-primary);
         margin: var(--spacing-xs) 0;
-        white-space: nowrap;
     }
 
     .vdr-folder-desc {
@@ -596,12 +596,43 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
             font-size: 1rem;
         }
 
+        .vdr-toc {
+            padding: var(--spacing-lg);
+        }
+
+        .vdr-toc-list {
+            padding-left: var(--spacing-lg);
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-xs);
+        }
+
+        .vdr-toc-list li {
+            margin-bottom: 0;
+        }
+
+        .vdr-toc-list a {
+            display: block;
+            padding: var(--spacing-xs) var(--spacing-sm);
+            border-radius: 4px;
+            font-size: var(--text-sm);
+        }
+
+        .vdr-toc-list a:hover {
+            background: rgba(5, 205, 153, 0.08);
+        }
+
         .vdr-folder-grid {
             grid-template-columns: 1fr;
         }
 
         .vdr-folder-card {
             padding: var(--spacing-lg);
+        }
+
+        .vdr-label-group {
+            gap: 0.3em;
         }
     }
 
@@ -618,8 +649,32 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
             font-size: 0.9rem;
         }
 
+        .vdr-toc {
+            padding: var(--spacing-sm);
+        }
+
         .vdr-section-heading {
             font-size: 1.05rem;
+        }
+
+        .vdr-body {
+            line-height: 1.7;
+        }
+
+        .vdr-list li {
+            gap: var(--spacing-xs);
+        }
+
+        .bullet-icon {
+            margin-top: 0.3em;
+        }
+
+        .vdr-label-group {
+            gap: 0.35em;
+        }
+
+        .vdr-label-desc {
+            line-height: 1.7;
         }
     }
 </style>

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -41,6 +41,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <li><a href="#corporate-it">Corporate IT</a></li>
                     <li><a href="#common-pitfalls">Common Pitfalls</a></li>
                     <li><a href="#best-practices">Best Practices</a></li>
+                    <li><a href="#vdr-platforms">VDR Platforms</a></li>
                 </ol>
             </nav>
 
@@ -331,6 +332,25 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     </ul>
                 </section>
 
+                <!-- VDR Platforms -->
+                <section class="vdr-section" id="vdr-platforms">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        VDR Platforms
+                    </h2>
+                    <p class="vdr-body">Core VDR functionality is highly commoditized. Most providers offer the same baseline: secure document storage, granular permissions, Q&A workflows, audit trails, and watermarking. Each platform has its own niceties and annoyances. The following are listed alphabetically and do not represent an endorsement.</p>
+                    <ul class="vdr-list vdr-list--labeled">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.ansarada.com" target="_blank" rel="noopener noreferrer">Ansarada</a></strong><span class="vdr-label-desc">AI-powered deal management platform with built-in bidder engagement scoring and workflow automation.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.box.com" target="_blank" rel="noopener noreferrer">Box</a></strong><span class="vdr-label-desc">Cloud content management platform with enterprise-grade security and broad third-party integrations.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.datasite.com" target="_blank" rel="noopener noreferrer">Datasite</a></strong><span class="vdr-label-desc">Purpose-built M&A platform (formerly Merrill DatasiteOne) with redaction, AI-assisted document organization, and deal analytics.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.dfsvenue.com" target="_blank" rel="noopener noreferrer">Venue (DFS)</a></strong><span class="vdr-label-desc">Deal-focused VDR with streamlined setup, granular permissions, and integrated Q&A tracking.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://drive.google.com" target="_blank" rel="noopener noreferrer">Google Drive</a></strong><span class="vdr-label-desc">General-purpose cloud storage often used for early-stage or lower-middle-market deals where dedicated VDR cost is not justified.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.intralinks.com" target="_blank" rel="noopener noreferrer">Intralinks</a></strong><span class="vdr-label-desc">Established M&A data room provider with strong compliance features and global deal network.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.microsoft.com/en-us/microsoft-365/sharepoint" target="_blank" rel="noopener noreferrer">SharePoint</a></strong><span class="vdr-label-desc">Microsoft ecosystem document management commonly used internally before migrating to a dedicated VDR for external diligence.</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong><a href="https://www.smartroom.com" target="_blank" rel="noopener noreferrer">SmartRoom</a></strong><span class="vdr-label-desc">Virtual data room with dynamic watermarking, fence view protection, and detailed user activity reporting.</span></span></li>
+                    </ul>
+                </section>
+
             </div>
 
             <div class="vdr-back-nav">
@@ -469,6 +489,17 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
 
     .vdr-list strong {
         color: var(--text-light-primary);
+    }
+
+    .vdr-list strong a {
+        color: var(--color-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+    }
+
+    .vdr-list strong a:hover {
+        color: var(--color-primary-dark);
+        text-decoration: underline;
     }
 
     .vdr-list code {

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -30,13 +30,12 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <li><a href="#what-this-is">What This Is</a></li>
                     <li><a href="#why-it-matters">Why VDR Structure Matters</a></li>
                     <li><a href="#folder-taxonomy">Recommended Folder Taxonomy</a></li>
-                    <li><a href="#corporate-legal">Corporate & Legal</a></li>
-                    <li><a href="#financial">Financial</a></li>
-                    <li><a href="#technology-product">Technology & Product</a></li>
+                    <li><a href="#software-architecture">Software Architecture</a></li>
+                    <li><a href="#product">Product</a></li>
+                    <li><a href="#infrastructure-operations">Infrastructure & Operations</a></li>
                     <li><a href="#people-organization">People & Organization</a></li>
-                    <li><a href="#commercial">Commercial & Go-to-Market</a></li>
-                    <li><a href="#security-compliance">Security & Compliance</a></li>
-                    <li><a href="#operations-infrastructure">Operations & Infrastructure</a></li>
+                    <li><a href="#security">Security</a></li>
+                    <li><a href="#governance-compliance">Governance & Compliance</a></li>
                     <li><a href="#common-pitfalls">Common Pitfalls</a></li>
                     <li><a href="#best-practices">Best Practices</a></li>
                 </ol>
@@ -70,115 +69,99 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
                         Recommended Folder Taxonomy
                     </h2>
-                    <p class="vdr-body">Use a numbered prefix convention for top-level folders to enforce a consistent browsing order across VDR platforms. The following nine categories cover the standard scope of technology due diligence.</p>
+                    <p class="vdr-body">Use a numbered prefix convention for top-level folders to enforce a consistent browsing order across VDR platforms. The following categories cover the technology diligence scope.</p>
                     <div class="vdr-folder-grid">
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">01</span>
-                            <h3 class="vdr-folder-name">Corporate & Legal</h3>
-                            <p class="vdr-folder-desc">Formation documents, cap table, material contracts, IP registrations, litigation, and insurance.</p>
+                            <h3 class="vdr-folder-name">Software Architecture</h3>
+                            <p class="vdr-folder-desc">System design, stack inventory, data models, integration points, and code quality metrics.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">02</span>
-                            <h3 class="vdr-folder-name">Financial</h3>
-                            <p class="vdr-folder-desc">Historical financials, forecasts, revenue breakdowns, AR/AP aging, and tax compliance.</p>
+                            <h3 class="vdr-folder-name">Product</h3>
+                            <p class="vdr-folder-desc">Roadmap, release history, feature analytics, UX research, and backlog health.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">03</span>
-                            <h3 class="vdr-folder-name">Technology & Product</h3>
-                            <p class="vdr-folder-desc">Architecture diagrams, stack inventory, code quality metrics, roadmap, and deployment processes.</p>
+                            <h3 class="vdr-folder-name">Infrastructure & Operations</h3>
+                            <p class="vdr-folder-desc">Cloud architecture, CI/CD pipelines, monitoring, SLA history, and capacity planning.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">04</span>
                             <h3 class="vdr-folder-name">People & Organization</h3>
-                            <p class="vdr-folder-desc">Org charts, key personnel, headcount census, compensation summary, and hiring plan.</p>
+                            <p class="vdr-folder-desc">Org charts, key personnel, headcount census, retention risk, and hiring plan.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">05</span>
-                            <h3 class="vdr-folder-name">Commercial & Go-to-Market</h3>
-                            <p class="vdr-folder-desc">Customer data, churn metrics, pricing models, sales pipeline, and channel agreements.</p>
+                            <h3 class="vdr-folder-name">Security</h3>
+                            <p class="vdr-folder-desc">Security policies, pen test results, incident history, access controls, and BCP/DR plans.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">06</span>
-                            <h3 class="vdr-folder-name">Security & Compliance</h3>
-                            <p class="vdr-folder-desc">Security frameworks, pen test results, incident history, data privacy, and audit reports.</p>
-                        </div>
-                        <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">07</span>
-                            <h3 class="vdr-folder-name">Operations & Infrastructure</h3>
-                            <p class="vdr-folder-desc">Cloud architecture, monitoring setup, SLA history, vendor inventory, and CI/CD pipelines.</p>
-                        </div>
-                        <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">08</span>
-                            <h3 class="vdr-folder-name">Management Presentations</h3>
-                            <p class="vdr-folder-desc">Board decks, investor materials, strategic plans, and narrative documents for context.</p>
-                        </div>
-                        <div class="vdr-folder-card">
-                            <span class="vdr-folder-number">09</span>
-                            <h3 class="vdr-folder-name">Q&A Log</h3>
-                            <p class="vdr-folder-desc">Buyer questions, management responses, follow-up requests, and supplemental materials.</p>
+                            <h3 class="vdr-folder-name">Governance & Compliance</h3>
+                            <p class="vdr-folder-desc">Certifications, audit reports, data privacy controls, regulatory correspondence, and licensing.</p>
                         </div>
                     </div>
                 </section>
 
-                <!-- Section 3: Corporate & Legal -->
-                <section class="vdr-section" id="corporate-legal">
+                <!-- Software Architecture -->
+                <section class="vdr-section" id="software-architecture">
                     <h2 class="vdr-section-heading">
                         <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Corporate & Legal
+                        Software Architecture
                     </h2>
-                    <p class="vdr-body">The foundation of any VDR. Buyers and their legal counsel will request these documents first, and incomplete corporate records are among the most common causes of diligence delays.</p>
-                    <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Articles of incorporation, bylaws, and certificates of good standing</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Fully diluted cap table with option pool, warrants, and convertible instruments</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Equity agreements, stock option plans, and vesting schedules</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Material contracts: top customer agreements, vendor MSAs, and partner agreements</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Litigation history, pending legal matters, and regulatory correspondence</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Insurance policies: D&O, E&O, cyber liability, general commercial</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />IP registrations: patents, trademarks, copyrights, and domain portfolio</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Employee and contractor IP assignment agreements</li>
-                    </ul>
-                </section>
-
-                <!-- Section 4: Financial -->
-                <section class="vdr-section" id="financial">
-                    <h2 class="vdr-section-heading">
-                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Financial
-                    </h2>
-                    <p class="vdr-body">Financial diligence requires both historical accuracy and forward-looking clarity. Provide clean, reconcilable data with consistent formatting across periods. Unexplained gaps or adjustments are red flags.</p>
-                    <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Historical financials: 3-5 years of P&L, balance sheet, and cash flow statements</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monthly and quarterly management reports for the trailing 24 months</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Annual budget, rolling forecasts, and underlying assumptions</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Revenue breakdowns by customer, product line, and geography</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Accounts receivable and accounts payable aging reports</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Tax returns (federal, state, international) for the past 3 years</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Deferred revenue schedule and revenue recognition policies</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capitalization of R&D expenses and amortization schedules</li>
-                    </ul>
-                </section>
-
-                <!-- Section 5: Technology & Product -->
-                <section class="vdr-section" id="technology-product">
-                    <h2 class="vdr-section-heading">
-                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Technology & Product
-                    </h2>
-                    <p class="vdr-body">This is where technology-focused buyers spend the most time. The goal is to give the diligence team a clear picture of the system without requiring access to source code repositories in early stages.</p>
+                    <p class="vdr-body">This is where technology-focused buyers spend the most time. The goal is to give the diligence team a clear picture of how the system is built without requiring access to source code repositories in early stages.</p>
                     <ul class="vdr-list">
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />System architecture diagrams: high-level, network topology, and data flow</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technology stack inventory: languages, frameworks, databases, and third-party services</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data model and schema documentation: entity relationships, storage engines, and migration history</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Repository structure overview: service boundaries, monorepo vs. polyrepo, code metrics</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technical debt assessment or code quality reports (SonarQube, CodeClimate, etc.)</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Product roadmap with current quarter priorities and 12-month outlook</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Release history: frequency, deployment process, rollback procedures</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />API documentation, integration points, and webhook/event architectures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technical debt assessment or code quality reports (SonarQube, CodeClimate, etc.)</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party dependency inventory with license types and update cadence</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Test coverage reports and QA process documentation</li>
                     </ul>
                 </section>
 
-                <!-- Section 6: People & Organization -->
+                <!-- Product -->
+                <section class="vdr-section" id="product">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Product
+                    </h2>
+                    <p class="vdr-body">Buyers evaluate whether the product organization can sustain innovation post-transaction. This section should demonstrate how the team prioritizes, ships, and measures outcomes.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Product roadmap: current quarter priorities, 12-month outlook, and strategic themes</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Release history: cadence, versioning approach, and rollback procedures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Feature adoption and usage analytics: DAU/MAU, feature engagement, and cohort trends</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Backlog health: size, age distribution, ratio of new features to tech debt to bugs</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Product management process: how priorities are set, how customer input is incorporated</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />UX research artifacts: personas, journey maps, and usability study summaries</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Competitive feature matrix: how the product positions against key alternatives</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Customer feedback channels: NPS scores, support ticket trends, and feature request tracking</li>
+                    </ul>
+                </section>
+
+                <!-- Infrastructure & Operations -->
+                <section class="vdr-section" id="infrastructure-operations">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Infrastructure & Operations
+                    </h2>
+                    <p class="vdr-body">Operational maturity directly impacts post-acquisition integration costs. Buyers assess whether infrastructure can scale and whether operational processes are documented or tribal.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cloud infrastructure documentation: provider, account structure, and resource inventory</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Hosting and deployment architecture: environments, promotion workflow, and IaC coverage</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />CI/CD pipeline overview: build, test, and deployment automation</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Database architecture: engines, replication strategy, backup procedures, and data volumes</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capacity planning: current utilization, scaling triggers, and growth headroom</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor and tool inventory: SaaS subscriptions, annual spend, and contract renewal dates</li>
+                    </ul>
+                </section>
+
+                <!-- People & Organization -->
                 <section class="vdr-section" id="people-organization">
                     <h2 class="vdr-section-heading">
                         <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
@@ -197,60 +180,41 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     </ul>
                 </section>
 
-                <!-- Section 7: Commercial & Go-to-Market -->
-                <section class="vdr-section" id="commercial">
+                <!-- Security -->
+                <section class="vdr-section" id="security">
                     <h2 class="vdr-section-heading">
                         <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Commercial & Go-to-Market
-                    </h2>
-                    <p class="vdr-body">Revenue quality and customer health are central to valuation. This section should demonstrate the durability and predictability of the revenue base.</p>
-                    <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Customer list with ARR/MRR attribution and contract terms</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Customer concentration analysis: top 10, top 20, and single-customer exposure</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cohort-level churn, retention, and net dollar retention metrics</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Sales pipeline: stage distribution, average deal size, and conversion rates</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Pricing model documentation: rate cards, discount policies, and packaging tiers</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Channel and reseller agreements with commission structures</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Marketing spend breakdown and customer acquisition cost by channel</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Competitive landscape summary and market positioning</li>
-                    </ul>
-                </section>
-
-                <!-- Section 8: Security & Compliance -->
-                <section class="vdr-section" id="security-compliance">
-                    <h2 class="vdr-section-heading">
-                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Security & Compliance
+                        Security
                     </h2>
                     <p class="vdr-body">Security posture is increasingly a deal-breaker in technology transactions. Gaps here can trigger purchase price adjustments or outright deal termination. Proactive disclosure demonstrates maturity.</p>
                     <ul class="vdr-list">
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Security policy framework: information security, acceptable use, and data classification</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Compliance certifications: SOC 2 Type II, ISO 27001, HITRUST, or equivalent</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Most recent penetration test report (executive summary, redacted as appropriate)</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Security incident history and incident response procedures</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data privacy compliance: GDPR, CCPA, HIPAA applicability and controls</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Access control architecture: SSO, MFA, role-based permissions, and privileged access</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vulnerability management: scanning cadence, patching SLAs, and remediation tracking</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Business continuity and disaster recovery plans with RPO/RTO targets</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party audit reports and vendor security assessments</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Network segmentation and perimeter defense documentation</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Security awareness training program and phishing simulation results</li>
                     </ul>
                 </section>
 
-                <!-- Section 9: Operations & Infrastructure -->
-                <section class="vdr-section" id="operations-infrastructure">
+                <!-- Governance & Compliance -->
+                <section class="vdr-section" id="governance-compliance">
                     <h2 class="vdr-section-heading">
                         <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
-                        Operations & Infrastructure
+                        Governance & Compliance
                     </h2>
-                    <p class="vdr-body">Operational maturity directly impacts post-acquisition integration costs. Buyers assess whether infrastructure can scale and whether operational processes are documented or tribal.</p>
+                    <p class="vdr-body">Compliance readiness determines whether the target can operate in regulated environments post-close. Buyers look for evidence of systematic controls, not just certifications on paper.</p>
                     <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cloud infrastructure documentation: provider, account structure, and resource inventory</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Hosting and deployment architecture: environments, promotion workflow, and IaC coverage</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor and tool inventory: SaaS subscriptions, annual spend, and contract renewal dates</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />CI/CD pipeline overview: build, test, and deployment automation</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capacity planning: current utilization, scaling triggers, and growth headroom</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Database architecture: engines, replication strategy, backup procedures, and data volumes</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Compliance certifications: SOC 2 Type II, ISO 27001, HITRUST, or equivalent</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party audit reports and findings remediation status</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data privacy compliance: GDPR, CCPA, HIPAA applicability and controls</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data processing agreements and cross-border transfer mechanisms</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Open-source license compliance: inventory, policy, and known exposure</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Change management and access review procedures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Regulatory correspondence and any outstanding remediation commitments</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor risk management program and third-party assessment results</li>
                     </ul>
                 </section>
 

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -190,10 +190,10 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <ul class="vdr-list">
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cloud infrastructure documentation: provider, account structure, and resource inventory</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Hosting and deployment architecture: environments, promotion workflow, and IaC coverage</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Database architecture: engines, replication strategy, backup procedures, and data volumes</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Infrastructure capacity planning: current utilization, scaling triggers, and growth headroom</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor and tool inventory: SaaS subscriptions, annual spend, and contract renewal dates</li>
                     </ul>
                 </section>
@@ -300,15 +300,15 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         Common Pitfalls
                     </h2>
                     <p class="vdr-body">These are the mistakes that repeatedly slow down diligence timelines and erode buyer confidence. Each one is avoidable with upfront preparation.</p>
-                    <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Flat folder structures</strong> &mdash; Hundreds of files in a single directory with no logical grouping forces buyers to search instead of browse</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>No naming convention</strong> &mdash; Files named "Final_v3_REVISED_JB.xlsx" create confusion about which version is authoritative</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Stale or undated documents</strong> &mdash; Materials without dates leave buyers guessing whether information is current or obsolete</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Incomplete financial data</strong> &mdash; Missing months, unexplained adjustments, or format inconsistencies between periods trigger follow-up requests</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Oversharing pre-LOI</strong> &mdash; Disclosing sensitive customer data, source code, or salary details before a signed Letter of Intent exposes the company unnecessarily</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Missing architecture diagrams</strong> &mdash; Without visual representations, buyers must reverse-engineer the system from scattered documents</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Ignoring the diligence request list</strong> &mdash; Uploading materials without mapping them to the buyer's specific request list creates unnecessary back-and-forth</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>No access controls</strong> &mdash; Granting all parties full access to all documents, instead of staging disclosure by workstream or phase</li>
+                    <ul class="vdr-list vdr-list--labeled">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Flat folder structures</strong><span class="vdr-label-desc">Hundreds of files in a single directory with no logical grouping forces buyers to search instead of browse</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>No naming convention</strong><span class="vdr-label-desc">Files named "Final_v3_REVISED_JB.xlsx" create confusion about which version is authoritative</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Stale or undated documents</strong><span class="vdr-label-desc">Materials without dates leave buyers guessing whether information is current or obsolete</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Incomplete financial data</strong><span class="vdr-label-desc">Missing months, unexplained adjustments, or format inconsistencies between periods trigger follow-up requests</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Oversharing pre-LOI</strong><span class="vdr-label-desc">Disclosing sensitive customer data, source code, or salary details before a signed Letter of Intent exposes the company unnecessarily</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Missing architecture diagrams</strong><span class="vdr-label-desc">Without visual representations, buyers must reverse-engineer the system from scattered documents</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Ignoring the diligence request list</strong><span class="vdr-label-desc">Uploading materials without mapping them to the buyer's specific request list creates unnecessary back-and-forth</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>No access controls</strong><span class="vdr-label-desc">Granting all parties full access to all documents, instead of staging disclosure by workstream or phase</span></span></li>
                     </ul>
                 </section>
 
@@ -319,15 +319,15 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         Best Practices
                     </h2>
                     <p class="vdr-body">The following practices consistently differentiate well-managed VDRs from the rest. Implement these before granting buyer access.</p>
-                    <ul class="vdr-list">
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Consistent naming convention</strong> &mdash; Use a standard format: <code>[Category]-[Document Name]-[YYYY-MM-DD]</code> for every file</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Root-level index document</strong> &mdash; Provide a master index that maps each folder to the diligence request list items it addresses</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Staged disclosure</strong> &mdash; Structure access by transaction phase: IOI stage (high-level), LOI stage (detailed), and confirmatory (full access)</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Designated VDR administrator</strong> &mdash; Assign a single point of contact responsible for uploads, access management, and version control</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Pre-populate against the request list</strong> &mdash; Map every anticipated diligence request to a document before the VDR opens</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Track Q&A within the platform</strong> &mdash; Use the VDR's built-in Q&A functionality rather than side-channel email threads</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Regular freshness audits</strong> &mdash; Review and update materials monthly during an active process to ensure nothing goes stale</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Watermarking and access logging</strong> &mdash; Enable document watermarks and track download activity by user for information security</li>
+                    <ul class="vdr-list vdr-list--labeled">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Consistent naming convention</strong><span class="vdr-label-desc">Use a standard format: <code>[Category]-[Document Name]-[YYYY-MM-DD]</code> for every file</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Root-level index document</strong><span class="vdr-label-desc">Provide a master index that maps each folder to the diligence request list items it addresses</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Staged disclosure</strong><span class="vdr-label-desc">Structure access by transaction phase: IOI stage (high-level), LOI stage (detailed), and confirmatory (full access)</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Designated VDR administrator</strong><span class="vdr-label-desc">Assign a single point of contact responsible for uploads, access management, and version control</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Pre-populate against the request list</strong><span class="vdr-label-desc">Map every anticipated diligence request to a document before the VDR opens</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Track Q&A within the platform</strong><span class="vdr-label-desc">Use the VDR's built-in Q&A functionality rather than side-channel email threads</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Regular freshness audits</strong><span class="vdr-label-desc">Review and update materials monthly during an active process to ensure nothing goes stale</span></span></li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><span class="vdr-label-group"><strong>Watermarking and access logging</strong><span class="vdr-label-desc">Enable document watermarks and track download activity by user for information security</span></span></li>
                     </ul>
                 </section>
 
@@ -477,6 +477,23 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
         padding: 0.15em 0.4em;
         border-radius: 3px;
         color: var(--color-primary);
+    }
+
+    /* Labeled lists (Best Practices, Common Pitfalls) */
+    .vdr-list--labeled {
+        gap: var(--spacing-lg);
+    }
+
+    .vdr-label-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2em;
+    }
+
+    .vdr-label-desc {
+        font-size: var(--text-sm);
+        color: var(--text-light-muted);
+        line-height: 1.6;
     }
 
     /* Folder Taxonomy Grid */

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -1,0 +1,537 @@
+---
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import { trackPageView } from '../../../../utils/analytics';
+
+trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
+---
+
+<BaseLayout
+    title="Virtual Data Room (VDR) | Strategic Intelligence Hub"
+    description="How to structure a Virtual Data Room for technology due diligence. Folder taxonomy, best practices, and common pitfalls from 100+ engagements."
+    ogTitle="Virtual Data Room (VDR) | GST"
+    ogDescription="Guidance for organizing a technology-focused Virtual Data Room for M&A transactions."
+    ogImage="/og-image.png"
+    ogUrl="https://globalstrategic.tech/hub/library/vdr-structure"
+>
+    <section class="vdr-guide">
+        <div class="container">
+            <header class="vdr-header">
+                <span class="section-label">Resources</span>
+                <h1>VDR Structure Guide</h1>
+                <p class="vdr-subtitle">A reference guide for organizing a technology-focused Virtual Data Room for M&A due diligence.</p>
+            </header>
+
+            <nav class="vdr-toc" aria-label="Table of contents">
+                <h2 class="vdr-section-heading">
+                    <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                    Contents
+                </h2>
+                <ol class="vdr-toc-list">
+                    <li><a href="#what-this-is">What This Is</a></li>
+                    <li><a href="#why-it-matters">Why VDR Structure Matters</a></li>
+                    <li><a href="#folder-taxonomy">Recommended Folder Taxonomy</a></li>
+                    <li><a href="#corporate-legal">Corporate & Legal</a></li>
+                    <li><a href="#financial">Financial</a></li>
+                    <li><a href="#technology-product">Technology & Product</a></li>
+                    <li><a href="#people-organization">People & Organization</a></li>
+                    <li><a href="#commercial">Commercial & Go-to-Market</a></li>
+                    <li><a href="#security-compliance">Security & Compliance</a></li>
+                    <li><a href="#operations-infrastructure">Operations & Infrastructure</a></li>
+                    <li><a href="#common-pitfalls">Common Pitfalls</a></li>
+                    <li><a href="#best-practices">Best Practices</a></li>
+                </ol>
+            </nav>
+
+            <div class="vdr-content">
+
+                <!-- Section 1: What This Is -->
+                <section class="vdr-section" id="what-this-is">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        What This Is
+                    </h2>
+                    <p class="vdr-body">This guide provides a reference strycture for technology-focused VDRs. It draws on patterns observed across 100+ due diligence engagements in enterprise SaaS, platform software, data platforms, tech-enabled businesses, service companies etc.</p>
+                    <p class="vdr-body">Other diligence tracks (i.e., Legal, Tax, Financial) are not covered here Best.</p>
+                </section>
+
+                <!-- Section 2: Why VDR Structure Matters -->
+                <section class="vdr-section" id="why-it-matters">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Why VDR Structure Matters
+                    </h2>
+                    <p class="vdr-body">A Virtual Data Room is the first substantive artifact a buyer encounters during due diligence. Its organization is a direct signal of how well the business is run. A well-structured VDR accelerates deal velocity. A disorganized one erodes buyer confidence and can derail a transaction entirely.</p>
+                    <p class="vdr-body">The difference between a 60-day close and a 120-day close often starts here. Buyers who spend their first week chasing down missing documents or navigating a flat folder of 400 unsorted files are already forming negative impressions about the target's operational discipline.</p>
+                </section>
+
+                <!-- Section 2: Recommended Folder Taxonomy -->
+                <section class="vdr-section" id="folder-taxonomy">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Recommended Folder Taxonomy
+                    </h2>
+                    <p class="vdr-body">Use a numbered prefix convention for top-level folders to enforce a consistent browsing order across VDR platforms. The following nine categories cover the standard scope of technology due diligence.</p>
+                    <div class="vdr-folder-grid">
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">01</span>
+                            <h3 class="vdr-folder-name">Corporate & Legal</h3>
+                            <p class="vdr-folder-desc">Formation documents, cap table, material contracts, IP registrations, litigation, and insurance.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">02</span>
+                            <h3 class="vdr-folder-name">Financial</h3>
+                            <p class="vdr-folder-desc">Historical financials, forecasts, revenue breakdowns, AR/AP aging, and tax compliance.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">03</span>
+                            <h3 class="vdr-folder-name">Technology & Product</h3>
+                            <p class="vdr-folder-desc">Architecture diagrams, stack inventory, code quality metrics, roadmap, and deployment processes.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">04</span>
+                            <h3 class="vdr-folder-name">People & Organization</h3>
+                            <p class="vdr-folder-desc">Org charts, key personnel, headcount census, compensation summary, and hiring plan.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">05</span>
+                            <h3 class="vdr-folder-name">Commercial & Go-to-Market</h3>
+                            <p class="vdr-folder-desc">Customer data, churn metrics, pricing models, sales pipeline, and channel agreements.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">06</span>
+                            <h3 class="vdr-folder-name">Security & Compliance</h3>
+                            <p class="vdr-folder-desc">Security frameworks, pen test results, incident history, data privacy, and audit reports.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">07</span>
+                            <h3 class="vdr-folder-name">Operations & Infrastructure</h3>
+                            <p class="vdr-folder-desc">Cloud architecture, monitoring setup, SLA history, vendor inventory, and CI/CD pipelines.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">08</span>
+                            <h3 class="vdr-folder-name">Management Presentations</h3>
+                            <p class="vdr-folder-desc">Board decks, investor materials, strategic plans, and narrative documents for context.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">09</span>
+                            <h3 class="vdr-folder-name">Q&A Log</h3>
+                            <p class="vdr-folder-desc">Buyer questions, management responses, follow-up requests, and supplemental materials.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Section 3: Corporate & Legal -->
+                <section class="vdr-section" id="corporate-legal">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Corporate & Legal
+                    </h2>
+                    <p class="vdr-body">The foundation of any VDR. Buyers and their legal counsel will request these documents first, and incomplete corporate records are among the most common causes of diligence delays.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Articles of incorporation, bylaws, and certificates of good standing</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Fully diluted cap table with option pool, warrants, and convertible instruments</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Equity agreements, stock option plans, and vesting schedules</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Material contracts: top customer agreements, vendor MSAs, and partner agreements</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Litigation history, pending legal matters, and regulatory correspondence</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Insurance policies: D&O, E&O, cyber liability, general commercial</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />IP registrations: patents, trademarks, copyrights, and domain portfolio</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Employee and contractor IP assignment agreements</li>
+                    </ul>
+                </section>
+
+                <!-- Section 4: Financial -->
+                <section class="vdr-section" id="financial">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Financial
+                    </h2>
+                    <p class="vdr-body">Financial diligence requires both historical accuracy and forward-looking clarity. Provide clean, reconcilable data with consistent formatting across periods. Unexplained gaps or adjustments are red flags.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Historical financials: 3-5 years of P&L, balance sheet, and cash flow statements</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monthly and quarterly management reports for the trailing 24 months</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Annual budget, rolling forecasts, and underlying assumptions</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Revenue breakdowns by customer, product line, and geography</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Accounts receivable and accounts payable aging reports</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Tax returns (federal, state, international) for the past 3 years</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Deferred revenue schedule and revenue recognition policies</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capitalization of R&D expenses and amortization schedules</li>
+                    </ul>
+                </section>
+
+                <!-- Section 5: Technology & Product -->
+                <section class="vdr-section" id="technology-product">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Technology & Product
+                    </h2>
+                    <p class="vdr-body">This is where technology-focused buyers spend the most time. The goal is to give the diligence team a clear picture of the system without requiring access to source code repositories in early stages.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />System architecture diagrams: high-level, network topology, and data flow</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technology stack inventory: languages, frameworks, databases, and third-party services</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Repository structure overview: service boundaries, monorepo vs. polyrepo, code metrics</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Technical debt assessment or code quality reports (SonarQube, CodeClimate, etc.)</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Product roadmap with current quarter priorities and 12-month outlook</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Release history: frequency, deployment process, rollback procedures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />API documentation, integration points, and webhook/event architectures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party dependency inventory with license types and update cadence</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Test coverage reports and QA process documentation</li>
+                    </ul>
+                </section>
+
+                <!-- Section 6: People & Organization -->
+                <section class="vdr-section" id="people-organization">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        People & Organization
+                    </h2>
+                    <p class="vdr-body">Talent is often the primary asset in technology acquisitions. Buyers need to assess key person risk and team depth alongside the technology itself.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Current organizational chart with reporting lines and department structure</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Key personnel bios, tenure, and retention risk assessment</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Employee census: headcount by department, location, tenure, and contractor mix</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Compensation and benefits summary: salary bands, bonus structures, equity grants</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Key person dependency analysis: bus factor for critical systems</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Open positions, hiring pipeline, and 12-month staffing plan</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Employee handbook, PTO policies, and remote work arrangements</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Attrition data: voluntary and involuntary turnover for the past 24 months</li>
+                    </ul>
+                </section>
+
+                <!-- Section 7: Commercial & Go-to-Market -->
+                <section class="vdr-section" id="commercial">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Commercial & Go-to-Market
+                    </h2>
+                    <p class="vdr-body">Revenue quality and customer health are central to valuation. This section should demonstrate the durability and predictability of the revenue base.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Customer list with ARR/MRR attribution and contract terms</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Customer concentration analysis: top 10, top 20, and single-customer exposure</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cohort-level churn, retention, and net dollar retention metrics</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Sales pipeline: stage distribution, average deal size, and conversion rates</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Pricing model documentation: rate cards, discount policies, and packaging tiers</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Channel and reseller agreements with commission structures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Marketing spend breakdown and customer acquisition cost by channel</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Competitive landscape summary and market positioning</li>
+                    </ul>
+                </section>
+
+                <!-- Section 8: Security & Compliance -->
+                <section class="vdr-section" id="security-compliance">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Security & Compliance
+                    </h2>
+                    <p class="vdr-body">Security posture is increasingly a deal-breaker in technology transactions. Gaps here can trigger purchase price adjustments or outright deal termination. Proactive disclosure demonstrates maturity.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Security policy framework: information security, acceptable use, and data classification</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Compliance certifications: SOC 2 Type II, ISO 27001, HITRUST, or equivalent</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Most recent penetration test report (executive summary, redacted as appropriate)</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Security incident history and incident response procedures</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data privacy compliance: GDPR, CCPA, HIPAA applicability and controls</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Access control architecture: SSO, MFA, role-based permissions, and privileged access</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Business continuity and disaster recovery plans with RPO/RTO targets</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party audit reports and vendor security assessments</li>
+                    </ul>
+                </section>
+
+                <!-- Section 9: Operations & Infrastructure -->
+                <section class="vdr-section" id="operations-infrastructure">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Operations & Infrastructure
+                    </h2>
+                    <p class="vdr-body">Operational maturity directly impacts post-acquisition integration costs. Buyers assess whether infrastructure can scale and whether operational processes are documented or tribal.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cloud infrastructure documentation: provider, account structure, and resource inventory</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Hosting and deployment architecture: environments, promotion workflow, and IaC coverage</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor and tool inventory: SaaS subscriptions, annual spend, and contract renewal dates</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />CI/CD pipeline overview: build, test, and deployment automation</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capacity planning: current utilization, scaling triggers, and growth headroom</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Database architecture: engines, replication strategy, backup procedures, and data volumes</li>
+                    </ul>
+                </section>
+
+                <!-- Section 10: Common Pitfalls -->
+                <section class="vdr-section" id="common-pitfalls">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Common Pitfalls
+                    </h2>
+                    <p class="vdr-body">These are the mistakes that repeatedly slow down diligence timelines and erode buyer confidence. Each one is avoidable with upfront preparation.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Flat folder structures</strong> &mdash; Hundreds of files in a single directory with no logical grouping forces buyers to search instead of browse</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>No naming convention</strong> &mdash; Files named "Final_v3_REVISED_JB.xlsx" create confusion about which version is authoritative</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Stale or undated documents</strong> &mdash; Materials without dates leave buyers guessing whether information is current or obsolete</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Incomplete financial data</strong> &mdash; Missing months, unexplained adjustments, or format inconsistencies between periods trigger follow-up requests</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Oversharing pre-LOI</strong> &mdash; Disclosing sensitive customer data, source code, or salary details before a signed Letter of Intent exposes the company unnecessarily</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Missing architecture diagrams</strong> &mdash; Without visual representations, buyers must reverse-engineer the system from scattered documents</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Ignoring the diligence request list</strong> &mdash; Uploading materials without mapping them to the buyer's specific request list creates unnecessary back-and-forth</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>No access controls</strong> &mdash; Granting all parties full access to all documents, instead of staging disclosure by workstream or phase</li>
+                    </ul>
+                </section>
+
+                <!-- Section 11: Best Practices -->
+                <section class="vdr-section" id="best-practices">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Best Practices
+                    </h2>
+                    <p class="vdr-body">The following practices consistently differentiate well-managed VDRs from the rest. Implement these before granting buyer access.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Consistent naming convention</strong> &mdash; Use a standard format: <code>[Category]-[Document Name]-[YYYY-MM-DD]</code> for every file</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Root-level index document</strong> &mdash; Provide a master index that maps each folder to the diligence request list items it addresses</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Staged disclosure</strong> &mdash; Structure access by transaction phase: IOI stage (high-level), LOI stage (detailed), and confirmatory (full access)</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Designated VDR administrator</strong> &mdash; Assign a single point of contact responsible for uploads, access management, and version control</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Pre-populate against the request list</strong> &mdash; Map every anticipated diligence request to a document before the VDR opens</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Track Q&A within the platform</strong> &mdash; Use the VDR's built-in Q&A functionality rather than side-channel email threads</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Regular freshness audits</strong> &mdash; Review and update materials monthly during an active process to ensure nothing goes stale</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" /><strong>Watermarking and access logging</strong> &mdash; Enable document watermarks and track download activity by user for information security</li>
+                    </ul>
+                </section>
+
+            </div>
+
+            <div class="vdr-back-nav">
+                <a href="/hub/library" class="cta-button secondary">Back to The Library</a>
+            </div>
+        </div>
+    </section>
+</BaseLayout>
+
+<style>
+    .vdr-guide {
+        padding: var(--spacing-3xl) 0 5rem;
+    }
+
+    /* Header */
+    .vdr-header {
+        text-align: center;
+        margin-bottom: var(--spacing-3xl);
+    }
+
+    .section-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--color-primary);
+        margin-bottom: var(--spacing-lg);
+        display: block;
+    }
+
+    .vdr-header h1 {
+        font-size: 2.5rem;
+        font-weight: 700;
+        color: var(--text-light-primary);
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        margin-bottom: var(--spacing-lg);
+    }
+
+    .vdr-subtitle {
+        font-size: 1.1rem;
+        color: var(--text-light-secondary);
+        line-height: 1.8;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+
+    /* Table of Contents */
+    .vdr-toc {
+        max-width: 800px;
+        margin: 0 auto var(--spacing-3xl);
+        padding: var(--spacing-xl);
+        background: rgba(5, 205, 153, 0.03);
+        border: 1px solid rgba(5, 205, 153, 0.15);
+        border-radius: 8px;
+    }
+
+    :global(html.dark-theme) .vdr-toc {
+        background: rgba(5, 205, 153, 0.05);
+        border-color: rgba(5, 205, 153, 0.2);
+    }
+
+    .vdr-toc-list {
+        padding-left: var(--spacing-xl);
+        margin: 0;
+    }
+
+    .vdr-toc-list li {
+        margin-bottom: var(--spacing-sm);
+    }
+
+    .vdr-toc-list a {
+        font-size: var(--text-base);
+        color: var(--text-light-secondary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+    }
+
+    .vdr-toc-list a:hover {
+        color: var(--color-primary);
+    }
+
+    /* Content */
+    .vdr-content {
+        max-width: 800px;
+        margin: 0 auto;
+    }
+
+    .vdr-section {
+        margin-bottom: var(--spacing-3xl);
+    }
+
+    .vdr-section-heading {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: var(--text-light-primary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        margin-bottom: var(--spacing-lg);
+    }
+
+    .vdr-body {
+        font-size: var(--text-base);
+        color: var(--text-light-secondary);
+        line-height: 1.8;
+        margin-bottom: var(--spacing-xl);
+    }
+
+    /* Lists */
+    .vdr-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+    }
+
+    .vdr-list li {
+        font-size: var(--text-base);
+        color: var(--text-light-secondary);
+        line-height: 1.7;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+    }
+
+    .bullet-icon {
+        flex-shrink: 0;
+        margin-top: 0.35em;
+        opacity: 0.8;
+    }
+
+    .vdr-list strong {
+        color: var(--text-light-primary);
+    }
+
+    .vdr-list code {
+        font-size: 0.9em;
+        background: rgba(5, 205, 153, 0.08);
+        padding: 0.15em 0.4em;
+        border-radius: 3px;
+        color: var(--color-primary);
+    }
+
+    /* Folder Taxonomy Grid */
+    .vdr-folder-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--spacing-lg);
+        margin-top: var(--spacing-xl);
+    }
+
+    .vdr-folder-card {
+        padding: var(--spacing-xl);
+        background: rgba(5, 205, 153, 0.03);
+        border: 1px solid rgba(5, 205, 153, 0.15);
+        border-radius: 8px;
+    }
+
+    :global(html.dark-theme) .vdr-folder-card {
+        background: rgba(5, 205, 153, 0.05);
+        border-color: rgba(5, 205, 153, 0.2);
+    }
+
+    .vdr-folder-number {
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--color-primary);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+    }
+
+    .vdr-folder-name {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--text-light-primary);
+        margin: var(--spacing-xs) 0;
+    }
+
+    .vdr-folder-desc {
+        font-size: var(--text-sm);
+        color: var(--text-light-secondary);
+        line-height: 1.6;
+        margin: 0;
+    }
+
+    /* Back Navigation */
+    .vdr-back-nav {
+        text-align: center;
+        margin-top: var(--spacing-3xl);
+    }
+
+    /* Responsive */
+    @media (max-width: 1024px) {
+        .vdr-folder-grid {
+            grid-template-columns: repeat(2, 1fr);
+        }
+    }
+
+    @media (max-width: 768px) {
+        .vdr-guide {
+            padding: var(--spacing-2xl) 0 var(--spacing-3xl);
+        }
+
+        .vdr-header h1 {
+            font-size: 1.75rem;
+        }
+
+        .vdr-subtitle {
+            font-size: 1rem;
+        }
+
+        .vdr-folder-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .vdr-folder-card {
+            padding: var(--spacing-lg);
+        }
+    }
+
+    @media (max-width: 480px) {
+        .vdr-guide {
+            padding: var(--spacing-xl) 0 var(--spacing-2xl);
+        }
+
+        .vdr-header h1 {
+            font-size: 1.5rem;
+        }
+
+        .vdr-subtitle {
+            font-size: 0.9rem;
+        }
+
+        .vdr-section-heading {
+            font-size: 1.05rem;
+        }
+    }
+</style>

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -37,6 +37,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <li><a href="#people-organization">People & Organization</a></li>
                     <li><a href="#security">Security</a></li>
                     <li><a href="#governance-compliance">Governance & Compliance</a></li>
+                    <li><a href="#data-analytics-ai">Data, Analytics & AI</a></li>
                     <li><a href="#common-pitfalls">Common Pitfalls</a></li>
                     <li><a href="#best-practices">Best Practices</a></li>
                 </ol>
@@ -106,6 +107,11 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                             <span class="vdr-folder-number">07</span>
                             <h3 class="vdr-folder-name">Governance & Compliance</h3>
                             <p class="vdr-folder-desc">Certifications, audit reports, data privacy controls, regulatory correspondence, and licensing.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">08</span>
+                            <h3 class="vdr-folder-name">Data, Analytics & AI</h3>
+                            <p class="vdr-folder-desc">Data architecture, pipeline inventory, analytics capabilities, ML/AI models, and data governance.</p>
                         </div>
                     </div>
                 </section>
@@ -240,6 +246,25 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Change management and access review procedures</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Regulatory correspondence and any outstanding remediation commitments</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor risk management program and third-party assessment results</li>
+                    </ul>
+                </section>
+
+                <!-- Data, Analytics & AI -->
+                <section class="vdr-section" id="data-analytics-ai">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Data, Analytics & AI
+                    </h2>
+                    <p class="vdr-body">Data is increasingly the core asset in technology acquisitions. Buyers need to understand how data is collected, stored, transformed, and used to generate value — and whether AI/ML capabilities are production-grade or experimental.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data architecture overview: sources, storage layers, transformation pipelines, and consumption patterns</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data pipeline inventory: ETL/ELT tooling, orchestration, scheduling, and failure handling</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Analytics stack: BI tools, dashboards, self-service reporting, and data warehouse platform</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />ML/AI model inventory: use cases, training data sources, performance metrics, and production status</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Model deployment and monitoring: serving infrastructure, drift detection, and retraining cadence</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data governance framework: ownership, data catalog, lineage tracking, and quality controls</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data access and permissioning: role-based access, PII handling, and anonymization practices</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party data dependencies: licensed datasets, API integrations, and vendor lock-in risks</li>
                     </ul>
                 </section>
 

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -38,6 +38,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <li><a href="#security">Security</a></li>
                     <li><a href="#governance-compliance">Governance & Compliance</a></li>
                     <li><a href="#data-analytics-ai">Data, Analytics & AI</a></li>
+                    <li><a href="#corporate-it">Corporate IT</a></li>
                     <li><a href="#common-pitfalls">Common Pitfalls</a></li>
                     <li><a href="#best-practices">Best Practices</a></li>
                 </ol>
@@ -91,7 +92,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">04</span>
                             <h3 class="vdr-folder-name">Infrastructure & Operations</h3>
-                            <p class="vdr-folder-desc">Cloud architecture, CI/CD pipelines, monitoring, SLA history, and capacity planning.</p>
+                            <p class="vdr-folder-desc">Cloud architecture, monitoring, SLA history, and infrastructure capacity planning.</p>
                         </div>
                         <div class="vdr-folder-card">
                             <span class="vdr-folder-number">05</span>
@@ -112,6 +113,11 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                             <span class="vdr-folder-number">08</span>
                             <h3 class="vdr-folder-name">Data, Analytics & AI</h3>
                             <p class="vdr-folder-desc">Data architecture, pipeline inventory, analytics capabilities, ML/AI models, and data governance.</p>
+                        </div>
+                        <div class="vdr-folder-card">
+                            <span class="vdr-folder-number">09</span>
+                            <h3 class="vdr-folder-name">Corporate IT</h3>
+                            <p class="vdr-folder-desc">Enterprise systems, internal tools, endpoint management, identity providers, and IT operations.</p>
                         </div>
                     </div>
                 </section>
@@ -149,6 +155,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Testing strategy: unit, integration, end-to-end coverage targets and enforcement</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Release and deployment process: manual vs. automated, gating criteria, rollback procedures</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Environment management: development, staging, production parity and provisioning</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />CI/CD pipeline overview: build, test, and deployment automation</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Incident and bug triage: severity classification, SLA targets, and escalation paths</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Developer onboarding: time-to-first-commit, documentation quality, and tooling setup</li>
                     </ul>
@@ -183,11 +190,10 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                     <ul class="vdr-list">
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Cloud infrastructure documentation: provider, account structure, and resource inventory</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Hosting and deployment architecture: environments, promotion workflow, and IaC coverage</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />CI/CD pipeline overview: build, test, and deployment automation</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Monitoring and alerting setup: tools, coverage, on-call rotation, and escalation paths</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />SLA commitments and historical uptime data for the past 12-24 months</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Database architecture: engines, replication strategy, backup procedures, and data volumes</li>
-                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Capacity planning: current utilization, scaling triggers, and growth headroom</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Infrastructure capacity planning: current utilization, scaling triggers, and growth headroom</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Vendor and tool inventory: SaaS subscriptions, annual spend, and contract renewal dates</li>
                     </ul>
                 </section>
@@ -265,6 +271,25 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data governance framework: ownership, data catalog, lineage tracking, and quality controls</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Data access and permissioning: role-based access, PII handling, and anonymization practices</li>
                         <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Third-party data dependencies: licensed datasets, API integrations, and vendor lock-in risks</li>
+                    </ul>
+                </section>
+
+                <!-- Corporate IT -->
+                <section class="vdr-section" id="corporate-it">
+                    <h2 class="vdr-section-heading">
+                        <img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" width="14" height="14" />
+                        Corporate IT
+                    </h2>
+                    <p class="vdr-body">Corporate IT covers the enterprise systems and technology that support internal operations. Buyers assess this area to understand integration complexity, hidden licensing costs, and operational dependencies that may not be visible in the product technology stack.</p>
+                    <ul class="vdr-list">
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Enterprise application inventory: ERP, CRM, HRIS, and other business-critical systems</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Identity and access management: directory services, SSO providers, and provisioning workflows</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Endpoint management: device inventory, MDM policies, OS standardization, and patching cadence</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Collaboration and communication tools: email, messaging, file storage, and video conferencing</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Network infrastructure: office connectivity, VPN, SD-WAN, and remote access architecture</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />IT support operations: helpdesk structure, ticketing system, SLA targets, and escalation paths</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Software licensing: enterprise agreements, per-seat costs, renewal schedules, and compliance status</li>
+                        <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />IT budget and spend allocation: headcount, infrastructure, licensing, and outsourced services</li>
                     </ul>
                 </section>
 


### PR DESCRIPTION
## Summary
- Adds the Strategic Intelligence Hub Library section with the VDR Structure Guide as the first resource
- VDR Structure Guide covers 9 technology due diligence domains: Software Architecture, SDLC, Product, Infrastructure & Operations, People & Organization, Security, Governance & Compliance, Data/Analytics/AI, and Corporate IT
- Includes Common Pitfalls, Best Practices, and VDR Platforms reference sections
- Fixes mobile UX layout issues: TOC two-column layout caused by global nav flex, folder name overflow, and responsive spacing

## Test plan
- [ ] Verify VDR Structure Guide renders correctly on desktop (1024px+)
- [ ] Verify mobile layout at 768px and 480px breakpoints — TOC should be single-column stacked list
- [ ] Verify folder taxonomy cards stack to single column on mobile without text overflow
- [ ] Check both light and dark themes
- [ ] Verify all TOC anchor links navigate to correct sections
- [ ] Run `npm run build` — passes
- [ ] Run `npm run test:run` — 409 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)