### PR TITLE
fix(radar): merge highlights and notes across separate Inoreader annotations

### DIFF
--- a/src/lib/inoreader/transform.ts
+++ b/src/lib/inoreader/transform.ts
@@ -108,14 +108,23 @@ function inferCategory(item: InoreaderItem): string {
 
 /**
  * Transform an annotated Inoreader item into an FYI display model.
- * Extracts the first highlight and note as the GST Take.
+ * Merges highlight text and notes across all annotations for the item,
+ * since Inoreader may return them as separate annotation objects.
  */
 export function toFyiItem(item: InoreaderItem): RadarFyiItem | null {
   const annotations = item.annotations || [];
   if (annotations.length === 0) return null;
 
-  const primaryAnnotation = annotations.find(a => a.note && a.note.trim() !== '')
-    || annotations[0];
+  // Merge across all annotations: collect the first non-empty text and note.
+  // Inoreader may store a highlight (text only) and a comment (note only)
+  // as separate annotation objects on the same item.
+  const highlightedText = annotations.find(a => a.text && a.text.trim() !== '')?.text || '';
+  const gstTake = annotations.find(a => a.note && a.note.trim() !== '')?.note || '';
+
+  // Use the most recent annotation timestamp for sort ordering
+  const latestAnnotation = annotations.reduce((latest, a) =>
+    a.added_on > latest.added_on ? a : latest
+  );
 
   const summary = stripHtml(item.summary?.content || item.content?.content || '');
 
@@ -127,9 +136,9 @@ export function toFyiItem(item: InoreaderItem): RadarFyiItem | null {
     sourceUrl: item.origin?.htmlUrl || '',
     category: inferCategory(item),
     publishedAt: new Date(item.published * 1000).toISOString(),
-    annotatedAt: new Date(primaryAnnotation.added_on * 1000).toISOString(),
-    highlightedText: primaryAnnotation.text || '',
-    gstTake: primaryAnnotation.note || '',
+    annotatedAt: new Date(latestAnnotation.added_on * 1000).toISOString(),
+    highlightedText,
+    gstTake,
     summary: truncate(summary, 250),
   };
 }

--- a/tests/unit/radar-transform.test.ts
+++ b/tests/unit/radar-transform.test.ts
@@ -307,17 +307,27 @@ describe('toFyiItem', () => {
     expect(result!.gstTake).toBe('This is the GST Take on this article.');
   });
 
-  it('should prefer annotation with a non-empty note as primary', () => {
+  it('should merge highlight and note from separate annotations', () => {
+    const highlightOnly = makeAnnotation({ id: 1, note: '', text: 'Key passage from article' });
+    const noteOnly = makeAnnotation({ id: 2, text: '', note: 'The real take' });
+    const item = makeItem({ annotations: [highlightOnly, noteOnly] });
+    const result = toFyiItem(item);
+
+    expect(result!.highlightedText).toBe('Key passage from article');
+    expect(result!.gstTake).toBe('The real take');
+  });
+
+  it('should use first non-empty text and first non-empty note across annotations', () => {
     const noNote = makeAnnotation({ id: 1, note: '', text: 'Highlight without note' });
     const withNote = makeAnnotation({ id: 2, note: 'The real take', text: 'Highlight with note' });
     const item = makeItem({ annotations: [noNote, withNote] });
     const result = toFyiItem(item);
 
+    expect(result!.highlightedText).toBe('Highlight without note');
     expect(result!.gstTake).toBe('The real take');
-    expect(result!.highlightedText).toBe('Highlight with note');
   });
 
-  it('should use first annotation when none have notes', () => {
+  it('should use first annotation text when none have notes', () => {
     const ann1 = makeAnnotation({ id: 1, note: '', text: 'First highlight' });
     const ann2 = makeAnnotation({ id: 2, note: '', text: 'Second highlight' });
     const item = makeItem({ annotations: [ann1, ann2] });
@@ -405,6 +415,15 @@ describe('toFyiItem', () => {
     const date = new Date(result!.annotatedAt);
     expect(date.getTime()).toBe(1708100000 * 1000);
     expect(date.toISOString()).toBe(result!.annotatedAt);
+  });
+
+  it('should use the most recent annotation timestamp for annotatedAt', () => {
+    const older = makeAnnotation({ id: 1, added_on: 1708100000, text: 'Highlight' });
+    const newer = makeAnnotation({ id: 2, added_on: 1708200000, note: 'Comment' });
+    const item = makeItem({ annotations: [older, newer] });
+    const result = toFyiItem(item);
+    const date = new Date(result!.annotatedAt);
+    expect(date.getTime()).toBe(1708200000 * 1000);
   });
 
   it('should assign category using the same inference rules as toWireItem (shared inferCategory)', () => {


### PR DESCRIPTION
## Summary
- Fix bug where FYI items with both a highlight and a comment only showed the comment, not the highlight
- Inoreader may return highlights (`text`) and comments (`note`) as separate annotation objects on the same item (especially after their 2025 annotation system changes)
- The old logic picked a single "primary" annotation, losing the highlight when the comment was on a different object
- Now merges the first non-empty `text` and `note` across all annotations, and uses the most recent timestamp for sort ordering

## Test plan
- [x] Added unit test for split-annotation merging (`should merge highlight and note from separate annotations`)
- [x] Added unit test for most-recent timestamp selection (`should use the most recent annotation timestamp`)
- [x] Updated existing tests to match new merging behavior
- [x] All 537 unit/integration tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)