### PR TITLE
Bug fixes: CSS load-order, DM multi-region, portfolio styling

### DIFF
--- a/src/components/PortfolioSummary.astro
+++ b/src/components/PortfolioSummary.astro
@@ -13,8 +13,8 @@
 <style>
     .portfolio-summary {
         padding: 3rem 0;
-        background: rgba(5, 205, 153, 0.05);
-        border-bottom: 1px solid rgba(5, 205, 153, 0.1);
+        background: linear-gradient(180deg, rgba(5, 205, 153, 0) 0%, rgba(5, 205, 153, 0.05) 15%, rgba(5, 205, 153, 0.05) 85%, rgba(5, 205, 153, 0) 100%);
+        border-bottom: none;
     }
 
     .summary-content {
@@ -37,8 +37,7 @@
     }
 
     :global(html.dark-theme) .portfolio-summary {
-        background: rgba(5, 205, 153, 0.08);
-        border-bottom-color: rgba(5, 205, 153, 0.15);
+        background: linear-gradient(180deg, rgba(5, 205, 153, 0) 0%, rgba(5, 205, 153, 0.08) 15%, rgba(5, 205, 153, 0.08) 85%, rgba(5, 205, 153, 0) 100%);
     }
 
 

--- a/src/components/portfolio/PortfolioHeader.astro
+++ b/src/components/portfolio/PortfolioHeader.astro
@@ -139,7 +139,7 @@ const technicalDiligenceEngagements = uniqueEngagementTypes.filter(e => technica
 <style>
   /* Component-Specific Overrides */
   .portfolio-header {
-    background: var(--bg-light);
+    background: transparent;
     border-bottom: none;
     padding: 0.875rem 0;
   }

--- a/src/pages/hub/tools/diligence-machine/index.astro
+++ b/src/pages/hub/tools/diligence-machine/index.astro
@@ -485,7 +485,7 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
         ) as HTMLElement | null;
         if (mrCard) {
             const shouldBeSelected = synced.includes(MULTI_REGION_ID);
-            mrCard.classList.toggle('selected', shouldBeSelected);
+            mrCard.classList.toggle('brutal-option-card--selected-outline', shouldBeSelected);
             mrCard.setAttribute('aria-pressed', String(shouldBeSelected));
         }
     }

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -1611,20 +1611,22 @@ import caData from '../../../../data/canada-provinces.json';
         z-index: 0;
     }
 
-    /* Scoped overrides for timeline entries in horizontal scroll context */
-    :global(.brutal-timeline-entry) {
+    /* Horizontal scroll overrides for .brutal-timeline-* base classes.
+       Use .timeline-track parent to beat global.css specificity
+       regardless of Astro's production CSS chunk load order. */
+    :global(.timeline-track .brutal-timeline-entry) {
         position: relative;
         z-index: 1;
     }
 
-    :global(.brutal-timeline-entry__name) {
+    :global(.timeline-track .brutal-timeline-entry__name) {
         max-width: 180px;
         overflow: hidden;
         text-overflow: ellipsis;
     }
 
     /* Today marker — absolute positioned in horizontal timeline */
-    :global(.brutal-timeline-today) {
+    :global(.timeline-track .brutal-timeline-today) {
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -1635,7 +1637,7 @@ import caData from '../../../../data/canada-provinces.json';
         pointer-events: none;
     }
 
-    :global(.brutal-timeline-today::after) {
+    :global(.timeline-track .brutal-timeline-today::after) {
         content: '';
         width: 2px;
         flex: 1;
@@ -1644,7 +1646,7 @@ import caData from '../../../../data/canada-provinces.json';
         opacity: 0.6;
     }
 
-    :global(.brutal-timeline-today__label) {
+    :global(.timeline-track .brutal-timeline-today__label) {
         white-space: nowrap;
         margin-bottom: 2px;
     }
@@ -1777,7 +1779,7 @@ import caData from '../../../../data/canada-provinces.json';
             max-width: 100%;
         }
 
-        :global(.brutal-timeline-entry) {
+        :global(.timeline-track .brutal-timeline-entry) {
             color: #333;
         }
 


### PR DESCRIPTION
## Summary

- **fix(regulatory-map):** Scoped `.brutal-timeline-*` CSS overrides under `.timeline-track` parent selector to prevent Astro's production CSS chunk load order from breaking the timeline layout — the Today marker's `position: relative` (from global.css) was overriding `position: absolute` (from scoped styles), doubling the scrollable width and pushing all entries offscreen
- **fix(dm):** Corrected the selection class in `syncMultiRegionDOM()` from bare `'selected'` to `'brutal-option-card--selected-outline'` — missed during the design migration rename in 335f851, preventing the multi-region card from visually highlighting when auto-toggled
- **fix(portfolio):** Removed opaque `var(--bg-light)` background from `.portfolio-header` that was obscuring the page grid pattern
- **refactor(portfolio):** Applied vertical gradient fade to the Overview section background, matching the hero section pattern for consistent visual blending in both themes

## Test plan

- [x] Unit tests pass (857/857)
- [ ] Verify regulatory map timeline renders correctly on production deploy (entries visible, Today marker positioned, scroll centered)
- [ ] Verify Diligence Machine multi-region auto-select highlights the card when 2+ geographies selected
- [ ] Verify M&A Portfolio header blends with page grid (no opaque white block)
- [ ] Verify Overview section fades softly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)