### PR TITLE
fix(ci): revert Lighthouse to dev server for Vercel adapter compat

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -32,9 +32,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Build for production
-        run: npm run build
-
       # ── Desktop audit ──────────────────────────────────────
       - name: Run Lighthouse CI (desktop)
         continue-on-error: true

--- a/.github/workflows/perf-dashboard.yml
+++ b/.github/workflows/perf-dashboard.yml
@@ -31,9 +31,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Build for production
-        run: npm run build
-
       # ── Desktop audit ──────────────────────────────────────
       - name: Run Lighthouse CI (desktop)
         continue-on-error: true

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'npm run preview',
+      startServerCommand: 'npm run dev',
       startServerReadyPattern: 'localhost',
       startServerReadyTimeout: 30000,
       url: [

--- a/lighthouserc.mobile.cjs
+++ b/lighthouserc.mobile.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'npm run preview',
+      startServerCommand: 'npm run dev',
       startServerReadyPattern: 'localhost',
       startServerReadyTimeout: 30000,
       url: [


### PR DESCRIPTION
## Summary

- Reverts `startServerCommand` from `npm run preview` to `npm run dev` in both Lighthouse configs
- Removes unnecessary `npm run build` step from lighthouse.yml and perf-dashboard.yml
- `npm run preview` with `@astrojs/vercel` adapter returns 404 for all pages — the build output is Vercel-specific and can't be served locally

## Test plan

- [ ] CI passes
- [ ] Perf-dashboard workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)