### PR TITLE
QA fixes: SEO, design, and tsconfig cleanup

### DIFF
--- a/src/pages/hub/library/business-architectures/index.astro
+++ b/src/pages/hub/library/business-architectures/index.astro
@@ -7,7 +7,7 @@ trackPageView('business-architectures-guide', 'Business & Technology Architectur
 ---
 
 <BaseLayout
-    title="Business & Technology Architectures | Strategic Intelligence Hub"
+    title="Business & Technology Architectures | GST"
     description="How technology architecture choices cascade into business outcomes: a guide for investors, executives, and board members navigating technology-driven decisions."
     ogTitle="Business & Technology Architectures | GST"
     ogDescription="A business leader's guide to understanding how technology architecture choices create, constrain, or destroy business value."

--- a/src/pages/hub/library/index.astro
+++ b/src/pages/hub/library/index.astro
@@ -9,7 +9,7 @@ const isDev = import.meta.env.DEV;
 ---
 
 <BaseLayout
-    title="The Library | Strategic Intelligence Hub"
+    title="The Library | GST"
     description="Deep-dive frameworks and blueprints for technical due diligence and value creation execution."
     ogTitle="The Library - Resources | GST"
     ogDescription="Frameworks and blueprints for technical due diligence and value creation."

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -7,7 +7,7 @@ trackPageView('vdr-structure-guide', 'VDR Structure Guide | GST');
 ---
 
 <BaseLayout
-    title="Virtual Data Room (VDR) | Strategic Intelligence Hub"
+    title="Virtual Data Room (VDR) | GST"
     description="How to structure a Virtual Data Room for technology due diligence. Folder taxonomy, best practices, and common pitfalls from 100+ engagements."
     ogTitle="Virtual Data Room (VDR) | GST"
     ogDescription="Guidance for organizing a technology-focused Virtual Data Room for M&A transactions."

--- a/src/pages/hub/tools/diligence-machine/index.astro
+++ b/src/pages/hub/tools/diligence-machine/index.astro
@@ -8,7 +8,7 @@ trackPageView('diligence-machine', 'The Diligence Machine | GST');
 ---
 
 <BaseLayout
-    title="The Diligence Machine | Strategic Intelligence Hub"
+    title="The Diligence Machine | GST"
     description="Generate a simple technology due diligence agenda customized to your target's profile. 15-20 high-impact questions organized by topic."
     ogTitle="The Diligence Machine | GST"
     ogDescription="Customize a technology diligence checklist by target parameters. Priority-weighted, executive-ready."

--- a/src/pages/hub/tools/infrastructure-cost-governance/index.astro
+++ b/src/pages/hub/tools/infrastructure-cost-governance/index.astro
@@ -10,7 +10,7 @@ const domainCount = DOMAINS.length;
 ---
 
 <BaseLayout
-    title="Infrastructure Cost Governance | Strategic Intelligence Hub"
+    title="Infrastructure Cost Governance | GST"
     description="A structured maturity assessment for cloud cost management. Answer 20 questions across six operational domains and receive a scored diagnostic with a prioritized improvement checklist."
     ogTitle="Infrastructure Cost Governance | GST"
     ogDescription="Cloud cost maturity assessment for PE diligence, board reviews, and 100-day planning. Score your cloud spend governance across six operational domains."

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -41,7 +41,7 @@ import caData from '../../../../data/canada-provinces.json';
 ---
 
 <BaseLayout
-    title="Regulatory Map | Strategic Intelligence Hub"
+    title="Regulatory Map | GST"
     description="Interactive map of global data privacy and AI regulations. Explore GDPR, CCPA, the EU AI Act, and dozens of other frameworks across jurisdictions."
     ogTitle="Regulatory Map | GST"
     ogDescription="Explore data privacy and AI regulatory frameworks, including GDPR, CCPA, EU AI Act and more, across global jurisdictions."

--- a/src/pages/hub/tools/tech-debt-calculator/index.astro
+++ b/src/pages/hub/tools/tech-debt-calculator/index.astro
@@ -11,7 +11,7 @@ trackPageView('tech-debt-calculator', 'Technical Debt Cost Calculator | GST');
 ---
 
 <BaseLayout
-    title="Technical Debt Cost Calculator | Strategic Intelligence Hub"
+    title="Technical Debt Cost Calculator | GST"
     description="Quantify the annual cost of technical debt. Built for PE diligence and portfolio executive conversations."
     ogTitle="Technical Debt Cost Calculator | GST"
     ogDescription="Quantify the annual carrying cost of technical debt. Input team size, salary, maintenance burden, and delivery metrics to produce defensible estimates."

--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -7,7 +7,7 @@ trackPageView('techpar', 'TechPar | GST');
 ---
 
 <BaseLayout
-    title="TechPar | Strategic Intelligence Hub"
+    title="TechPar | GST"
     description="A technology cost structure analysis tool for PE diligence and portfolio company benchmarking. Enter spend across infrastructure, personnel, and R&D to compute a blended technology cost ratio benchmarked against stage-adjusted ranges."
     ogTitle="TechPar | GST"
     ogDescription="Technology cost structure analysis tool. Enter spend across infrastructure, personnel, and R&D to compute a blended cost ratio benchmarked against stage-adjusted ranges."

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ trackPageView('home', 'technology Advisory & Execution');
     description="M&A technical due diligence, post-acquisition integration, and platform modernization. Led by Reid Peryam, 20-year technology strategy veteran."
     ogTitle="GST | Strategic Technology Advisory"
     ogDescription="Specialized technical diligence and AI strategy for organizations navigating complex product transitions."
-    ogImage="https://globalstrategic.tech/og-image.jpg"
+    ogImage="https://globalstrategic.tech/og-image.png"
     ogUrl="https://globalstrategic.tech"
 >
     <Hero

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Privacy Policy | GST">
+<BaseLayout title="Privacy Policy | GST" description="How Global Strategic Technologies collects, uses, and safeguards your information when you visit our website or engage with our advisory services.">
   <main class="privacy-container">
     <div class="privacy-content">
       <header class="privacy-header">

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Terms | GST">
+<BaseLayout title="Terms | GST" description="Terms and conditions governing the use of the Global Strategic Technologies website and advisory services.">
   <main class="terms-container">
     <div class="terms-content">
       <header class="terms-header">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -761,11 +761,6 @@ html.dark-theme .trust-line {
 .stat-item {
     text-align: center;
     padding: 2rem;
-    border-right: 2px solid var(--color-primary);
-}
-
-.stat-item:last-child {
-    border-right: none;
 }
 
 .stat-value {
@@ -1128,7 +1123,7 @@ html.dark-theme .hero p {
 
 /* Dark Theme - Stats */
 html.dark-theme .stat-item {
-    border-right-color: var(--stat-item-border);
+    border-right-color: transparent;
 }
 
 html.dark-theme .stat-value {
@@ -1456,16 +1451,6 @@ html.dark-theme .cta-box p {
 
     .stat-item {
         padding: 1.75rem 1.25rem;
-        border-right: 1px solid rgba(0, 0, 0, 0.15);
-        border-bottom: 1px solid rgba(0, 0, 0, 0.15);
-    }
-
-    .stat-item:nth-child(2n) {
-        border-right: none;
-    }
-
-    .stat-item:nth-last-child(-n+2) {
-        border-bottom: none;
     }
 
     .stat-value {
@@ -5266,11 +5251,6 @@ html.dark-theme .filter-drawer-demo {
 .stat-item {
     text-align: center;
     padding: 1.5rem 1rem;
-    border-right: 2px solid rgba(0, 0, 0, 0.1);
-}
-
-.stat-item:last-child {
-    border-right: none;
 }
 
 .stat-value {
@@ -5334,15 +5314,6 @@ html.dark-theme .cta-box {
 
     .stats-grid {
         grid-template-columns: 1fr;
-    }
-
-    .stat-item {
-        border-right: none;
-        border-bottom: 2px solid rgba(0, 0, 0, 0.1);
-    }
-
-    .stat-item:last-child {
-        border-bottom: none;
     }
 
     .stat-value {

--- a/src/utils/breadcrumbs.ts
+++ b/src/utils/breadcrumbs.ts
@@ -10,7 +10,7 @@ export const BREADCRUMB_NAMES: Record<string, string> = {
   'about': 'About',
   'ma-portfolio': 'M&A Portfolio',
   'privacy': 'Privacy Policy',
-  'terms': 'Terms of Service',
+  'terms': 'Terms and Conditions',
   'hub': 'The GST Hub',
   'tools': 'Tools',
   'diligence-machine': 'Diligence Machine',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "types": ["node", "vitest/globals"],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "types": ["node", "vitest/globals"]
   },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
## Summary

- **refactor(design):** Remove stat-item border separators across all themes and breakpoints
- **fix(seo):** Correct OG image extension from `.jpg` to `.png` on homepage — social share previews were broken
- **fix(terms):** Align breadcrumb text ("Terms of Service" → "Terms and Conditions") with the page H1
- **fix(seo):** Add page-specific meta descriptions to Privacy and Terms pages (were falling back to generic site description)
- **fix(seo):** Standardize title tag suffix to "| GST" across all 8 hub pages that used "| Strategic Intelligence Hub"
- **chore:** Remove deprecated `baseUrl` and unused `@/*` path alias from tsconfig.json (TS 7.0 deprecation)

## Test plan

- [x] Unit tests pass (857/857)
- [x] Production build succeeds
- [ ] Verify OG image renders on social share preview (LinkedIn/Twitter debugger)
- [ ] Verify Terms breadcrumb shows "Terms and Conditions"
- [ ] Verify Privacy/Terms pages have specific meta descriptions in page source
- [ ] Verify all hub tool/library pages show "| GST" in browser tab
- [ ] Verify TS deprecation warning gone in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)