### PR TITLE
Add Terms and Conditions page, radar button fix, and E2E tests

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,6 +8,7 @@ import ThemeToggle from './ThemeToggle.astro';
             <div class="footer-links">
                 <a href="https://www.linkedin.com/company/global-strategic-technologies/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="/privacy">Privacy</a>
+                <a href="/terms">Terms</a>
             </div>
             <ThemeToggle />
         </div>

--- a/src/pages/hub/radar/index.astro
+++ b/src/pages/hub/radar/index.astro
@@ -41,9 +41,7 @@ trackPageView('hub-radar', 'The Radar - Perspectives | GST');
         <RadarFeedSkeleton slot="fallback" />
       </RadarFeed>
 
-      <footer class="radar-footer">
-        <a href="/hub" class="cta-button secondary">&larr; Return to Hub</a>
-      </footer>
+      <a href="/hub" class="cta-button secondary">Return to Hub</a>
     </div>
   </div>
 </BaseLayout>
@@ -53,14 +51,4 @@ trackPageView('hub-radar', 'The Radar - Perspectives | GST');
     padding-bottom: var(--spacing-3xl);
   }
 
-  .radar-footer {
-    margin-top: var(--spacing-3xl);
-    padding: var(--spacing-2xl) 0;
-    background: transparent;
-    border-top: none;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--spacing-lg);
-  }
 </style>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,276 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Terms and Conditions | Global Strategic Tech">
