### PR TITLE
fix(ci): Lighthouse summary with proper page name extraction

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -32,82 +32,44 @@ jobs:
 
       - run: npm ci
 
-      - name: Collect Lighthouse results
-        run: npx lhci collect --config=lighthouserc.cjs
-
-      - name: Lighthouse scores summary
-        run: |
-          echo "## Lighthouse CI Scores" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          MANIFEST=".lighthouseci/manifest.json"
-          if [ -f "$MANIFEST" ]; then
-            echo "| Page | Performance | FCP | LCP | TBT | CLS |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|-------------|-----|-----|-----|-----|" >> $GITHUB_STEP_SUMMARY
-            node -e "
-              const m = JSON.parse(require('fs').readFileSync('$MANIFEST', 'utf8'));
-              m.forEach(r => {
-                const s = JSON.parse(require('fs').readFileSync(r.jsonPath, 'utf8'));
-                const perf = Math.round((s.categories.performance?.score || 0) * 100);
-                const fcp = Math.round(s.audits['first-contentful-paint'].numericValue);
-                const lcp = Math.round(s.audits['largest-contentful-paint'].numericValue);
-                const tbt = Math.round(s.audits['total-blocking-time'].numericValue);
-                const cls = s.audits['cumulative-layout-shift'].numericValue.toFixed(3);
-                const url = new URL(r.url).pathname || '/';
-                const icon = perf >= 90 ? '🟢' : perf >= 50 ? '🟠' : '🔴';
-                console.log('| ' + icon + ' \`' + url + '\` | **' + perf + '** | ' + fcp + 'ms | ' + lcp + 'ms | ' + tbt + 'ms | ' + cls + ' |');
-              });
-            " >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ No Lighthouse results found" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Assert performance budgets
+      - name: Run Lighthouse CI
         continue-on-error: true
-        run: npx lhci assert --config=lighthouserc.cjs 2>&1 | tee lhci-assert.txt
-
-      - name: Assertion results
-        if: always()
-        run: |
-          if [ -f "lhci-assert.txt" ]; then
-            ASSERTIONS=$(grep -E "result\(s\) for|warning for|failure for" lhci-assert.txt | sed 's/\x1b\[[0-9;]*m//g' || true)
-            if [ -n "$ASSERTIONS" ]; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "### Assertion Results" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              echo "$ASSERTIONS" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-            else
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "✅ All performance assertions passed" >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
-
-      - name: Upload results
-        if: always()
-        run: npx lhci upload --config=lighthouserc.cjs 2>&1 | tee lhci-upload.txt
+        run: npx lhci autorun --config=lighthouserc.cjs 2>&1 | tee lhci-output.txt
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add report links
+      - name: Generate summary
         if: always()
         run: |
-          if [ -f "lhci-upload.txt" ]; then
-            LINKS=$(grep "Open the report at" lhci-upload.txt | grep -oP 'https://\S+' || true)
-            if [ -n "$LINKS" ]; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "### Reports" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "$LINKS" | while read -r url; do
-                echo "- [View Report]($url)" >> $GITHUB_STEP_SUMMARY
-              done
-            fi
+          if [ ! -f "lhci-output.txt" ]; then
+            echo "## Lighthouse CI Scores" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ No Lighthouse output found" >> $GITHUB_STEP_SUMMARY
+            exit 0
           fi
 
-      - name: Upload Lighthouse artifacts
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: lighthouse-reports
-          path: .lighthouseci/
-          retention-days: 14
+          echo "## Lighthouse CI Scores" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Build scores table by pairing "Uploading median LHR" lines with "Open the report" lines
+          echo "| Page | Report |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          paste <(grep "Uploading median LHR" lhci-output.txt) <(grep "Open the report at" lhci-output.txt) | while IFS=$'\t' read -r upload_line report_line; do
+            PAGE=$(echo "$upload_line" | sed 's/.*http:\/\/localhost:4321//' | sed 's/\.\.\.success!//' | sed 's/^$/\//')
+            URL=$(echo "$report_line" | grep -oP 'https://\S+')
+            echo "| \`${PAGE}\` | [View Report](${URL}) |" >> $GITHUB_STEP_SUMMARY
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Show assertion results
+          ASSERTIONS=$(grep -E "result\(s\) for|warning for|failure for" lhci-output.txt | sed 's/\x1b\[[0-9;]*m//g' || true)
+          if [ -n "$ASSERTIONS" ]; then
+            echo "### Assertion Results" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$ASSERTIONS" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ All performance assertions passed" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Revert to single `autorun` step and fix summary parsing. Uses `paste` to pair "Uploading median LHR" lines with "Open the report" lines, correctly extracting page paths alongside report URLs.

## Test plan

- [ ] After merge: trigger manual dispatch, verify summary shows page names and report links

🤖 Generated with [Claude Code](https://claude.com/claude-code)