### PR TITLE
fix(perf): brand regression fix, geodata preloads, dashboard enhancements

### DIFF
--- a/.github/workflows/perf-dashboard.yml
+++ b/.github/workflows/perf-dashboard.yml
@@ -77,6 +77,7 @@ jobs:
           # Copy dashboard template files if they don't exist or are outdated
           cp scripts/dashboard/index.html gh-pages-dir/index.html
           cp scripts/dashboard/dashboard.css gh-pages-dir/dashboard.css
+          cp scripts/dashboard/favicon.svg gh-pages-dir/favicon.svg
           cp scripts/dashboard/.nojekyll gh-pages-dir/.nojekyll
 
       - name: Merge metrics

--- a/scripts/dashboard/dashboard.css
+++ b/scripts/dashboard/dashboard.css
@@ -190,6 +190,27 @@ body {
   margin: calc(-1 * var(--spacing-sm)) 0 var(--spacing-lg);
 }
 
+/* Run Now Button */
+.run-now-btn {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+  margin-left: auto;
+}
+
+.run-now-btn:hover {
+  background: rgba(5, 205, 153, 0.15);
+  color: var(--color-primary);
+}
+
 /* Page Filter Pills */
 .page-filters {
   display: flex;

--- a/scripts/dashboard/favicon.svg
+++ b/scripts/dashboard/favicon.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Delta Symbol Icon Only - Teal Stroke (Thick) -->
+
+  <!-- Delta Triangle -->
+  <path d="M32 12 L52 52 L12 52 Z"
+        fill="none"
+        stroke="#00D9B5"
+        stroke-width="6"
+        stroke-linejoin="miter"/>
+</svg>

--- a/scripts/dashboard/index.html
+++ b/scripts/dashboard/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Performance Dashboard — Global Strategic Technologies</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="stylesheet" href="dashboard.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   </head>
@@ -29,12 +30,22 @@
       </div>
       <label for="dateRange">Date range:</label>
       <select id="dateRange">
+        <option value="1">Last 24 hours</option>
+        <option value="7">Last 7 days</option>
         <option value="28">Last 4 weeks</option>
         <option value="90">Last 3 months</option>
         <option value="180" selected>Last 6 months</option>
         <option value="365">Last year</option>
         <option value="0">All time</option>
       </select>
+      <a
+        class="run-now-btn"
+        href="https://github.com/Global-Strategic-Technologies/gst-website/actions/workflows/perf-dashboard.yml"
+        target="_blank"
+        rel="noopener"
+        title="Open GitHub Actions to trigger a manual run"
+        >Run Now ↗</a
+      >
     </div>
 
     <div class="page-filters" id="pageFilters"></div>
@@ -162,7 +173,6 @@
             document.getElementById('emptyState').style.display = '';
             document.querySelector('.summary-section').style.display = 'none';
             document.querySelector('.charts-section').style.display = 'none';
-            // Destroy existing charts
             Object.values(charts).forEach((c) => c.destroy());
             charts = {};
             return;
@@ -172,7 +182,6 @@
           document.querySelector('.summary-section').style.display = '';
           document.querySelector('.charts-section').style.display = '';
 
-          // Rebuild with new data
           Object.values(charts).forEach((c) => c.destroy());
           charts = {};
           showData();
@@ -180,25 +189,21 @@
       }
 
       function showData() {
-        // Show last updated
         const lastRun = historyData.runs[historyData.runs.length - 1];
+        const commitShort = (lastRun.commit || '').slice(0, 7);
         document.getElementById('lastUpdated').textContent =
-          'Last updated: ' + new Date(lastRun.timestamp).toLocaleDateString();
+          'Last updated: ' +
+          new Date(lastRun.timestamp).toLocaleDateString() +
+          (commitShort ? ' (' + commitShort + ')' : '');
 
-        // Discover all pages across all runs
         const allPages = new Set();
         historyData.runs.forEach((run) => {
           Object.keys(run.pages).forEach((p) => allPages.add(p));
         });
         activePages = new Set(allPages);
 
-        // Build page filter pills
         buildPageFilters(Array.from(allPages));
-
-        // Build charts
         createCharts();
-
-        // Render
         render();
       }
 
@@ -292,32 +297,55 @@
         tension: 0.3,
       };
 