+  <main class="terms-container">
+    <div class="terms-content">
+      <header class="terms-header">
+        <h1>Terms and Conditions</h1>
+        <p class="last-updated">Last Updated: February 2026</p>
+      </header>
+
+      <section class="terms-body">
+        <p>
+          Welcome to the website of Global Strategic Technologies LLC ("GST," "we," "us," or "our").
+          By accessing or using our website and services, you agree to be bound by these Terms and Conditions.
+          Please read them carefully before using our website.
+        </p>
+
+        <h2>Acceptance of Terms</h2>
+        <p>
+          By accessing or using our website at <a href="https://globalstrategic.tech">globalstrategic.tech</a>,
+          you acknowledge that you have read, understood, and agree to be bound by these Terms and Conditions.
+          If you do not agree, please do not use our website or services.
+        </p>
+
+        <h2>Services</h2>
+        <p>
+          GST provides strategic technology consulting, digital transformation advisory, and related
+          professional services. The information on our website is provided for general informational
+          purposes and does not constitute professional advice. Specific engagements are governed by
+          separate service agreements.
+        </p>
+
+        <h2>Use of Website</h2>
+        <p>You agree to use our website only for lawful purposes and in accordance with these Terms. You agree not to:</p>
+        <ul>
+          <li>Use the website in any way that violates applicable federal, state, local, or international law or regulation</li>
+          <li>Attempt to gain unauthorized access to any portion of the website, server, or any systems connected to the website</li>
+          <li>Use the website to transmit any malicious code, viruses, or harmful data</li>
+          <li>Interfere with or disrupt the integrity or performance of the website</li>
+          <li>Collect or harvest any information from the website without our prior written consent</li>
+        </ul>
+
+        <h2>Intellectual Property</h2>
+        <p>
+          All content on this website, including but not limited to text, graphics, logos, images, and software,
+          is the property of Global Strategic Technologies LLC or its licensors and is protected by United States
+          and international intellectual property laws. You may not reproduce, distribute, modify, or create
+          derivative works from any content without our express written permission.
+        </p>
+
+        <h2>Confidentiality</h2>
+        <p>
+          Any confidential information shared between GST and its clients during engagements is governed by
+          the terms of the applicable engagement agreement. Nothing on this website constitutes a waiver of
+          any confidentiality obligations.
+        </p>
+
+        <h2>Disclaimer of Warranties</h2>
+        <p>
+          Our website and its content are provided on an "as is" and "as available" basis without warranties
+          of any kind, either express or implied. We do not warrant that the website will be uninterrupted,
+          error-free, or free of viruses or other harmful components. To the fullest extent permitted by law,
+          we disclaim all warranties, express or implied, including implied warranties of merchantability,
+          fitness for a particular purpose, and non-infringement.
+        </p>
+
+        <h2>Limitation of Liability</h2>
+        <p>
+          To the maximum extent permitted by applicable law, GST and its officers, directors, employees, and
+          agents shall not be liable for any indirect, incidental, special, consequential, or punitive damages,
+          including but not limited to loss of profits, data, or goodwill, arising out of or in connection with
+          your use of or inability to use our website or services.
+        </p>
+
+        <h2>Indemnification</h2>
+        <p>
+          You agree to indemnify, defend, and hold harmless Global Strategic Technologies LLC and its officers,
+          directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses,
+          including reasonable attorney's fees, arising out of or in any way connected with your access to or use
+          of the website or your violation of these Terms.
+        </p>
+
+        <h2>SMS/Text Messaging Terms</h2>
+        <p>
+          By providing your phone number to Global Strategic Technologies LLC, you consent to receive
+          text messages related to our business operations, including but not limited to appointment
+          reminders, notifications, and verification codes. Message frequency may vary. Message and
+          data rates may apply.
+        </p>
+        <p>
+          You may opt out of receiving text messages at any time by replying <strong>STOP</strong> to
+          any message. After opting out, you will receive a final confirmation message and will no
+          longer receive texts from us. You may reply <strong>HELP</strong> for support information
+          or contact us at <a href="mailto:contact@globalstrategic.tech">contact@globalstrategic.tech</a>.
+        </p>
+        <p>
+          We do not sell, rent, or share phone numbers collected for SMS purposes with third parties
+          for marketing purposes. Your information is handled in accordance with our
+          <a href="/privacy">Privacy Policy</a>.
+        </p>
+
+        <h2>Third-Party Links</h2>
+        <p>
+          Our website may contain links to third-party websites or services that are not owned or controlled by GST.
+          We have no control over and assume no responsibility for the content, privacy policies, or practices of any
+          third-party websites. You acknowledge and agree that we are not responsible for any damage or loss caused by
+          your use of any third-party websites.
+        </p>
+
+        <h2>Governing Law</h2>
+        <p>
+          These Terms and Conditions shall be governed by and construed in accordance with the laws of the
+          State of Colorado, without regard to its conflict of law provisions. Any disputes arising under these
+          Terms shall be subject to the exclusive jurisdiction of the courts located in Colorado.
+        </p>
+
+        <h2>Changes to These Terms</h2>
+        <p>
+          We reserve the right to modify or replace these Terms at any time at our sole discretion. Any changes
+          will be posted on this page with an updated "Last Updated" date. Your continued use of the website
+          after any changes constitutes acceptance of the new Terms.
+        </p>
+
+        <h2>Severability</h2>
+        <p>
+          If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited
+          or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
+        </p>
+
+        <section class="contact-section">
+          <h2>Contact Us</h2>
+          <p>
+            If you have any questions about these Terms and Conditions, please contact us:
+          </p>
+          <p>
+            <strong>Global Strategic Technologies LLC</strong><br>
+            Email: <a href="mailto:contact@globalstrategic.tech">contact@globalstrategic.tech</a><br>
+            Website: <a href="https://globalstrategic.tech">globalstrategic.tech</a>
+          </p>
+        </section>
+      </section>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .terms-header {
+    position: static !important;
+    top: auto;
+  }
+
+  .terms-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .terms-header {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid rgba(26, 26, 26, 0.1);
+    background: transparent;
+  }
+
+  .terms-header h1 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: rgba(26, 26, 26, 0.95);
+  }
+
+  .last-updated {
+    font-size: 0.85rem;
+    color: rgba(26, 26, 26, 0.6);
+  }
+
+  .terms-body {
+    line-height: 1.8;
+    color: rgba(26, 26, 26, 0.85);
+  }
+
+  .terms-body h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: rgba(26, 26, 26, 0.95);
+  }
+
+  .terms-body p {
+    margin-bottom: 1rem;
+  }
+
+  .terms-body ul {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .terms-body li {
+    margin-bottom: 0.75rem;
+  }
+
+  .terms-body a {
+    color: #05cd99;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(5, 205, 153, 0.3);
+    transition: border-color 0.2s;
+  }
+
+  .terms-body a:hover {
+    border-bottom-color: #05cd99;
+  }
+
+  .contact-section {
+    margin-top: 3rem;
+    padding: 2rem;
+    background: rgba(5, 205, 153, 0.05);
+    border-left: 3px solid #05cd99;
+  }
+
+  .contact-section h2 {
+    margin-top: 0;
+  }
+
+  :global(html.dark-theme) .terms-header {
+    border-bottom-color: rgba(245, 245, 245, 0.1);
+  }
+
+  :global(html.dark-theme) .terms-header h1 {
+    color: rgba(245, 245, 245, 0.95);
+  }
+
+  :global(html.dark-theme) .last-updated {
+    color: rgba(245, 245, 245, 0.6);
+  }
+
+  :global(html.dark-theme) .terms-body {
+    color: rgba(245, 245, 245, 0.85);
+  }
+
+  :global(html.dark-theme) .terms-body h2 {
+    color: rgba(245, 245, 245, 0.95);
+  }
+
+  :global(html.dark-theme) .contact-section {
+    background: rgba(5, 205, 153, 0.08);
+  }
+
+  /* Tablet (480px - 768px) */
+  @media (min-width: 480px) {
+    .terms-container {
+      padding: 4rem 2rem;
+    }
+
+    .terms-header h1 {
+      font-size: 2.75rem;
+    }
+  }
+
+  /* Desktop (768px+) */
+  @media (min-width: 768px) {
+    .terms-container {
+      padding: 5rem 2rem;
+    }
+
+    .terms-header h1 {
+      font-size: 3rem;
+    }
+
+    .terms-body h2 {
+      font-size: 1.75rem;
+    }
+  }
+</style>

--- a/tests/e2e/radar-page.test.ts
+++ b/tests/e2e/radar-page.test.ts
@@ -55,7 +55,7 @@ test.describe('Radar Page', () => {
     });
 
     test('should display return link and header with valid timestamp', async ({ page }) => {
-      const returnLink = page.locator('.radar-container a[href="/hub"]');
+      const returnLink = page.locator('.radar-container a.cta-button[href="/hub"]');
       await expect(returnLink).toBeVisible();
 
       const timestamp = page.locator('.hub-header__updated');

--- a/tests/e2e/radar-page.test.ts
+++ b/tests/e2e/radar-page.test.ts
@@ -54,11 +54,8 @@ test.describe('Radar Page', () => {
       }
     });
 
-    test('should display footer with return link and header with valid timestamp', async ({ page }) => {
-      const footer = page.locator('.radar-footer');
-      await expect(footer).toBeVisible();
-
-      const returnLink = footer.locator('a[href="/hub"]');
+    test('should display return link and header with valid timestamp', async ({ page }) => {
+      const returnLink = page.locator('.radar-container a[href="/hub"]');
       await expect(returnLink).toBeVisible();
 
       const timestamp = page.locator('.hub-header__updated');

--- a/tests/e2e/terms-page.test.ts
+++ b/tests/e2e/terms-page.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Terms and Conditions Page E2E Tests
+ * Tests for page structure, content sections, links, dark theme, responsive layout, and accessibility
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Terms Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Block external GA requests
+    await page.route('**/googletagmanager.com/**', route => {
+      route.abort();
+    });
+    await page.route('**/google-analytics.com/**', route => {
+      route.abort();
+    });
+
+    // Navigate to terms page
+    await page.goto('/terms', { waitUntil: 'networkidle' });
+  });
+
+  test.describe('Page Load & Structure', () => {
+    test('should load the terms page successfully at /terms', async ({ page }) => {
+      const container = page.locator('.terms-container');
+      await expect(container).toBeVisible();
+    });
+
+    test('should have correct page title containing "Terms and Conditions"', async ({ page }) => {
+      const title = await page.title();
+      expect(title).toContain('Terms and Conditions');
+    });
+
+    test('should display h1 heading "Terms and Conditions"', async ({ page }) => {
+      const heading = page.locator('.terms-header h1');
+      await expect(heading).toBeVisible();
+      await expect(heading).toHaveText('Terms and Conditions');
+    });
+
+    test('should show "Last Updated" date', async ({ page }) => {
+      const lastUpdated = page.locator('.last-updated');
+      await expect(lastUpdated).toBeVisible();
+      await expect(lastUpdated).toContainText('Last Updated');
+      await expect(lastUpdated).toContainText('February 2026');
+    });
+
+    test('should contain terms-container, terms-header, and terms-body elements', async ({ page }) => {
+      const container = page.locator('.terms-container');
+      const header = page.locator('.terms-header');
+      const body = page.locator('.terms-body');
+
+      await expect(container).toBeVisible();
+      await expect(header).toBeVisible();
+      await expect(body).toBeVisible();
+    });
+  });
+
+  test.describe('Content Sections', () => {
+    test('should have at least 14 h2 headings', async ({ page }) => {
+      const headings = page.locator('.terms-body h2');
+      const count = await headings.count();
+      expect(count).toBeGreaterThanOrEqual(14);
+    });
+
+    test('should contain "Acceptance of Terms" heading', async ({ page }) => {
+      const heading = page.locator('.terms-body h2', { hasText: 'Acceptance of Terms' });
+      await expect(heading).toBeVisible();
+    });
+
+    test('should contain "SMS/Text Messaging Terms" heading', async ({ page }) => {
+      const heading = page.locator('.terms-body h2', { hasText: 'SMS/Text Messaging Terms' });
+      await expect(heading).toBeVisible();
+    });
+
+    test('should contain "Governing Law" heading', async ({ page }) => {
+      const heading = page.locator('.terms-body h2', { hasText: 'Governing Law' });
+      await expect(heading).toBeVisible();
+    });
+
+    test('should contain "Contact Us" heading', async ({ page }) => {
+      const heading = page.locator('.terms-body h2', { hasText: 'Contact Us' });
+      await expect(heading).toBeVisible();
+    });
+
+    test('should have 5 list items in the "Use of Website" section', async ({ page }) => {
+      const listItems = page.locator('.terms-body ul li');
+      const count = await listItems.count();
+      expect(count).toBe(5);
+    });
+
+    test('should reference Colorado in the "Governing Law" section', async ({ page }) => {
+      const termsBody = page.locator('.terms-body');
+      await expect(termsBody).toContainText('State of Colorado');
+    });
+
+    test('should contain STOP and HELP keywords in SMS section', async ({ page }) => {
+      const stopKeyword = page.locator('.terms-body strong', { hasText: 'STOP' });
+      const helpKeyword = page.locator('.terms-body strong', { hasText: 'HELP' });
+
+      await expect(stopKeyword).toBeVisible();
+      await expect(helpKeyword).toBeVisible();
+    });
+  });
+
+  test.describe('Links', () => {
+    test('should have contact email link with correct mailto href', async ({ page }) => {
+      const emailLink = page.locator('.terms-body a[href="mailto:contact@globalstrategic.tech"]').first();
+      await expect(emailLink).toBeVisible();
+
+      const href = await emailLink.getAttribute('href');
+      expect(href).toBe('mailto:contact@globalstrategic.tech');
+    });
+
+    test('should have website link with correct href', async ({ page }) => {
+      const websiteLink = page.locator('.terms-body a[href="https://globalstrategic.tech"]').first();
+      await expect(websiteLink).toBeVisible();
+
+      const href = await websiteLink.getAttribute('href');
+      expect(href).toBe('https://globalstrategic.tech');
+    });
+
+    test('should have Privacy Policy link pointing to /privacy', async ({ page }) => {
+      const privacyLink = page.locator('.terms-body a[href="/privacy"]');
+      await expect(privacyLink).toBeVisible();
+
+      const href = await privacyLink.getAttribute('href');
+      expect(href).toBe('/privacy');
+    });
+
+    test('should style links in terms-body with teal color', async ({ page }) => {
+      const link = page.locator('.terms-body a').first();
+      await expect(link).toBeVisible();
+
+      const color = await link.evaluate(el => {
+        return window.getComputedStyle(el).color;
+      });
+
+      // #05cd99 converts to rgb(5, 205, 153)
+      expect(color).toBe('rgb(5, 205, 153)');
+    });
+  });
+
+  test.describe('Contact Section', () => {
+    test('should display the contact section', async ({ page }) => {
+      const contactSection = page.locator('.contact-section');
+      await expect(contactSection).toBeVisible();
+    });
+
+    test('should have green left border on contact section', async ({ page }) => {
+      const contactSection = page.locator('.contact-section');
+      const borderLeft = await contactSection.evaluate(el => {
+        const style = window.getComputedStyle(el);
+        return style.borderLeftColor;
+      });
+
+      // #05cd99 converts to rgb(5, 205, 153)
+      expect(borderLeft).toBe('rgb(5, 205, 153)');
+    });
+
+    test('should contain company name "Global Strategic Technologies LLC"', async ({ page }) => {
+      const contactSection = page.locator('.contact-section');
+      await expect(contactSection).toContainText('Global Strategic Technologies LLC');
+    });
+
+    test('should have email and website links in contact section', async ({ page }) => {
+      const contactSection = page.locator('.contact-section');
+
+      const emailLink = contactSection.locator('a[href="mailto:contact@globalstrategic.tech"]');
+      await expect(emailLink).toBeVisible();
+
+      const websiteLink = contactSection.locator('a[href="https://globalstrategic.tech"]');
+      await expect(websiteLink).toBeVisible();
+    });
+  });
+
+  test.describe('Dark Theme Support', () => {
+    test('should change heading color when dark theme is toggled', async ({ page }) => {
+      const heading = page.locator('.terms-header h1');
+
+      // Get light theme color
+      const lightColor = await heading.evaluate(el => {
+        return window.getComputedStyle(el).color;
+      });
+
+      // Toggle to dark theme
+      const themeToggle = page.locator('[data-testid="theme-toggle"]');
+      await themeToggle.click();
+      await page.waitForTimeout(150);
+
+      // Verify dark theme is active
+      const isDark = await page.evaluate(() => document.documentElement.classList.contains('dark-theme'));
+      expect(isDark).toBe(true);
+
+      // Get dark theme color
+      const darkColor = await heading.evaluate(el => {
+        return window.getComputedStyle(el).color;
+      });
+
+      // Colors should be different between themes
+      expect(darkColor).not.toBe(lightColor);
+    });
+
+    test('should change body text color in dark theme', async ({ page }) => {
+      const termsBody = page.locator('.terms-body');
+
+      // Get light theme color
+      const lightColor = await termsBody.evaluate(el => {
+        return window.getComputedStyle(el).color;
+      });
+
+      // Toggle to dark theme
+      const themeToggle = page.locator('[data-testid="theme-toggle"]');
+      await themeToggle.click();
+      await page.waitForTimeout(150);
+
+      // Get dark theme color
+      const darkColor = await termsBody.evaluate(el => {
+        return window.getComputedStyle(el).color;
+      });
+
+      expect(darkColor).not.toBe(lightColor);
+    });
+
+    test('should change contact section background in dark theme', async ({ page }) => {
+      const contactSection = page.locator('.contact-section');
+
+      // Get light theme background
+      const lightBg = await contactSection.evaluate(el => {
+        return window.getComputedStyle(el).backgroundColor;
+      });
+
+      // Toggle to dark theme
+      const themeToggle = page.locator('[data-testid="theme-toggle"]');
+      await themeToggle.click();
+      await page.waitForTimeout(150);
+
+      // Get dark theme background
+      const darkBg = await contactSection.evaluate(el => {
+        return window.getComputedStyle(el).backgroundColor;
+      });
+
+      expect(darkBg).not.toBe(lightBg);
+    });
+  });
+
+  test.describe('Responsive Layout', () => {
+    test('should render correctly on mobile viewport (375px)', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto('/terms', { waitUntil: 'networkidle' });
+
+      const container = page.locator('.terms-container');
+      await expect(container).toBeVisible();
+
+      const heading = page.locator('.terms-header h1');
+      await expect(heading).toBeVisible();
+
+      const termsBody = page.locator('.terms-body');
+      await expect(termsBody).toBeVisible();
+    });
+
+    test('should render heading at larger size on tablet viewport (768px)', async ({ page }) => {
+      await page.setViewportSize({ width: 768, height: 1024 });
+      await page.goto('/terms', { waitUntil: 'networkidle' });
+
+      const heading = page.locator('.terms-header h1');
+      await expect(heading).toBeVisible();
+
+      const fontSize = await heading.evaluate(el => {
+        return window.getComputedStyle(el).fontSize;
+      });
+
+      // At 768px breakpoint, font-size should be 3rem (48px)
+      const fontSizeValue = parseFloat(fontSize);
+      expect(fontSizeValue).toBeGreaterThanOrEqual(48);
+    });
+
+    test('should render correctly on desktop viewport (1920px)', async ({ page }) => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto('/terms', { waitUntil: 'networkidle' });
+
+      const container = page.locator('.terms-container');
+      await expect(container).toBeVisible();
+
+      const heading = page.locator('.terms-header h1');
+      await expect(heading).toBeVisible();
+
+      const contactSection = page.locator('.contact-section');
+      await expect(contactSection).toBeVisible();
+    });
+  });
+
+  test.describe('Accessibility', () => {
+    test('should allow email links to receive keyboard focus', async ({ page }) => {
+      const emailLink = page.locator('.terms-body a[href="mailto:contact@globalstrategic.tech"]').first();
+
+      await emailLink.focus();
+
+      const isFocused = await emailLink.evaluate(el => el === document.activeElement);
+      expect(isFocused).toBe(true);
+    });
+
+    test('should have meaningful text content on the page', async ({ page }) => {
+      const termsBody = page.locator('.terms-body');
+      const textContent = await termsBody.textContent();
+
+      expect(textContent).toBeTruthy();
+      expect(textContent!.length).toBeGreaterThan(100);
+    });
+
+    test('should not have sticky positioning on the terms header', async ({ page }) => {
+      const header = page.locator('.terms-header');
+
+      const position = await header.evaluate(el => {
+        return window.getComputedStyle(el).position;
+      });
+
+      expect(position).toBe('static');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Terms and Conditions page**: New `/terms` page matching the Privacy Policy layout, with sections covering acceptance, services, use of website, IP, confidentiality, warranties, liability, indemnification, SMS/text messaging terms, third-party links, governing law (Colorado), severability, and contact info
- **Footer link**: Added "Terms" link to site footer next to existing "Privacy" link
- **Radar button fix**: Updated Return to Hub button on `/hub/radar` to match the style and placement used on the tools and library hub pages (removed footer wrapper, arrow prefix, and centered layout)
- **E2E tests**: 27 Playwright tests for the Terms page covering page structure, content sections, links, contact section, dark theme, responsive layout, and accessibility

## Files Changed
- `src/pages/terms.astro` — New Terms and Conditions page
- `src/components/Footer.astro` — Added Terms link
- `src/pages/hub/radar/index.astro` — Simplified Return to Hub button
- `tests/e2e/terms-page.test.ts` — 27 E2E tests for Terms page

## Test plan
- [x] `npm run build` succeeds
- [x] All 535 unit/integration tests pass
- [ ] E2E tests pass in CI (27 new terms-page tests × 3 browsers)
- [ ] Verify `/terms` page renders correctly in light and dark themes
- [ ] Verify "Terms" link appears in footer next to "Privacy"
- [ ] Verify Return to Hub button on `/hub/radar` matches tools/library pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)