### PR TITLE
chore: widen node engines to >=22 for Vercel Node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": "22.x"
+    "node": ">=22"
   },
   "browserslist": [
     "defaults",


### PR DESCRIPTION
## Summary

- Widen `engines.node` from `22.x` to `>=22` so Vercel's project setting (Node 24.x) is respected instead of overridden

## Root cause

The `engines` field in `package.json` pinned Node to `22.x`, which takes precedence over Vercel's project-level Node version setting. This produced a build warning on every deploy:

> Warning: Due to "engines": { "node": "22.x" }, the Node.js Version defined in your Project Settings ("24.x") will not apply

## Test plan

- [x] Build passes locally
- [ ] Vercel build warning disappears after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)