-      const chartOptions = {
-        responsive: true,
-        maintainAspectRatio: true,
-        interaction: { mode: 'index', intersect: false },
-        plugins: {
-          legend: {
-            position: 'bottom',
-            labels: {
-              color: 'rgba(200,200,200,0.8)',
-              font: { family: 'monospace', size: 11 },
-              boxWidth: 12,
-              padding: 12,
+      function buildChartOptions(metric) {
+        return {
+          responsive: true,
+          maintainAspectRatio: true,
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                color: 'rgba(200,200,200,0.8)',
+                font: { family: 'monospace', size: 11 },
+                boxWidth: 12,
+                padding: 12,
+              },
+            },
+            tooltip: {
+              callbacks: {
+                title: function (items) {
+                  if (!items.length) return '';
+                  const idx = items[0].dataIndex;
+                  const runs = getFilteredRuns();
+                  const run = runs[idx];
+                  if (!run) return items[0].label;
+                  const date = new Date(run.timestamp).toLocaleString();
+                  const sha = (run.commit || '').slice(0, 7);
+                  return sha ? date + '  \u2022  ' + sha : date;
+                },
+              },
             },
           },
-        },
-        scales: {
-          x: {
-            ticks: { color: 'rgba(200,200,200,0.6)', font: { family: 'monospace', size: 10 } },
-            grid: { color: 'rgba(255,255,255,0.05)' },
+          scales: {
+            x: {
+              ticks: {
+                color: 'rgba(200,200,200,0.6)',
+                font: { family: 'monospace', size: 10 },
+              },
+              grid: { color: 'rgba(255,255,255,0.05)' },
+            },
+            y: {
+              beginAtZero: metric === 'Tbt' || metric === 'Cls',
+              ticks: {
+                color: 'rgba(200,200,200,0.6)',
+                font: { family: 'monospace', size: 10 },
+              },
+              grid: { color: 'rgba(255,255,255,0.05)' },
+            },
           },
-          y: {
-            ticks: { color: 'rgba(200,200,200,0.6)', font: { family: 'monospace', size: 10 } },
-            grid: { color: 'rgba(255,255,255,0.05)' },
-          },
-        },
-      };
+        };
+      }
 
       function createCharts() {
         const metrics = ['Performance', 'Fcp', 'Lcp', 'Tbt', 'Cls'];
@@ -326,16 +354,7 @@
           charts[metric.toLowerCase()] = new Chart(ctx, {
             type: 'line',
             data: { labels: [], datasets: [] },
-            options: {
-              ...chartOptions,
-              scales: {
-                ...chartOptions.scales,
-                y: {
-                  ...chartOptions.scales.y,
-                  beginAtZero: metric === 'Tbt' || metric === 'Cls',
-                },
-              },
-            },
+            options: buildChartOptions(metric),
           });
         });
       }
@@ -346,7 +365,6 @@
           return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
         });
 
-        // Collect all active pages
         const pages = new Set();
         runs.forEach((r) => {
           Object.keys(r.pages).forEach((p) => {

--- a/src/pages/brand.astro
+++ b/src/pages/brand.astro
@@ -125,6 +125,11 @@ import BrandUILibrary from '../components/brand/BrandUILibrary.astro';
   .brand-section {
     padding: var(--spacing-3xl) 0;
     border-bottom: 1px solid var(--border-light);
+  }
+
+  /* Defer rendering of below-fold sections — skip the first two
+     (BrandIdentity + BrandColors) which are at or near the fold */
+  .brand-section:nth-of-type(n + 3) {
     content-visibility: auto;
     contain-intrinsic-size: auto 500px;
   }

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -50,6 +50,11 @@ import DeltaIcon from '../../../../components/DeltaIcon.astro';
   ogUrl="https://globalstrategic.tech/hub/tools/regulatory-map"
   faqItems={faqItems}
 >
+  {/* Preload geodata so downloads start during HTML parsing, before the D3 module executes */}
+  <link rel="preload" href="/data/world-110m.json" as="fetch" crossorigin />
+  <link rel="preload" href="/data/us-states-10m.json" as="fetch" crossorigin />
+  <link rel="preload" href="/data/canada-provinces.json" as="fetch" crossorigin />
+
   <script
     is:inline
     type="application/ld+json"


### PR DESCRIPTION
## Summary

- **Brand regression fix**: `content-visibility: auto` was applied to all `.brand-section` elements including the above-fold BrandIdentity, deferring its render and regressing desktop LCP by 68% (91→80). Fixed by applying only to the 3rd section onward via `:nth-of-type(n+3)`.
- **Regulatory map geodata preloads**: Added `<link rel="preload">` for 3 geodata JSON files (327 KB) so downloads start during HTML parsing instead of waiting for the D3 module to execute its top-level `await`.
- **Dashboard enhancements**: Added "Last 24 hours" and "Last 7 days" date ranges for commit-level tracking, commit SHA in chart tooltips, "Run Now" link to trigger workflow dispatch, favicon matching the GST site.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] `npm run lint` + `npm run lint:css` — clean
- [x] `npm run test:run` — 1034 tests pass
- [x] `npm run build` — successful
- [ ] After merge: run `gh workflow run perf-dashboard.yml` to verify dashboard updates (favicon, date ranges, tooltips)
- [ ] After merge: compare Lighthouse CI brand score in PR summary — should return to ~90+

🤖 Generated with [Claude Code](https://claude.com/claude-code)