### PR TITLE
fix(icons): restore footer delta icon and shift-left CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     paths-ignore:
       - '**.md'
       - 'src/docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
         run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -104,7 +104,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report

--- a/src/components/DeltaIcon.astro
+++ b/src/components/DeltaIcon.astro
@@ -8,6 +8,6 @@ const { size = 14, class: className = '' } = Astro.props;
 <svg viewBox="0 0 64 64" fill="none" aria-hidden="true"
      width={size} height={size} class={className}
      style="flex-shrink:0;">
-  <path d="M32 8 L56 56 L8 56 Z" fill="none" stroke="currentColor"
-        stroke-width="5" stroke-linejoin="miter"/>
+  <path d="M32 12 L52 52 L12 52 Z" fill="none" stroke="currentColor"
+        stroke-width="6" stroke-linejoin="miter"/>
 </svg>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -5,11 +5,13 @@ import { trackThemeToggle } from '../utils/analytics';
 ---
 
 <button class="theme-toggle" id="themeToggle" data-testid="theme-toggle" title="Toggle dark theme" aria-label="Toggle dark theme">
-    <DeltaIcon size={10} class="theme-toggle-icon" />
+    <DeltaIcon class="theme-toggle-icon" />
 </button>
 
-<style>
-    .theme-toggle-icon {
+<style is:global>
+    .theme-toggle .theme-toggle-icon {
+        width: 0.67em;
+        height: 0.67em;
         display: block;
     }
 </style>


### PR DESCRIPTION
## Summary
- **Fix footer delta icon**: restored correct size and stroke thickness after regression from DeltaIcon refactor (`81d8fe6f`). Used `is:global` style to pierce Astro component scoping, matching original `0.67em` em-based sizing. Updated SVG path and stroke-width to match `gst-delta-icon-teal-stroke-thick.svg`
- **Shift-left CI**: added `dev` to push trigger branches so tests run immediately on push, not just on PR. Existing concurrency group deduplicates against PR-triggered runs

## Test plan
- [ ] Footer delta icon renders at correct size (~54px) matching original appearance
- [ ] Delta icon stroke thickness matches the original thick-stroke SVG
- [ ] Delta bullet icons across site render correctly (unchanged 14px size)
- [ ] CI pipeline triggers on push to `dev`
- [ ] No duplicate CI runs when PR is also open
- [ ] `npm run test:run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)