### PR TITLE
fix(regulatory-map): eliminate CLS from timeline section

### DIFF
--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -1509,15 +1509,18 @@ import DeltaIcon from '../../../../components/DeltaIcon.astro';
 
     track.innerHTML = html;
 
-    // Position the Today marker over the correct year group
-    positionTodayMarker(track);
+    // Defer offset reads to next frame — lets the browser render the injected
+    // content within the reserved min-height before we force a reflow.
+    requestAnimationFrame(() => {
+      positionTodayMarker(track);
 
-    // Auto-scroll to "today" marker
-    const todayMarker = document.getElementById('timelineTodayMarker');
-    if (todayMarker) {
-      const scroll = document.getElementById('timelineScroll')!;
-      scroll.scrollLeft = todayMarker.offsetLeft - scroll.clientWidth / 3;
-    }
+      // Auto-scroll to "today" marker
+      const todayMarker = document.getElementById('timelineTodayMarker');
+      if (todayMarker) {
+        const scroll = document.getElementById('timelineScroll')!;
+        scroll.scrollLeft = todayMarker.offsetLeft - scroll.clientWidth / 3;
+      }
+    });
   }
 
   // Timeline click handler
@@ -1836,6 +1839,7 @@ import DeltaIcon from '../../../../components/DeltaIcon.astro';
   }
 
   .timeline-scroll {
+    min-height: 140px; /* Reserve space to prevent CLS when renderTimeline() injects content */
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 14px;


### PR DESCRIPTION
## Summary

- **Reserve timeline space** — add `min-height: 140px` to `.timeline-scroll` so the section doesn't grow from ~60px to ~180px when `renderTimeline()` injects content, preventing the FAQ section from shifting down
- **Defer offset reads** — wrap `positionTodayMarker()` and auto-scroll in `requestAnimationFrame` to let the browser render within the reserved space before forcing reflow

Addresses Vercel Speed Insights CLS of 0.38 (Poor) on `#timelineSection` — target is <0.1.

## Test plan

- [x] `npx astro check && npm run lint && npm run lint:css && npm run test:run` passes
- [ ] CI passes
- [ ] Visual: FAQ section doesn't jump when timeline renders
- [ ] Timeline horizontal scroll and Today marker positioning still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)