### PR TITLE
TechPar tool, SEO/a11y fixes, and portfolio updates

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -12,9 +12,6 @@ import ThemeToggle from './ThemeToggle.astro';
             </div>
             <ThemeToggle />
         </div>
-        <div class="footer-copyright">
-            &copy; 2026 Global Strategic Technologies LLC. All rights reserved.
-        </div>
     </div>
 </footer>
 
@@ -41,16 +38,6 @@ import ThemeToggle from './ThemeToggle.astro';
 
     .footer-links a:hover {
         color: #05cd99;
-    }
-
-    .footer-copyright {
-        color: rgba(26, 26, 26, 0.5);
-        font-size: 0.8rem;
-        margin-top: 0.5rem;
-    }
-
-    :global(html.dark-theme) .footer-copyright {
-        color: rgba(200, 200, 200, 0.4);
     }
 
     :global(html.dark-theme) .footer-links a {

--- a/src/docs/testing/TEST_BEST_PRACTICES.md
+++ b/src/docs/testing/TEST_BEST_PRACTICES.md
@@ -557,6 +557,7 @@ If your test has any of these, it's likely a false positive:
 22. ✗ Source code uses `setTimeout` for navigation/state changes without saving and clearing the timer ID
 23. ✗ Assumes `page.evaluate()` mocks survive `page.goto()` — mocks are lost on navigation, must be re-applied
 24. ✗ Dispatches mouse events to test CSS `:hover` styles — pseudo-class state cannot be activated via JS
+25. ✗ Relies on implicit UI defaults (pre-selected stage, pre-filled growth rate) instead of explicitly setting required state — breaks when defaults are removed or changed
 
 ## E2E Cross-Browser Pitfalls
 
@@ -941,6 +942,41 @@ test('should track events across pages', async ({ page }) => {
 
 **Key principle:** Any `page.evaluate()`-based mock must be re-applied after every `page.goto()`. If your test navigates between pages, call the mock setup function again. Route-based mocks (`page.route()`) persist across navigations because they operate at the network layer, not the page context.
 
+### 21. ❌ Relying on Implicit UI Defaults Instead of Explicit Setup
+
+Tests that depend on a page's default selections (e.g., "Series B-C is pre-selected on load") are brittle. When the UX is improved to require explicit user choices — or when defaults are changed — every test that skipped the setup step breaks simultaneously.
+
+This was discovered in the TechPar tool: 13 E2E tests relied on `series_bc` being the default company stage. When the default was removed (forcing users to make an intentional choice), all 13 tests failed because `buildInputs()` returned `null` without a stage selection.
+
+**Bad:**
+```typescript
+// ❌ Assumes series_bc is pre-selected — breaks when default is removed
+test('should enable analysis button', async ({ page }) => {
+  await gotoTool(page);
+  await fillInput(page, 'arr', '10000000');
+  await clickTab(page, 'costs');
+  await fillInput(page, 'infra', '50000');
+  const btn = page.locator('[data-btn-analysis]');
+  await expect(btn).toBeEnabled(); // Fails: no stage selected → compute returns null
+});
+```
+
+**Good:**
+```typescript
+// ✅ Explicitly sets all required state — survives default changes
+test('should enable analysis button', async ({ page }) => {
+  await gotoTool(page);
+  await selectStage(page, 'series_bc');  // Explicit — no implicit dependency
+  await fillInput(page, 'arr', '10000000');
+  await clickTab(page, 'costs');
+  await fillInput(page, 'infra', '50000');
+  const btn = page.locator('[data-btn-analysis]');
+  await expect(btn).toBeEnabled();
+});
+```
+
+**Key principle:** Every test should explicitly set up its own required state. Never rely on what happens to be selected when the page loads — those defaults are a UX decision that can change. Extract a helper (e.g., `selectStage()`) so the setup is clean and consistent across tests.
+
 ### 20. ❌ Simulating CSS `:hover` with JavaScript Events in Headless Browsers
 
 CSS `:hover` is a browser-internal pseudo-class state. Dispatching `mouseenter`, `mouseover`, or `pointerover` events via JavaScript does **not** activate `:hover` styles in headless browsers (and often not in headed mode either). Tests that dispatch mouse events and then assert on `:hover` CSS properties always fail.
@@ -1042,3 +1078,4 @@ The key principle: **Test what users experience, not implementation details.**
 - ✗ Don't use meaningless assertions
 - ✗ Don't use arbitrary timeouts
 - ✗ Don't assume CSS classes mean functionality works
+- ✗ Don't rely on implicit UI defaults — explicitly set all required state in each test

--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -72,7 +72,7 @@ trackPageView('techpar', 'TechPar | GST');
                                 <span class="tp-stage-card__name">Series A</span>
                                 <span class="tp-stage-card__range">45&ndash;75%</span>
                             </button>
-                            <button class="tp-stage-card tp-stage-card--active" data-stage="series_bc" type="button">
+                            <button class="tp-stage-card" data-stage="series_bc" type="button">
                                 <span class="tp-stage-card__name">Series B&ndash;C</span>
                                 <span class="tp-stage-card__range">35&ndash;55%</span>
                             </button>
@@ -112,7 +112,7 @@ trackPageView('techpar', 'TechPar | GST');
                         <div class="tp-seg-row">
                             <div class="tp-seg" data-seg="growth">
                                 <button class="tp-seg__btn" data-growth="10" type="button">10%</button>
-                                <button class="tp-seg__btn tp-seg__btn--active" data-growth="20" type="button">20%</button>
+                                <button class="tp-seg__btn" data-growth="20" type="button">20%</button>
                                 <button class="tp-seg__btn" data-growth="30" type="button">30%</button>
                                 <button class="tp-seg__btn" data-growth="50" type="button">50%</button>
                             </div>
@@ -1466,8 +1466,8 @@ trackPageView('techpar', 'TechPar | GST');
     Chart.register(...registerables);
 
     // ─── State ─────────────────────────────────────────────────
-    let stageKey = 'series_bc';
-    let growthRate = 20;
+    let stageKey: string | null = null;
+    let growthRate: number | null = null;
     let mode: 'quick' | 'deepdive' = 'quick';
     let trajChart: Chart | null = null;
 
@@ -1526,20 +1526,18 @@ trackPageView('techpar', 'TechPar | GST');
             else el.value = '';
         });
 
-        // Reset JS state to defaults
-        stageKey = 'series_bc';
-        growthRate = 20;
+        // Reset JS state
+        stageKey = null;
+        growthRate = null;
         mode = 'quick';
 
-        // Reset stage cards
+        // Reset stage cards — clear all selections
         $$('.tp-stage-card').forEach(c => c.classList.remove('tp-stage-card--active'));
-        document.querySelector('[data-stage="series_bc"]')?.classList.add('tp-stage-card--active');
 
-        // Reset growth buttons and custom input
+        // Reset growth buttons and custom input — clear all selections
         $$('[data-growth]').forEach(b => b.classList.remove('tp-seg__btn--active'));
-        document.querySelector('[data-growth="20"]')?.classList.add('tp-seg__btn--active');
         const growthCustomEl = document.getElementById('tp-growth-custom') as HTMLInputElement | null;
-        if (growthCustomEl) growthCustomEl.value = '20';
+        if (growthCustomEl) growthCustomEl.value = '';
 
         // Reset mode toggle
         $$('[data-mode]').forEach(b => b.classList.remove('tp-seg__btn--active'));
@@ -1577,7 +1575,7 @@ trackPageView('techpar', 'TechPar | GST');
 
     // ─── Growth rate selector ──────────────────────────────────
     const growthCustomInput = document.getElementById('tp-growth-custom') as HTMLInputElement | null;
-    if (growthCustomInput) growthCustomInput.value = String(growthRate);
+    if (growthCustomInput) growthCustomInput.value = growthRate !== null ? String(growthRate) : '';
 
     $$('[data-growth]').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -1699,14 +1697,15 @@ trackPageView('techpar', 'TechPar | GST');
     });
 
     // ─── Build inputs from DOM ─────────────────────────────────
