### PR TITLE
Fix homepage bullet icon alignment

### DIFF
--- a/src/components/WhatWeDo.astro
+++ b/src/components/WhatWeDo.astro
@@ -76,9 +76,6 @@ import DeltaIcon from './DeltaIcon.astro';
         align-items: flex-start;
         gap: var(--spacing-lg);
         justify-content: flex-end;
-    }
-
-    .services-list li span {
         font-size: var(--text-base);
         font-family: monospace;
         color: var(--text-primary);

--- a/src/components/WhatWeDo.astro
+++ b/src/components/WhatWeDo.astro
@@ -73,15 +73,9 @@ import DeltaIcon from './DeltaIcon.astro';
 
     .services-list li {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: var(--spacing-lg);
         justify-content: flex-end;
-    }
-
-    .bullet-icon {
-        width: 1.25rem;
-        height: 1.25rem;
-        flex-shrink: 0;
     }
 
     .services-list li span {
@@ -129,11 +123,6 @@ import DeltaIcon from './DeltaIcon.astro';
 
         .services-list {
             gap: var(--gap-normal);
-        }
-
-        .bullet-icon {
-            width: 1rem;
-            height: 1rem;
         }
 
         .services-list li span {

--- a/src/components/WhoWeSupport.astro
+++ b/src/components/WhoWeSupport.astro
@@ -70,9 +70,6 @@ import DeltaIcon from './DeltaIcon.astro';
         display: flex;
         align-items: flex-start;
         gap: var(--spacing-lg);
-    }
-
-    .support-list li span {
         font-size: var(--text-base);
         font-family: monospace;
         color: var(--text-primary);

--- a/src/components/WhoWeSupport.astro
+++ b/src/components/WhoWeSupport.astro
@@ -68,14 +68,8 @@ import DeltaIcon from './DeltaIcon.astro';
 
     .support-list li {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: var(--spacing-lg);
-    }
-
-    .bullet-icon {
-        width: 1.25rem;
-        height: 1.25rem;
-        flex-shrink: 0;
     }
 
     .support-list li span {
@@ -123,11 +117,6 @@ import DeltaIcon from './DeltaIcon.astro';
 
         .support-list {
             gap: var(--gap-normal);
-        }
-
-        .bullet-icon {
-            width: 1rem;
-            height: 1rem;
         }
 
         .support-list li span {


### PR DESCRIPTION
## Summary

- Switch WhatWeDo and WhoWeSupport bullet lists from `align-items: center` to `flex-start`, matching the site-wide pattern
- Remove scoped `.bullet-icon` size overrides that never applied due to Astro's CSS scoping on child components (DeltaIcon)
- Delta icons now use the global `.bullet-icon` margin-top formula consistently across all pages

## Test plan

- [ ] Visual check: delta bullets align with text on homepage "Who We Support" section
- [ ] Visual check: delta bullets align with text on homepage "What We Do" section
- [ ] Visual check: both sections at 768px and 480px breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)