### PR TITLE
feat(regulatory-map): add AI regulations and update copy

### DIFF
--- a/src/components/hub/HubHeader.astro
+++ b/src/components/hub/HubHeader.astro
@@ -70,7 +70,7 @@ if (showTimestamp) {
   .hub-header__subtitle {
     font-size: var(--text-lg);
     color: var(--text-light-secondary);
-    max-width: 600px;
+    max-width: 720px;
     line-height: 1.6;
   }
 

--- a/src/data/regulatory-map/CN-ALGO-REC.json
+++ b/src/data/regulatory-map/CN-ALGO-REC.json
@@ -1,0 +1,17 @@
+{
+  "id": "cn-algo-rec",
+  "name": "Administrative Provisions on Algorithm Recommendation for Internet Information Services",
+  "regions": ["CHN"],
+  "effectiveDate": "2022-03-01",
+  "summary": "The world's first comprehensive regulation governing recommendation algorithms. Requires transparency over algorithm functionality, gives users control over their data profiles, and mandates algorithm filing with the Cyberspace Administration of China. Targets services that use algorithms to recommend content to users.",
+  "keyRequirements": [
+    "Algorithm recommendation providers must file algorithms with the Cyberspace Administration of China within 10 working days",
+    "Users must be given the option to disable personalized recommendations",
+    "Algorithms must not be used for anti-competitive practices or price discrimination",
+    "Providers must audit keywords and enable user access to personal data profiles",
+    "Content recommendation algorithms must adhere to mainstream values",
+    "Licensing requirement for providers operating in online news",
+    "Prohibition on algorithmic generation of fake news"
+  ],
+  "penalties": "Warnings, public denouncements, rectification orders, administrative fines on companies and individuals, business suspension, and criminal liability for severe violations under the Cybersecurity Law, Data Security Law, and PIPL."
+}

--- a/src/data/regulatory-map/CN-DEEP-SYNTHESIS.json
+++ b/src/data/regulatory-map/CN-DEEP-SYNTHESIS.json
@@ -1,0 +1,17 @@
+{
+  "id": "cn-deep-synthesis",
+  "name": "Administrative Provisions on Deep Synthesis in Internet-Based Information Services",
+  "regions": ["CHN"],
+  "effectiveDate": "2023-01-10",
+  "summary": "Regulates the use of deep synthesis (deepfake) technology for generating or altering video, voice, text, and image content online. Requires content labeling, platform responsibilities for blocking harmful content, and establishes mechanisms for algorithm filing and user protection.",
+  "keyRequirements": [
+    "Mandatory labeling and tagging of AI-generated content including voice simulation, face synthesis, and face manipulation",
+    "Establish management systems for algorithm review, ethics review, and content monitoring",
+    "File applicable algorithms with the Cyberspace Administration of China",
+    "Implement personal data protection and child protection measures",
+    "Platform capabilities to identify and block toxic synthesis content",
+    "User reporting mechanisms and timely removal of illegal content",
+    "Prohibition on creating politically sensitive deepfake content"
+  ],
+  "penalties": "Rectification orders, suspension of services, penalties under the Cybersecurity Law, Data Security Law, and PIPL. Criminal liability for severe violations."
+}

--- a/src/data/regulatory-map/CN-GENAI.json
+++ b/src/data/regulatory-map/CN-GENAI.json
@@ -1,0 +1,17 @@
+{
+  "id": "cn-genai",
+  "name": "Interim Measures for the Management of Generative Artificial Intelligence Services",
+  "regions": ["CHN"],
+  "effectiveDate": "2023-08-15",
+  "summary": "China's first regulation specifically targeting generative AI services. Governs the provision of text, image, audio, video, and other content generation services to the public within China. Takes a balanced approach promoting innovation while requiring safety assessments and lawful data sourcing.",
+  "keyRequirements": [
+    "Training data must be from lawful sources with no intellectual property infringement",
+    "Obtain consent for personal information used in training",
+    "Ensure training data quality, accuracy, objectivity, and diversity",
+    "Security assessments required for services with public opinion properties or social mobilization capacity",
+    "Comply with algorithmic filing requirements",
+    "Generated content must not incite subversion of state power or contain illegal content",
+    "Providers must accept and process user complaints"
+  ],
+  "penalties": "Violations penalized under the Cybersecurity Law, Data Security Law, PIPL, and Law on Progress of Science and Technology. Includes warnings, rectification orders, and suspension orders."
+}

--- a/src/data/regulatory-map/EU-AI-ACT.json
+++ b/src/data/regulatory-map/EU-AI-ACT.json
@@ -1,0 +1,21 @@
+{
+  "id": "eu-ai-act",
+  "name": "EU Artificial Intelligence Act (Regulation 2024/1689)",
+  "regions": [
+    "AUT", "BEL", "BGR", "HRV", "CYP", "CZE", "DNK", "EST", "FIN", "FRA",
+    "DEU", "GRC", "HUN", "IRL", "ITA", "LVA", "LTU", "LUX", "MLT", "NLD",
+    "POL", "PRT", "ROU", "SVK", "SVN", "ESP", "SWE"
+  ],
+  "effectiveDate": "2024-08-01",
+  "summary": "The world's first comprehensive AI regulatory framework. Establishes a risk-based classification system for AI systems across the EU, banning certain practices outright and imposing strict requirements on high-risk applications. Applies to providers, deployers, importers, and distributors of AI systems in the EU market, with phased implementation through 2027.",
+  "keyRequirements": [
+    "Prohibition of AI for social scoring, subliminal manipulation, exploitation of vulnerabilities, and real-time remote biometric identification in public spaces",
+    "Risk management systems and conformity assessments for high-risk AI systems",
+    "High-quality training data requirements with bias detection and mitigation",
+    "Transparency obligations including user notification when interacting with AI",
+    "Human oversight mechanisms for high-risk AI systems",
+    "Registration of high-risk AI systems in an EU-wide public database",
+    "General-purpose AI model providers must provide technical documentation, comply with copyright law, and publish training content summaries"
+  ],
+  "penalties": "Prohibited practices: up to EUR 35 million or 7% of global annual turnover. High-risk system violations: up to EUR 15 million or 3% of global annual turnover. Providing incorrect information: up to EUR 7.5 million or 1% of global annual turnover."
+}

--- a/src/data/regulatory-map/JP-AI-PROMOTION.json
+++ b/src/data/regulatory-map/JP-AI-PROMOTION.json
@@ -1,0 +1,17 @@
+{
+  "id": "jp-ai-promotion",
+  "name": "Act on the Promotion of Research and Development and the Utilization of AI-Related Technologies (AI Promotion Act)",
+  "regions": ["JPN"],
+  "effectiveDate": "2025-06-04",
+  "summary": "Japan's first comprehensive AI legislation, structured as a fundamental law establishing high-level principles rather than prescriptive rules. Embodies Japan's agile governance philosophy, positioning the country to be the most AI-friendly nation while promoting responsible AI development and use.",
+  "keyRequirements": [
+    "Enhance AI research and development capabilities",
+    "Ensure transparency regarding AI risks",
+    "Promote international cooperation on AI governance",
+    "Businesses and citizens to cooperate with government on reasonable efforts basis",
+    "Establish AI Strategy Headquarters under the Prime Minister's Office",
+    "Government may issue advice and guidance to businesses using AI harmfully",
+    "Promote comprehensive stakeholder initiatives from R&D to social implementation"
+  ],
+  "penalties": "No direct fines or penalties. Authorities may issue advice, request information, or publicly disclose non-compliance. Enforcement relies on existing sector-specific laws including privacy, competition, intellectual property, and product safety."
+}

--- a/src/data/regulatory-map/KR-AI-BASIC-ACT.json
+++ b/src/data/regulatory-map/KR-AI-BASIC-ACT.json
@@ -1,0 +1,17 @@
+{
+  "id": "kr-ai-basic-act",
+  "name": "Framework Act on the Development of Artificial Intelligence and Establishment of Trust (AI Basic Act)",
+  "regions": ["KOR"],
+  "effectiveDate": "2026-01-22",
+  "summary": "South Korea's comprehensive national AI regulatory framework, the second after the EU AI Act. Establishes a legal framework for advancing competitiveness in AI while ensuring ethical standards and public trust. Assigns transparency and safety responsibilities to businesses developing or deploying high-impact AI and generative AI.",
+  "keyRequirements": [
+    "Notify users when interacting with high-impact AI or generative AI systems",
+    "Clearly label AI-generated content",
+    "Implement risk management throughout the AI lifecycle with human oversight",
+    "Conduct impact assessments on fundamental rights for high-impact AI",
+    "Designate a domestic representative for foreign AI providers meeting scale thresholds",
+    "Document safety measures for high-impact AI systems",
+    "Establish AI safety institute and national AI governance body"
+  ],
+  "penalties": "Administrative fines up to KRW 30 million (~USD 22,000) for violations of notification obligations, domestic agent designation, and non-compliance with suspension or corrective orders."
+}

--- a/src/data/regulatory-map/PE-AI-LAW31814.json
+++ b/src/data/regulatory-map/PE-AI-LAW31814.json
@@ -1,0 +1,17 @@
+{
+  "id": "pe-ai-law31814",
+  "name": "Law No. 31814 - Law that Promotes the Use of Artificial Intelligence in Favor of Economic and Social Development",
+  "regions": ["PER"],
+  "effectiveDate": "2023-07-05",
+  "summary": "Peru's foundational AI law establishing a national framework to promote AI development while protecting fundamental rights. Designates the Presidency of the Council of Ministers as the national AI regulator and sets principles for risk-based governance, transparency, and interoperability.",
+  "keyRequirements": [
+    "Perform risk assessments for AI systems",
+    "Establish governance structures for AI lifecycle management",
+    "Ensure transparency and human oversight in AI deployment",
+    "Guard personal data in AI processing",
+    "Prohibit unacceptable-risk AI including subliminal manipulation, social scoring, and biometric identification without safeguards",
+    "Monitor regulatory updates and maintain compliance",
+    "Cybersecurity and audit requirements per implementing regulation"
+  ],
+  "penalties": "Specific penalty amounts defined by the regulatory authority under implementing regulation (Supreme Decree No. 115-2025-PCM)."
+}

--- a/src/data/regulatory-map/US-CA-AI-TRANSPARENCY.json
+++ b/src/data/regulatory-map/US-CA-AI-TRANSPARENCY.json
@@ -1,0 +1,16 @@
+{
+  "id": "us-ca-ai-transparency",
+  "name": "California AI Transparency Act (SB 942)",
+  "regions": ["US-CA"],
+  "effectiveDate": "2026-08-02",
+  "summary": "Requires large generative AI providers to watermark AI-generated content and provide free detection tools. Focuses on image, video, and audio content transparency. Applies to providers with over 1 million monthly users accessible in California.",
+  "keyRequirements": [
+    "Embed invisible watermarks in AI-generated image, video, and audio content",
+    "Watermarks must include creator name, AI system version, timestamp, and unique identifier",
+    "Provide free, publicly available detection tools for checking AI-generated content",
+    "Offer visible label option that users can choose to include",
+    "Large online platforms must provide content provenance inspection tools",
+    "Does not apply to text-only content"
+  ],
+  "penalties": "$5,000 per violation. Each day of non-compliance is a separate offense. Enforced by the California Attorney General, city attorneys, and county counsel."
+}

--- a/src/data/regulatory-map/US-CO-AI-ACT.json
+++ b/src/data/regulatory-map/US-CO-AI-ACT.json
@@ -1,0 +1,17 @@
+{
+  "id": "us-co-ai-act",
+  "name": "Colorado Artificial Intelligence Act (SB 24-205)",
+  "regions": ["US-CO"],
+  "effectiveDate": "2026-06-30",
+  "summary": "The most detailed AI-specific consumer protection law in the United States. Focuses on preventing algorithmic discrimination in consequential decisions covering employment, education, healthcare, housing, insurance, and legal services. Requires a duty of care from both developers and deployers of high-risk AI systems.",
+  "keyRequirements": [
+    "Developers must use reasonable care to protect consumers from algorithmic discrimination",
+    "Deployers must implement a risk management policy and program",
+    "Complete impact assessments for high-risk AI systems",
+    "Notify consumers when high-risk AI systems make or substantially factor into consequential decisions",
+    "Provide consumers with right to explanation of AI's role in decisions",
+    "Report known algorithmic discrimination to the Attorney General",
+    "Rebuttable presumption of compliance for those following specified provisions"
+  ],
+  "penalties": "$20,000 per violation counted per consumer or transaction. Enforced exclusively by the Colorado Attorney General under the Colorado Consumer Protection Act. No private right of action."
+}

--- a/src/data/regulatory-map/US-IL-AI-EMPLOYMENT.json
+++ b/src/data/regulatory-map/US-IL-AI-EMPLOYMENT.json
@@ -1,0 +1,15 @@
+{
+  "id": "us-il-ai-employment",
+  "name": "Illinois AI Employment Discrimination Law (HB 3773)",
+  "regions": ["US-IL"],
+  "effectiveDate": "2026-01-01",
+  "summary": "Amends the Illinois Human Rights Act to address AI use in employment decisions. Prohibits employers from using AI that discriminates against employees based on protected classes and requires notice to employees and applicants when AI is used in employment decisions.",
+  "keyRequirements": [
+    "Prohibits AI use that discriminates based on protected classes in recruitment, hiring, promotion, discharge, discipline, or terms of employment",
+    "Employers must provide notice to employees and applicants when AI is used in employment decisions",
+    "Failure to provide AI notice is a standalone violation of the Human Rights Act",
+    "Applies to recruitment, hiring, promotion, renewal, training, discharge, discipline, and tenure decisions",
+    "Employers must maintain compliance with existing nondiscrimination obligations when deploying AI"
+  ],
+  "penalties": "Civil penalties up to $5,000 per willful or repeated violation. Actual damages and attorney's fees. Each affected individual may constitute a separate violation."
+}

--- a/src/data/regulatory-map/US-IL-AIVRA.json
+++ b/src/data/regulatory-map/US-IL-AIVRA.json
@@ -1,0 +1,15 @@
+{
+  "id": "us-il-aivra",
+  "name": "Illinois Artificial Intelligence Video Interview Act",
+  "regions": ["US-IL"],
+  "effectiveDate": "2020-01-01",
+  "summary": "One of the first AI-specific laws in the United States. Regulates the use of AI analysis in video interviews for employment purposes. Requires employers to notify applicants, explain AI functionality, and obtain consent before using AI to evaluate video interviews.",
+  "keyRequirements": [
+    "Notify applicants that AI may be used to analyze video interviews",
+    "Provide information explaining how the AI works and what characteristics it evaluates",
+    "Obtain applicant's consent before using AI analysis",
+    "Prohibit sharing of applicant video interviews except with those whose expertise is necessary for evaluation",
+    "Upon request, destroy video interviews within 30 days"
+  ],
+  "penalties": "Enforced under the Illinois Attorney General's authority. Violators subject to civil penalties determined by enforcement action."
+}

--- a/src/data/regulatory-map/US-NY-APDA.json
+++ b/src/data/regulatory-map/US-NY-APDA.json
@@ -1,0 +1,14 @@
+{
+  "id": "us-ny-apda",
+  "name": "New York Algorithmic Pricing Disclosure Act",
+  "regions": ["US-NY"],
+  "effectiveDate": "2025-11-10",
+  "summary": "First US state law requiring disclosure of AI-driven personalized pricing. Mandates clear notification when consumer prices are set by algorithms using personal data. Aims to protect consumers from opaque AI-driven price discrimination.",
+  "keyRequirements": [
+    "Display clear and conspicuous disclosure alongside algorithmically personalized prices",
+    "Disclosure must state that the price was set by an algorithm using the consumer's personal data",
+    "Applies to any entity using personal data to set individualized consumer prices",
+    "Disclosure must be presented at the point of sale or display of price"
+  ],
+  "penalties": "Civil penalty up to $1,000 per violation regardless of actual consumer injury."
+}

--- a/src/data/regulatory-map/US-NY-LL144.json
+++ b/src/data/regulatory-map/US-NY-LL144.json
@@ -1,0 +1,15 @@
+{
+  "id": "us-ny-ll144",
+  "name": "NYC Local Law 144 - Automated Employment Decision Tools",
+  "regions": ["US-NY"],
+  "effectiveDate": "2023-07-05",
+  "summary": "Regulates the use of automated employment decision tools (AEDTs) in hiring and promotion decisions in New York City. Requires independent bias audits, public disclosure of audit results, and candidate notification before using AI-powered hiring tools.",
+  "keyRequirements": [
+    "Conduct independent bias audit of AEDT no more than 1 year prior to use",
+    "Publish summary of bias audit results on employer's website",
+    "Notify candidates that AEDT will be used in hiring or promotion decisions",
+    "Disclose how the AEDT will be used and what data will be collected",
+    "Allow candidates to request alternative selection process or human review"
+  ],
+  "penalties": "Civil penalties of up to $500 for first violation and additional violations on the same day. $500 to $1,500 for each subsequent violation. Each day of non-compliance constitutes a separate violation."
+}

--- a/src/data/regulatory-map/US-TN-ELVIS.json
+++ b/src/data/regulatory-map/US-TN-ELVIS.json
@@ -1,0 +1,15 @@
+{
+  "id": "us-tn-elvis",
+  "name": "Ensuring Likeness Voice and Image Security Act (ELVIS Act)",
+  "regions": ["US-TN"],
+  "effectiveDate": "2024-07-01",
+  "summary": "The first US state law specifically protecting individuals from unauthorized AI voice cloning and deepfakes. Expands Tennessee's right of publicity law to explicitly cover voice protection against AI-generated replicas. Applies nationwide regardless of where the individual resides or where the violation occurs.",
+  "keyRequirements": [
+    "Prohibits unauthorized commercial use of an individual's voice including AI-generated replicas",
+    "Creates liability for publishing or distributing AI-generated voice or likeness without authorization",
+    "Creates cause of action against distributors of AI tools whose primary purpose is producing unauthorized replicas",
+    "Protects voice and likeness of deceased persons for up to 12 years after death",
+    "Extends protection regardless of geographic location of individual or violation"
+  ],
+  "penalties": "Class A misdemeanor (up to 11 months 29 days jail, up to $2,500 fine). Treble damages for knowing use of unauthorized voice replica. Treble damages plus attorney's fees when victim is armed forces member."
+}

--- a/src/data/regulatory-map/US-TX-TRAIGA.json
+++ b/src/data/regulatory-map/US-TX-TRAIGA.json
@@ -1,0 +1,17 @@
+{
+  "id": "us-tx-traiga",
+  "name": "Texas Responsible Artificial Intelligence Governance Act (TRAIGA, HB 149)",
+  "regions": ["US-TX"],
+  "effectiveDate": "2026-01-01",
+  "summary": "Texas's first comprehensive AI law. Focuses on prohibiting AI systems designed for harmful purposes rather than broad regulatory compliance. Requires disclosure by state agencies and healthcare providers. Provides affirmative defenses for NIST AI Risk Management Framework compliance.",
+  "keyRequirements": [
+    "Prohibits AI systems intended to incite self-harm or criminal activity",
+    "Prohibits AI for generating child sexual abuse material or deepfake pornography",
+    "Prohibits government use of AI for social scoring",
+    "State agencies must disclose AI interactions to consumers",
+    "Healthcare providers must disclose AI use in treatment to patients",
+    "Affirmative defense available for compliance with NIST AI Risk Management Framework",
+    "60-day cure period after receiving notice of violation from the Attorney General"
+  ],
+  "penalties": "Curable violations: $10,000 to $12,000 per violation. Uncurable violations: $80,000 to $200,000 per violation. Continuing violations: $2,000 to $40,000 per day. Plus attorney's fees and court costs."
+}

--- a/src/data/regulatory-map/US-UT-AIPA.json
+++ b/src/data/regulatory-map/US-UT-AIPA.json
@@ -1,0 +1,16 @@
+{
+  "id": "us-ut-aipa",
+  "name": "Utah Artificial Intelligence Policy Act (SB 149)",
+  "regions": ["US-UT"],
+  "effectiveDate": "2024-05-01",
+  "summary": "One of the first comprehensive state AI consumer protection laws in the US. Brings generative AI usage into Utah's consumer protection framework. Requires disclosure of AI interactions in licensed and regulated professions and establishes the Office of AI Policy.",
+  "keyRequirements": [
+    "Disclose use of generative AI when providing services requiring a license or state certification",
+    "Disclose AI interaction to any person who directly asks whether they are interacting with AI",
+    "Businesses are liable for consumer deception caused by their AI systems",
+    "Licensed mental health providers must disclose AI use upfront",
+    "Establish Office of AI Policy within consumer protection division",
+    "AI Learning Lab Program to study risks and benefits"
+  ],
+  "penalties": "Administrative fine up to $2,500. Civil penalty up to $5,000. Criminal liability if AI is used to commit an offense."
+}

--- a/src/docs/hub/REGULATORY_MAP.md
+++ b/src/docs/hub/REGULATORY_MAP.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Regulatory Map is an interactive D3.js world map that visualizes global technology and data privacy regulations across 56 jurisdictions. Users click highlighted countries, US states, or Canadian provinces to view regulation details in a side panel.
+The Regulatory Map is an interactive D3.js world map that visualizes global data privacy and AI regulations across 72 regulatory frameworks. Users click highlighted countries, US states, or Canadian provinces to view regulation details in a side panel. Regions with multiple applicable regulations (e.g., an EU member state with both GDPR and the AI Act) display all of them.
 
 **Entry point**: `src/pages/hub/tools/regulatory-map/index.astro`
 
@@ -20,7 +20,7 @@ User (Map UI)
 │     CompliancePanel.astro       ← Regulation detail panel (cards, requirements, penalties)
 │
 ├── src/data/regulatory-map/
-│     *.json                      ← 56 regulation files (Zod-validated at build time)
+│     *.json                      ← 72 regulation files (Zod-validated at build time)
 │
 ├── src/data/canada-provinces.json ← TopoJSON for Canadian province boundaries
 │
@@ -113,16 +113,22 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 
 ---
 
-## Regulation Coverage (56 regulations)
+## Regulation Coverage (72 regulations)
 
-### Multi-Country (2)
+The map covers two categories of regulation: **data privacy** (56 regulations) and **artificial intelligence** (16 regulations). Both categories share the same data schema, rendering pipeline, and region code system. A single region may have multiple regulations from both categories.
+
+---
+
+### Data Privacy Regulations (56)
+
+#### Multi-Country (2)
 
 | File | Regulation | Coverage |
 |------|-----------|---------|
 | `EU-GDPR.json` | General Data Protection Regulation | 27 EU member states |
 | `CA-PIPEDA.json` | Personal Information Protection and Electronic Documents Act | All Canadian provinces |
 
-### US State Laws (20)
+#### US State Privacy Laws (20)
 
 | File | State | Law |
 |------|-------|-----|
@@ -147,7 +153,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `US-UT-UCPA.json` | Utah | UCPA |
 | `US-VA-VCDPA.json` | Virginia | VCDPA |
 
-### Canadian Provincial Laws (3)
+#### Canadian Provincial Laws (3)
 
 | File | Province | Law |
 |------|----------|-----|
@@ -155,7 +161,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `CA-AB-PIPA.json` | Alberta | PIPA |
 | `CA-BC-PIPA.json` | British Columbia | PIPA |
 
-### Asia-Pacific (11)
+#### Asia-Pacific (11)
 
 | File | Country | Law |
 |------|---------|-----|
@@ -171,7 +177,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `VN-PDPL.json` | Vietnam | PDPL |
 | `MY-PDPA.json` | Malaysia | PDPA 2010 |
 
-### Europe Non-EU (3)
+#### Europe Non-EU (3)
 
 | File | Country | Law |
 |------|---------|-----|
@@ -179,7 +185,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `CH-FADP.json` | Switzerland | nFADP |
 | `TR-KVKK.json` | Turkey | KVKK (Law 6698) |
 
-### Middle East & Africa (7)
+#### Middle East & Africa (7)
 
 | File | Country | Law |
 |------|---------|-----|
@@ -191,7 +197,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `EG-PDPL.json` | Egypt | PDPL |
 | `RW-DPP.json` | Rwanda | DPP Law |
 
-### Latin America (6)
+#### Latin America (6)
 
 | File | Country | Law |
 |------|---------|-----|
@@ -202,7 +208,7 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `UY-LAW18331.json` | Uruguay | Law 18.331 |
 | `PE-LAW29733.json` | Peru | Law 29.733 |
 
-### Other (3)
+#### Other (4)
 
 | File | Country | Law | Note |
 |------|---------|-----|------|
@@ -210,6 +216,60 @@ Each JSON file in `src/data/regulatory-map/` follows this schema:
 | `BH-PDPL.json` | Bahrain | PDPL | Not visible on 110m map (too small) |
 | `CL-LAW19628.json` | Chile | Law 19.628 | |
 | `RS-LPDP.json` | Serbia | LPDP | Not visible on 110m map |
+
+---
+
+### AI Regulations (16)
+
+#### Multi-Country (1)
+
+| File | Regulation | Coverage | Effective |
+|------|-----------|---------|-----------|
+| `EU-AI-ACT.json` | EU Artificial Intelligence Act (Regulation 2024/1689) | 27 EU member states | 2024-08-01 (phased through 2027) |
+
+#### National AI Laws (6)
+
+| File | Country | Law | Effective |
+|------|---------|-----|-----------|
+| `CN-ALGO-REC.json` | China | Algorithm Recommendation Regulation | 2022-03-01 |
+| `CN-DEEP-SYNTHESIS.json` | China | Deep Synthesis Provisions (deepfakes) | 2023-01-10 |
+| `CN-GENAI.json` | China | Interim Measures for Generative AI | 2023-08-15 |
+| `KR-AI-BASIC-ACT.json` | South Korea | AI Basic Act | 2026-01-22 |
+| `JP-AI-PROMOTION.json` | Japan | AI Promotion Act | 2025-06-04 |
+| `PE-AI-LAW31814.json` | Peru | AI Promotion Law (Law 31814) | 2023-07-05 |
+
+#### US State AI Laws (9)
+
+| File | State | Law | Focus | Effective |
+|------|-------|-----|-------|-----------|
+| `US-IL-AIVRA.json` | Illinois | AI Video Interview Act | AI in employment video interviews | 2020-01-01 |
+| `US-NY-LL144.json` | New York | NYC Local Law 144 (AEDT) | Automated employment decision tools | 2023-07-05 |
+| `US-TN-ELVIS.json` | Tennessee | ELVIS Act | AI voice cloning and deepfakes | 2024-07-01 |
+| `US-UT-AIPA.json` | Utah | AI Policy Act (SB 149) | AI consumer protection and disclosure | 2024-05-01 |
+| `US-NY-APDA.json` | New York | Algorithmic Pricing Disclosure Act | AI-driven personalized pricing | 2025-11-10 |
+| `US-CO-AI-ACT.json` | Colorado | AI Act (SB 24-205) | Algorithmic discrimination in consequential decisions | 2026-06-30 |
+| `US-IL-AI-EMPLOYMENT.json` | Illinois | AI Employment Discrimination Law (HB 3773) | AI discrimination in employment | 2026-01-01 |
+| `US-TX-TRAIGA.json` | Texas | TRAIGA (HB 149) | Harmful AI prohibition, state/healthcare disclosure | 2026-01-01 |
+| `US-CA-AI-TRANSPARENCY.json` | California | AI Transparency Act (SB 942) | AI content watermarking and detection | 2026-08-02 |
+
+#### Multi-Regulation Regions
+
+Some regions now display regulations from both categories:
+
+| Region | Privacy | AI |
+|--------|---------|-----|
+| EU member states (27) | GDPR | EU AI Act |
+| China | PIPL | Algorithm Rec, Deep Synthesis, Generative AI |
+| South Korea | PIPA | AI Basic Act |
+| Japan | APPI | AI Promotion Act |
+| Peru | Law 29.733 | AI Promotion Law 31814 |
+| California | CCPA/CPRA | AI Transparency Act |
+| Colorado | CPA | AI Act (SB 24-205) |
+| Illinois | (none) | AIVRA, AI Employment (HB 3773) |
+| New York | (none) | NYC LL144, Algorithmic Pricing Act |
+| Tennessee | TIPA | ELVIS Act |
+| Texas | TDPSA | TRAIGA |
+| Utah | UCPA | AI Policy Act |
 
 ---
 
@@ -294,8 +354,8 @@ Adding state/province-level rendering for a new country (beyond the US and Canad
 
 ## Future Expansion
 
-- Additional regulations (AI Act, HIPAA, SOX, PCI-DSS)
-- Regulation category filtering (data privacy, cybersecurity, AI governance)
+- Regulation category filtering (data privacy, AI governance, cybersecurity)
+- Additional regulation categories (HIPAA, SOX, PCI-DSS, sector-specific cybersecurity)
 - Timeline view showing regulation effective dates
 - Comparison mode for multi-jurisdiction analysis
 - Search/filter by regulation name or keyword
@@ -304,3 +364,4 @@ Adding state/province-level rendering for a new country (beyond the US and Canad
 ---
 
 **Created:** March 2026
+**Last updated:** March 2026 (added 16 AI regulations, total 72)

--- a/src/pages/hub/tools/index.astro
+++ b/src/pages/hub/tools/index.astro
@@ -28,7 +28,7 @@ const isDev = import.meta.env.DEV;
                     <h2>Regulatory Map</h2>
                 </div>
                 <ul class="tool-features">
-                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Interactive world map of global technology and data privacy regulations</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Interactive world map of data and privacy regulations</li>
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Click any country to explore GDPR, CCPA, LGPD and other frameworks</li>
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Key requirements, penalties, and effective dates at a glance</li>
                 </ul>

--- a/src/pages/hub/tools/index.astro
+++ b/src/pages/hub/tools/index.astro
@@ -28,8 +28,8 @@ const isDev = import.meta.env.DEV;
                     <h2>Regulatory Map</h2>
                 </div>
                 <ul class="tool-features">
-                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Interactive world map of data and privacy regulations</li>
-                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Click any country to explore GDPR, CCPA, LGPD and other frameworks</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Interactive world map of data privacy and AI regulations</li>
+                    <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Click any country to explore GDPR, CCPA, EU AI Act and other frameworks</li>
                     <li><img src="/images/gst-delta-icon-teal-stroke-thick.svg" alt="" aria-hidden="true" class="bullet-icon" width="12" height="12" />Key requirements, penalties, and effective dates at a glance</li>
                 </ul>
                 <a href="/hub/tools/regulatory-map" class="cta-button primary tool-launch-button">Launch Tool</a>

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -8,6 +8,29 @@ import { fetchAllRegulations, getRegulationsByRegion } from '../../../../utils/f
 
 trackPageView('regulatory-map', 'Regulatory Map | GST');
 
+const faqItems = [
+    {
+        question: "Why does data regulation matter for technology investments?",
+        answer: "Data is the foundation of nearly every modern business — it drives product decisions, customer engagement, and revenue. When a company operates across jurisdictions without a clear understanding of its regulatory obligations, the result is unchecked exposure: fines, forced operational changes, or deal-killing liabilities discovered during diligence. For investors, regulatory posture is a direct indicator of operational maturity and risk."
+    },
+    {
+        question: "What regulations does the map cover?",
+        answer: "The map includes major data protection and privacy frameworks across global jurisdictions, including the EU's GDPR, California's CCPA/CPRA, Brazil's LGPD, Canada's PIPEDA and provincial laws, and dozens of other national and sub-national regulations. Coverage is continually expanding as new frameworks are enacted worldwide."
+    },
+    {
+        question: "How current is the regulatory data shown here?",
+        answer: "Regulatory data is sourced from official government publications and authoritative legal databases. The dataset is updated periodically to reflect new legislation, amendments, and enforcement changes. For time-sensitive compliance decisions, we recommend validating against the relevant regulatory authority's most recent publications."
+    },
+    {
+        question: "How should I use this tool during due diligence?",
+        answer: "Start by identifying every jurisdiction where the target company collects, processes, or stores data. Use the map to surface the applicable regulations in those regions, then cross-reference the target's compliance posture against each framework's key requirements. This gives you a structured view of regulatory exposure — gaps that could translate into remediation costs, integration delays, or post-close liabilities."
+    },
+    {
+        question: "Does GST provide regulatory compliance advisory?",
+        answer: "<p>Yes. The Regulatory Map is one component of GST's broader technology diligence capability. When regulatory exposure is identified during an engagement, we assess the scope of non-compliance, estimate remediation costs, and build those findings into our overall risk analysis and integration roadmap.</p><p><a href='/services'>Learn more about our advisory services</a> or <a href='https://calendly.com/globalstrategictech'>schedule a consultation</a>.</p>"
+    },
+];
+
 const regulations = await fetchAllRegulations();
 const regionMap = getRegulationsByRegion(regulations);
 
@@ -24,6 +47,7 @@ import caData from '../../../../data/canada-provinces.json';
     ogDescription="Explore regulatory frameworks — GDPR, CCPA, LGPD and more — across global jurisdictions."
     ogImage="/og-image.png"
     ogUrl="https://globalstrategic.tech/hub/tools/regulatory-map"
+    faqItems={faqItems}
 >
     <section class="regulatory-map-section">
         <div class="container">
@@ -56,6 +80,20 @@ import caData from '../../../../data/canada-provinces.json';
             </div>
 
             <a href="/hub/tools" class="cta-button secondary back-link">Back to The Workbench</a>
+        </div>
+    </section>
+
+    <section class="faq-section">
+        <div class="container">
+            <h2 class="heading-lg">Frequently Asked Questions</h2>
+            <div class="faq-list">
+                {faqItems.map((item) => (
+                    <details class="faq-item">
+                        <summary class="faq-question">{item.question}</summary>
+                        <div class="faq-answer" set:html={item.answer} />
+                    </details>
+                ))}
+            </div>
         </div>
     </section>
 </BaseLayout>
@@ -409,6 +447,24 @@ import caData from '../../../../data/canada-provinces.json';
     window.addEventListener('resize', syncPanelHeight);
 </script>
 
+<script>
+    import { trackEvent } from '../../../../utils/analytics';
+
+    document.querySelectorAll('.faq-item').forEach((item) => {
+        item.addEventListener('toggle', () => {
+            const details = item as HTMLDetailsElement;
+            const question = details.querySelector('.faq-question')?.textContent?.trim() || '';
+            trackEvent({
+                event: 'faq_interaction',
+                category: 'engagement',
+                question,
+                action: details.open ? 'open' : 'close',
+                page: 'regulatory-map',
+            });
+        });
+    });
+</script>
+
 <style>
     .regulatory-map-section {
         padding-bottom: var(--spacing-3xl);
@@ -527,6 +583,144 @@ import caData from '../../../../data/canada-provinces.json';
             grid-template-columns: 1fr 380px;
             gap: var(--spacing-xl);
         }
+    }
 
+    /* FAQ Section */
+    .faq-section {
+        padding: var(--spacing-3xl) 0;
+    }
+
+    .faq-section .heading-lg {
+        margin-bottom: var(--spacing-2xl);
+        text-align: center;
+    }
+
+    .faq-list {
+        max-width: 800px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-md);
+    }
+
+    .faq-item {
+        background: rgba(5, 205, 153, 0.03);
+        border: 1px solid rgba(5, 205, 153, 0.1);
+        border-radius: 8px;
+        transition: background var(--transition-normal), border-color var(--transition-normal);
+    }
+
+    .faq-item[open] {
+        background: rgba(5, 205, 153, 0.06);
+        border-color: rgba(5, 205, 153, 0.2);
+    }
+
+    .faq-question {
+        padding: var(--spacing-xl);
+        font-size: var(--text-lg);
+        font-weight: var(--font-weight-semibold);
+        color: rgba(26, 26, 26, 0.95);
+        cursor: pointer;
+        list-style: none;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--spacing-md);
+        transition: color var(--transition-fast);
+    }
+
+    .faq-question::-webkit-details-marker {
+        display: none;
+    }
+
+    .faq-question::after {
+        content: '+';
+        font-size: var(--text-2xl);
+        font-weight: var(--font-weight-bold);
+        color: var(--color-primary);
+        flex-shrink: 0;
+        transition: transform var(--transition-fast);
+    }
+
+    .faq-item[open] .faq-question::after {
+        content: '\2212';
+    }
+
+    .faq-question:hover {
+        color: var(--color-primary);
+    }
+
+    .faq-answer {
+        padding: 0 var(--spacing-xl) var(--spacing-xl);
+        font-size: var(--text-base);
+        color: rgba(26, 26, 26, 0.7);
+        line-height: 1.7;
+    }
+
+    .faq-answer :global(p) {
+        margin: 0 0 var(--spacing-md) 0;
+    }
+
+    .faq-answer :global(p:last-child) {
+        margin-bottom: 0;
+    }
+
+    .faq-answer :global(a) {
+        color: var(--color-primary);
+        text-decoration: none;
+        transition: opacity var(--transition-fast);
+    }
+
+    .faq-answer :global(a:hover) {
+        opacity: 0.8;
+    }
+
+    :global(html.dark-theme) .faq-item {
+        background: rgba(5, 205, 153, 0.05);
+        border-color: rgba(5, 205, 153, 0.15);
+    }
+
+    :global(html.dark-theme) .faq-item[open] {
+        background: rgba(5, 205, 153, 0.08);
+        border-color: rgba(5, 205, 153, 0.25);
+    }
+
+    :global(html.dark-theme) .faq-question {
+        color: rgba(245, 245, 245, 0.95);
+    }
+
+    :global(html.dark-theme) .faq-question:hover {
+        color: var(--color-primary);
+    }
+
+    :global(html.dark-theme) .faq-answer {
+        color: rgba(200, 200, 200, 0.7);
+    }
+
+    @media (max-width: 768px) {
+        .faq-section {
+            padding: var(--spacing-2xl) 0;
+        }
+
+        .faq-question {
+            padding: var(--spacing-lg);
+            font-size: var(--text-base);
+        }
+
+        .faq-answer {
+            padding: 0 var(--spacing-lg) var(--spacing-lg);
+            font-size: var(--text-sm);
+        }
+    }
+
+    @media (max-width: 480px) {
+        .faq-question {
+            padding: var(--spacing-md);
+        }
+
+        .faq-answer {
+            padding: 0 var(--spacing-md) var(--spacing-md);
+            font-size: var(--text-sm);
+        }
     }
 </style>

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -10,12 +10,12 @@ trackPageView('regulatory-map', 'Regulatory Map | GST');
 
 const faqItems = [
     {
-        question: "Why does data regulation matter for technology investments?",
-        answer: "Data is the foundation of nearly every modern business. It drives product decisions, customer engagement, and revenue. When a company operates across jurisdictions without a clear understanding of its regulatory obligations, the result is unchecked exposure: fines, forced operational changes, or deal-killing liabilities discovered during diligence. For investors, regulatory posture is a direct indicator of operational maturity and risk."
+        question: "Why do data privacy and AI regulations matter for technology investments?",
+        answer: "Data and AI capabilities are central to nearly every modern business. They drive product decisions, customer engagement, and revenue. When a company operates across jurisdictions without a clear understanding of its regulatory obligations in both data privacy and AI governance, the result is unchecked exposure: fines, forced operational changes, or deal-killing liabilities discovered during diligence. For investors, regulatory posture is a direct indicator of operational maturity and risk."
     },
     {
         question: "What regulations does the map cover?",
-        answer: "The map includes major data protection and privacy frameworks across global jurisdictions, including the EU's GDPR, California's CCPA/CPRA, Brazil's LGPD, Canada's PIPEDA and provincial laws, and dozens of other national and sub-national regulations. Coverage is continually expanding as new frameworks are enacted worldwide."
+        answer: "The map covers two categories of regulation. For data privacy, it includes major frameworks such as the EU's GDPR, California's CCPA/CPRA, Brazil's LGPD, Canada's PIPEDA and provincial laws, and dozens of other national and sub-national regulations. For artificial intelligence, it includes the EU AI Act, China's algorithm and generative AI regulations, South Korea's AI Basic Act, and US state-level AI laws covering areas like algorithmic discrimination, AI transparency, and automated employment decisions. Coverage is continually expanding as new frameworks are enacted worldwide."
     },
     {
         question: "How current is the regulatory data shown here?",
@@ -23,11 +23,11 @@ const faqItems = [
     },
     {
         question: "How should I use this tool during due diligence?",
-        answer: "Start by identifying every jurisdiction where the target company collects, processes, or stores data. Use the map to surface the applicable regulations in those regions, then cross-reference the target's compliance posture against each framework's key requirements. This gives you a structured view of regulatory exposure, highlighting gaps that could translate into remediation costs, integration delays, or post-close liabilities."
+        answer: "Start by identifying every jurisdiction where the target company collects, processes, or stores data, and where it develops or deploys AI systems. Use the map to surface the applicable regulations in those regions, then cross-reference the target's compliance posture against each framework's key requirements. This gives you a structured view of regulatory exposure across both data privacy and AI governance, highlighting gaps that could translate into remediation costs, integration delays, or post-close liabilities."
     },
     {
         question: "Does GST provide regulatory compliance advisory?",
-        answer: "<p>Yes. The Regulatory Map is one component of GST's broader technology diligence capability. When regulatory exposure is identified during an engagement, we assess the scope of non-compliance, estimate remediation costs, and build those findings into our overall risk analysis and integration roadmap.</p><p><a href='/services'>Learn more about our advisory services</a> or <a href='https://calendly.com/globalstrategictech'>schedule a consultation</a>.</p>"
+        answer: "<p>Yes. The Regulatory Map is one component of GST's broader technology diligence capability. When regulatory exposure is identified during an engagement, whether in data privacy, AI governance, or both, we assess the scope of non-compliance, estimate remediation costs, and build those findings into our overall risk analysis and integration roadmap.</p><p><a href='/services'>Learn more about our advisory services</a> or <a href='https://calendly.com/globalstrategictech'>schedule a consultation</a>.</p>"
     },
 ];
 
@@ -42,9 +42,9 @@ import caData from '../../../../data/canada-provinces.json';
 
 <BaseLayout
     title="Regulatory Map | Strategic Intelligence Hub"
-    description="Interactive map of global technology regulations and data privacy compliance requirements across jurisdictions."
+    description="Interactive map of global data privacy and AI regulations. Explore GDPR, CCPA, the EU AI Act, and dozens of other frameworks across jurisdictions."
     ogTitle="Regulatory Map | GST"
-    ogDescription="Explore regulatory frameworks — GDPR, CCPA, LGPD and more — across global jurisdictions."
+    ogDescription="Explore data privacy and AI regulatory frameworks, including GDPR, CCPA, EU AI Act and more, across global jurisdictions."
     ogImage="/og-image.png"
     ogUrl="https://globalstrategic.tech/hub/tools/regulatory-map"
     faqItems={faqItems}
@@ -53,7 +53,7 @@ import caData from '../../../../data/canada-provinces.json';
         <div class="container">
             <HubHeader
                 title="Regulatory Map"
-                subtitle="Data is the lifeblood of every digital organization. Understanding the regulatory frameworks governing how it can legally be collected, stored, and transferred across jurisdictions is imperative."
+                subtitle="Data privacy and artificial intelligence are among the most actively regulated areas in technology. Understanding the frameworks governing how data can be collected, stored, and transferred, and how AI can be developed and deployed, across jurisdictions is imperative."
             />
 
             <div class="map-layout" id="mapLayout">

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -475,6 +475,8 @@ import caData from '../../../../data/canada-provinces.json';
         grid-template-columns: 1fr;
         gap: var(--spacing-lg);
         align-items: start;
+        max-width: 960px;
+        margin: 0 auto;
     }
 
     .map-wrapper {
@@ -579,9 +581,10 @@ import caData from '../../../../data/canada-provinces.json';
 
     /* Responsive */
     @media (min-width: 1024px) {
-        .map-layout {
+        .map-layout:has(.compliance-panel:not([hidden])) {
             grid-template-columns: 1fr 380px;
             gap: var(--spacing-xl);
+            max-width: none;
         }
     }
 

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -11,7 +11,7 @@ trackPageView('regulatory-map', 'Regulatory Map | GST');
 const faqItems = [
     {
         question: "Why does data regulation matter for technology investments?",
-        answer: "Data is the foundation of nearly every modern business — it drives product decisions, customer engagement, and revenue. When a company operates across jurisdictions without a clear understanding of its regulatory obligations, the result is unchecked exposure: fines, forced operational changes, or deal-killing liabilities discovered during diligence. For investors, regulatory posture is a direct indicator of operational maturity and risk."
+        answer: "Data is the foundation of nearly every modern business. It drives product decisions, customer engagement, and revenue. When a company operates across jurisdictions without a clear understanding of its regulatory obligations, the result is unchecked exposure: fines, forced operational changes, or deal-killing liabilities discovered during diligence. For investors, regulatory posture is a direct indicator of operational maturity and risk."
     },
     {
         question: "What regulations does the map cover?",
@@ -23,7 +23,7 @@ const faqItems = [
     },
     {
         question: "How should I use this tool during due diligence?",
-        answer: "Start by identifying every jurisdiction where the target company collects, processes, or stores data. Use the map to surface the applicable regulations in those regions, then cross-reference the target's compliance posture against each framework's key requirements. This gives you a structured view of regulatory exposure — gaps that could translate into remediation costs, integration delays, or post-close liabilities."
+        answer: "Start by identifying every jurisdiction where the target company collects, processes, or stores data. Use the map to surface the applicable regulations in those regions, then cross-reference the target's compliance posture against each framework's key requirements. This gives you a structured view of regulatory exposure, highlighting gaps that could translate into remediation costs, integration delays, or post-close liabilities."
     },
     {
         question: "Does GST provide regulatory compliance advisory?",

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -79,7 +79,6 @@ import caData from '../../../../data/canada-provinces.json';
                 <CompliancePanel />
             </div>
 
-            <a href="/hub/tools" class="cta-button secondary back-link">Back to The Workbench</a>
         </div>
     </section>
 
@@ -94,6 +93,7 @@ import caData from '../../../../data/canada-provinces.json';
                     </details>
                 ))}
             </div>
+            <a href="/hub/tools" class="cta-button secondary back-link">Back to The Workbench</a>
         </div>
     </section>
 </BaseLayout>
@@ -566,7 +566,7 @@ import caData from '../../../../data/canada-provinces.json';
 
     .back-link {
         display: inline-block;
-        margin-top: var(--spacing-md);
+        margin-top: var(--spacing-2xl);
     }
 
     /* Dark theme */

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -29,7 +29,7 @@ import caData from '../../../../data/canada-provinces.json';
         <div class="container">
             <HubHeader
                 title="Regulatory Map"
-                subtitle="Global data regulation and privacy compliance landscape."
+                subtitle="Data is the lifeblood of every digital organization. Understanding the regulatory frameworks governing how it can legally be collected, stored, and transferred across jurisdictions is imperative."
             />
 
             <div class="map-layout" id="mapLayout">

--- a/tests/unit/regulatory-map-data.test.ts
+++ b/tests/unit/regulatory-map-data.test.ts
@@ -28,8 +28,8 @@ describe('Regulatory Map Data Validation', () => {
       expect(Array.isArray(regulations)).toBe(true);
     });
 
-    it('should have exactly 56 regulation files', () => {
-      expect(filenames.length).toBe(56);
+    it('should have exactly 72 regulation files', () => {
+      expect(filenames.length).toBe(72);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add 16 enacted AI-specific regulations across global jurisdictions (EU AI Act, 3 China AI laws, South Korea, Japan, Peru, 9 US state AI laws)
- Update page metadata, subtitle, FAQ, and Workbench card copy to reflect expanded data privacy + AI governance scope
- Remove em dashes from user-facing copy
- Update technical documentation with full AI regulation inventory and multi-regulation region cross-reference
- Update test assertion for regulation file count (56 → 72)

## Test plan
- [x] `npm run build` passes (Zod validates all 72 JSON files)
- [x] `npm run test:run` passes (560 unit/integration tests, including updated file count assertion)
- [x] `npm run test:e2e` passes (E2E tests verify map interaction with regulation cards)
- [ ] Visual check: click an EU country (e.g., Germany) and verify both GDPR and EU AI Act cards appear
- [ ] Visual check: click California and verify both CCPA and AI Transparency Act cards appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)