-    function buildInputs(): TechParInputs {
+    function buildInputs(): TechParInputs | null {
+        if (!stageKey) return null;
         const gaapEl = document.querySelector('[data-input="gaapChk"]') as HTMLInputElement | null;
         return {
             arr: getInput('arr'),
             stage: stageKey as TechParInputs['stage'],
             mode,
             capexView: gaapEl?.checked ? 'gaap' : 'cash',
-            growthRate,
+            growthRate: growthRate || 0,
             exitMultiple: getInput('exitMult') || 12,
             infraHosting: getInput('infra'),
             infraPersonnel: getInput('infraPers'),
@@ -1720,13 +1719,14 @@ trackPageView('techpar', 'TechPar | GST');
     }
 
     function runCompute() {
-        return compute(buildInputs());
+        const inputs = buildInputs();
+        return inputs ? compute(inputs) : null;
     }
 
     // ─── Main update ───────────────────────────────────────────
     function updateAll() {
         const inputs = buildInputs();
-        const r = compute(inputs);
+        const r = inputs ? compute(inputs) : null;
 
         // Exit field visibility
         const showExit = stageKey === 'pe' || stageKey === 'enterprise';
@@ -1745,7 +1745,7 @@ trackPageView('techpar', 'TechPar | GST');
         if (btnAnalysis) btnAnalysis.disabled = !r;
 
         // Tab completion — teal bottom border on done tabs
-        const profileDone = inputs.arr > 0;
+        const profileDone = !!inputs && inputs.arr > 0 && !!stageKey;
         const costsDone = r !== null;
         document.querySelector('[data-tab="profile"]')?.classList.toggle('tp-tab--done', profileDone);
         document.querySelector('[data-tab="costs"]')?.classList.toggle('tp-tab--done', costsDone);
@@ -1755,26 +1755,45 @@ trackPageView('techpar', 'TechPar | GST');
         document.querySelector('[data-badge="analysis"]')?.classList.toggle('tp-tab__badge--on', !!analysisAlert);
 
         if (!r) {
-            // Update analysis empty state to point at the missing required field
-            const missingArr = !inputs.arr;
+            // Determine what's missing to show targeted guidance
+            const missingStage = !stageKey;
+            const missingArr = !inputs || !inputs.arr;
             const emptyMsg = document.querySelector('[data-analysis-empty-msg]');
             const emptyCta = document.querySelector('[data-analysis-empty-cta]') as HTMLButtonElement | null;
-            if (emptyMsg) emptyMsg.textContent = missingArr
-                ? 'Enter your ARR on the Profile tab\nto compute TechPar.'
-                : 'Enter infrastructure spend on the\nCosts tab to compute TechPar.';
-            if (emptyCta) {
-                emptyCta.dataset.action = missingArr ? 'go-profile' : 'go-costs';
-                emptyCta.textContent = missingArr ? 'Go to profile →' : 'Go to costs →';
+            if (missingStage || missingArr) {
+                const msg = missingStage
+                    ? 'Select a company stage on the Profile\ntab to compute TechPar.'
+                    : 'Enter your ARR on the Profile tab\nto compute TechPar.';
+                if (emptyMsg) emptyMsg.textContent = msg;
+                if (emptyCta) {
+                    emptyCta.dataset.action = 'go-profile';
+                    emptyCta.textContent = 'Go to profile →';
+                }
+            } else {
+                if (emptyMsg) emptyMsg.textContent = 'Enter infrastructure spend on the\nCosts tab to compute TechPar.';
+                if (emptyCta) {
+                    emptyCta.dataset.action = 'go-costs';
+                    emptyCta.textContent = 'Go to costs →';
+                }
             }
             // Trajectory empty state
             const trajMsg = document.querySelector('[data-traj-empty-msg]');
             const trajCta = document.querySelector('[data-traj-empty-cta]') as HTMLButtonElement | null;
-            if (trajMsg) trajMsg.textContent = missingArr
-                ? 'Enter your ARR on the Profile tab\nto generate trajectory.'
-                : 'Enter infrastructure spend on the\nCosts tab to generate trajectory.';
-            if (trajCta) {
-                trajCta.dataset.action = missingArr ? 'go-profile' : 'go-costs';
-                trajCta.textContent = missingArr ? 'Go to profile →' : 'Go to costs →';
+            if (missingStage || missingArr) {
+                const msg = missingStage
+                    ? 'Select a company stage on the Profile\ntab to generate trajectory.'
+                    : 'Enter your ARR on the Profile tab\nto generate trajectory.';
+                if (trajMsg) trajMsg.textContent = msg;
+                if (trajCta) {
+                    trajCta.dataset.action = 'go-profile';
+                    trajCta.textContent = 'Go to profile →';
+                }
+            } else {
+                if (trajMsg) trajMsg.textContent = 'Enter infrastructure spend on the\nCosts tab to generate trajectory.';
+                if (trajCta) {
+                    trajCta.dataset.action = 'go-costs';
+                    trajCta.textContent = 'Go to costs →';
+                }
             }
             // Show empty states
             g('analysis-empty')?.classList.remove('tp-empty--hidden');

--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -644,6 +644,7 @@ trackPageView('techpar', 'TechPar | GST');
 
     .tp-input-wrap {
         position: relative;
+        width: 100%;
         max-width: 280px;
     }
 
@@ -799,6 +800,7 @@ trackPageView('techpar', 'TechPar | GST');
 
     .tp-seg {
         display: flex;
+        width: 100%;
         border: 1px solid var(--text-light-muted);
         overflow: hidden;
         max-width: 280px;

--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -118,7 +118,7 @@ trackPageView('techpar', 'TechPar | GST');
                             </div>
                         </div>
                         <div class="tp-input-wrap">
-                            <input type="number" id="tp-growth-custom" data-input="growthCustom" min="1" max="500" placeholder="Custom %" class="tp-input--no-pre tp-input--has-suf" />
+                            <input type="number" id="tp-growth-custom" data-input="growthCustom" min="1" max="500" placeholder="Custom" class="tp-input--no-pre tp-input--has-suf" />
                             <span class="tp-input-suf">%</span>
                         </div>
                         <div class="tp-hint text-tiny">Used in trajectory projections. Does not affect current-period KPIs.</div>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -129,6 +129,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
         </p>
 
+        <h2>Copyright Notice</h2>
+        <p>
+          &copy; 2026 Global Strategic Technologies LLC. All rights reserved.
+        </p>
+
         <section class="contact-section">
           <h2>Contact Us</h2>
           <p>

--- a/tests/e2e/techpar.test.ts
+++ b/tests/e2e/techpar.test.ts
@@ -18,6 +18,10 @@ async function clickTab(page: Page, tab: string): Promise<void> {
   await page.click(`.tp-tab[data-tab="${tab}"]`);
 }
 
+async function selectStage(page: Page, stage: string = 'series_bc'): Promise<void> {
+  await page.click(`[data-stage="${stage}"]`);
+}
+
 // ─── Profile tab ─────────────────────────────────────────────────────────────
 
 test.describe('TechPar - Profile tab', () => {
@@ -42,23 +46,24 @@ test.describe('TechPar - Profile tab', () => {
     await expect(page.locator('[data-panel="costs"]')).toHaveClass(/tp-panel--active/);
   });
 
-  test('Profile tab shows checkmark when ARR > 0', async ({ page }) => {
+  test('Profile tab shows checkmark when ARR > 0 and stage selected', async ({ page }) => {
     await gotoTool(page);
     const tab = page.locator('[data-tab="profile"]');
     await expect(tab).not.toHaveClass(/tp-tab--done/);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await expect(tab).toHaveClass(/tp-tab--done/);
   });
 
   test('exit multiple field is hidden on Seed, Series A, Series B-C stages', async ({ page }) => {
     await gotoTool(page);
-    // Default is series_bc
+    // No stage selected — exit field should be hidden
     await expect(page.locator('[data-exit-field]')).not.toHaveClass(/tp-exit-field--vis/);
-    // Switch to seed
-    await page.click('[data-stage="seed"]');
+    await selectStage(page, 'series_bc');
     await expect(page.locator('[data-exit-field]')).not.toHaveClass(/tp-exit-field--vis/);
-    // Switch to series_a
-    await page.click('[data-stage="series_a"]');
+    await selectStage(page, 'seed');
+    await expect(page.locator('[data-exit-field]')).not.toHaveClass(/tp-exit-field--vis/);
+    await selectStage(page, 'series_a');
     await expect(page.locator('[data-exit-field]')).not.toHaveClass(/tp-exit-field--vis/);
   });
 
@@ -76,6 +81,7 @@ test.describe('TechPar - Profile tab', () => {
 test.describe('TechPar - Costs tab', () => {
   test('"View analysis" button is disabled when infraHosting is 0', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     const btn = page.locator('[data-btn-analysis]');
@@ -84,6 +90,7 @@ test.describe('TechPar - Costs tab', () => {
 
   test('"View analysis" button is enabled when ARR > 0 and infraHosting > 0', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -93,6 +100,7 @@ test.describe('TechPar - Costs tab', () => {
 
   test('Costs tab shows checkmark when both required fields have values', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -137,6 +145,7 @@ test.describe('TechPar - Costs tab', () => {
 
   test('CapEx toggle changes the primary KPI value and basis label', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -172,6 +181,7 @@ test.describe('TechPar - Analysis tab', () => {
 
   test('Analysis tab renders primary KPI when required inputs are present', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -183,6 +193,7 @@ test.describe('TechPar - Analysis tab', () => {
 
   test('zone pill label matches the computed zone', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -195,6 +206,7 @@ test.describe('TechPar - Analysis tab', () => {
 
   test('benchmark table highlights the active stage row', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -215,6 +227,7 @@ test.describe('TechPar - Trajectory tab', () => {
 
   test('Trajectory tab renders chart when costs are entered', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -225,6 +238,7 @@ test.describe('TechPar - Trajectory tab', () => {
 
   test('Trajectory chart has convergence revenue line on Series B-C stage', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -257,6 +271,7 @@ test.describe('TechPar - Navigation', () => {
     await expect(page.locator('[data-panel="profile"]')).toHaveClass(/tp-panel--active/);
 
     // Fill required fields so analysis content (with go-costs back button) is shown
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');
@@ -283,6 +298,7 @@ test.describe('TechPar - Integrity', () => {
 
   test('no em dashes present in any rendered signal copy', async ({ page }) => {
     await gotoTool(page);
+    await selectStage(page);
     await fillInput(page, 'arr', '10000000');
     await clickTab(page, 'costs');
     await fillInput(page, 'infra', '50000');


### PR DESCRIPTION
## Summary

- **TechPar Tool** — New technology cost benchmarking tool (`/hub/tools/techpar/`) with trajectory charts, signal analysis, preset chips, segmented controls, sticky mobile nav, and full E2E + unit test coverage (309 unit tests, 316 E2E tests)
- **SEO & Accessibility** — Standardised page titles to `Page Name | GST` format, added aria-label to logo anchor, corrected typos across services and portfolio pages
- **Portfolio Data** — Added project Eagle to ma-portfolio, corrected ARR capitalisation for market research project, renamed project to disambiguate
- **Footer/Terms** — Moved copyright notice from footer to terms page
- **Tooling** — Added `gst-ma-portfolio-card` skill and `get-api-docs` skill
- **Testing** — Fixed flaky WebKit aria-expanded test, added anti-pattern docs for implicit UI defaults

## Test plan

- [ ] Verify TechPar tool loads and all tabs function correctly
- [ ] Confirm trajectory chart renders with correct CVD-safe palette
- [ ] Test preset chips and manual input sync on all cost fields
- [ ] Verify page titles follow `Page Name | GST` format across site
- [ ] Check copyright notice appears on terms page (not in footer)
- [ ] Run `npm run test:run` — all unit/integration tests pass
- [ ] Run `npm run test:e2e` — all E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)