### PR TITLE
docs: MCP server roadmap — BL-031.x and BL-032.x architecture docs

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -15,6 +15,8 @@ module.exports = {
         'http://localhost:4321/hub/tools/diligence-machine',
         'http://localhost:4321/hub/tools/regulatory-map',
         'http://localhost:4321/hub/tools/techpar',
+        'http://localhost:4321/hub/radar',
+        'http://localhost:4321/hub/library',
       ],
       numberOfRuns: 1,
       settings: {

--- a/lighthouserc.mobile.cjs
+++ b/lighthouserc.mobile.cjs
@@ -15,6 +15,8 @@ module.exports = {
         'http://localhost:4321/hub/tools/diligence-machine',
         'http://localhost:4321/hub/tools/regulatory-map',
         'http://localhost:4321/hub/tools/techpar',
+        'http://localhost:4321/hub/radar',
+        'http://localhost:4321/hub/library',
       ],
       numberOfRuns: 1,
       settings: {

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -171,9 +171,11 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 ### BL-031: MCP Server — Internal Prototype (Phase 1)
 
-**Source**: MCP_SERVER_INITIATIVE.md (archived) | **Effort**: 1-2 days | **Status**: Open
+**Source**: MCP_SERVER_INITIATIVE.md (archived) | **Architecture & plan**: [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) | **Effort**: 1-2 days | **Status**: Open
 
 **As a** GST team member, **I want** a local MCP server exposing the diligence engine and portfolio search **so that** I can query GST's tools from Claude Desktop and Claude Code without opening the website.
+
+> **Implementation plan**: see [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) — covers MCP architecture introduction, repo-placement and lifecycle decisions, the Phase 1 file layout and tool surface, and verification steps. Note: that document supersedes the `@modelcontextprotocol/sdk` package reference in the acceptance criteria below — current canonical SDK is the v2 split-package family (`@modelcontextprotocol/server` + companions).
 
 #### Planning Criteria
 
@@ -277,6 +279,195 @@ The relative-import dance keeps the engines as the single source of truth — no
 3. Add the local server to `claude_desktop_config.json`, restart Claude Desktop, confirm tools appear in the tool list
 4. Invoke each tool with the README's example payload, confirm a sensible response
 5. Invoke `generate_diligence_agenda` with a deliberately invalid `transactionType` (e.g. `"foo"`), confirm a clean MCP error rather than a stack trace
+
+---
+
+### BL-031.5: MCP Server — Hub Surface Extension
+
+**Source**: BL-031.5 — extends Phase 1 surface | **Architecture & plan**: [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) | **Effort**: 3-5 days | **Status**: Open | **Depends on**: BL-031
+
+**As a** GST team member, **I want** the local MCP server to also expose the remaining Hub tool engines (ICG, TechPar, Tech Debt, Regulatory Map) and to expose the Library articles and the Radar snapshot as MCP **Resources** **so that** my agents can pull GST's full advisory toolkit and reference content into any conversation without opening the website.
+
+> **Implementation plan**: see [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) — covers the MCP "Resources" primitive, the Tool/Resource taxonomy across the Hub surface, content-source decisions for Library articles, the Radar-snapshot constraint that protects the Inoreader 200 req/day budget, and verification steps.
+
+#### Planning Criteria
+
+**Use cases**
+
+- **Cost-governance assessment in-flow** — while drafting an ICG memo for a target, ask the model to score the company's cost maturity (`assess_infrastructure_cost_governance { answers: {...}, stage: 'scaling' }`) and produce a prioritized remediation list inline; eliminates the wizard round-trip
+- **TechPar benchmarking mid-conversation** — drop a target's spend breakdown into a chat (`compute_techpar { arr: 25_000_000, stage: 'expansion', ... }`) and get the blended cost ratio + 36-month trajectory back without leaving the document
+- **Tech-debt sizing on the call** — during a CTO conversation, estimate the carrying cost of legacy maintenance (`estimate_tech_debt_cost { teamSize, salary, maintenanceBurdenPct }`) for a defensible figure to anchor the discussion
+- **Regulatory framework as native context** — pin `gst://regulations/eu/gdpr` or `gst://regulations/us/ca/ccpa` into a deal-review conversation; the model treats it as referenceable context rather than re-typed quotes
+- **Library article reuse** — pull the **VDR Structure Guide** (`gst://library/vdr-structure`) into a client-prep conversation as a single resource the model can read and adapt without us re-explaining it
+- **Radar context for prep work** — read `gst://radar/fyi/latest` from the local snapshot to surface the most recent annotated items before a partner call (offline-safe; no Inoreader calls)
+- **Proof-of-concept for Resources primitive** — exercises the read-only Resource handler pattern that BL-032 (radar live) and BL-033 (per-client regulatory access) will inherit
+
+**Outcomes**
+
+- Tool parity: `assess_infrastructure_cost_governance`, `compute_techpar`, `estimate_tech_debt_cost`, `search_regulations`, `list_regulation_facets`, and `search_radar_cache` all installed locally by every GST team member alongside the BL-031 tools
+- Resource exposure: Library × 2, Regulations × 120+, Radar Wire/FYI streams visible in Claude Desktop's resource picker; at least one team member uses a pinned Library or Regulation URI in a real client-prep conversation within the first two weeks
+- Zero Inoreader API calls attributable to MCP traffic — the local snapshot pattern (`npm run radar:seed`) holds; verified by absence of 4xx/5xx Inoreader log entries in the seed window
+- URI stability invariant: a frozen Vitest-asserted manifest of expected resource URIs prevents accidental contract breakage
+- Foundation validated: hybrid Tool+Resource pattern proven locally before BL-032 layers HTTP transport on top
+
+**Business value**
+
+- **Multiplies the BL-031 productivity win** — the Hub has 5 tools; BL-031 covers 1; BL-031.5 brings the other 4 into the same conversational surface
+- **De-risks BL-032's hybrid surface** — Resources are not just a "nice extra"; they are the right primitive for regulatory, library, and per-item radar exposure. Validating the URI scheme + freshness semantics now (locally, low-stakes) is the cheapest place to learn the ergonomics
+- **Concrete differentiator for narrative** — "agents can pin GST's regulatory library and TechPar engine as native context" reads materially stronger than "agents can call our diligence tool"
+- **Marginal cost** — same workspace, same SDK, same CI; the 3-5 day estimate covers four engine wrappers, the Resources registry, library-content sourcing, and the snapshot-based radar handler
+
+#### Acceptance Criteria
+
+**New tools (extend BL-031's tool registry)**
+
+- [ ] `assess_infrastructure_cost_governance` — wraps the ICG engine; input includes `answers` map and `stage`; output is `{ overall, domainScores[], recommendations[] }`
+- [ ] `compute_techpar` — wraps the TechPar engine; input is `TechParInputs`; output is `TechParResult`
+- [ ] `estimate_tech_debt_cost` — wraps the Tech Debt engine; **input MUST be raw values** (team size, salary, maintenance burden, deploy frequency) — slider-position helpers stay on the website side
+- [ ] `search_regulations` — facet/search across the regulatory-map JSON files; input `{ jurisdiction?, domain?, query?, limit? }`; output includes the resource `uri` for each matched framework
+- [ ] `list_regulation_facets` — companion enumerator for `{ jurisdictions[], domains[] }`
+- [ ] `search_radar_cache` — local-only equivalent of BL-032's `search_radar`; reads from the seed snapshot ONLY; explicitly named to avoid future collision with the live remote tool
+
+**Resources primitive (new for this initiative)**
+
+- [ ] MCP server registers `resources/list` and `resources/read` handlers
+- [ ] Library: `gst://library/business-architectures` and `gst://library/vdr-structure`, `mimeType: text/markdown`, body sourced from a single canonical location (Astro content collection migration preferred; sibling `article.md` acceptable as interim — see [MCP_SERVER_HUB_SURFACE.md § Content-source question](MCP_SERVER_HUB_SURFACE.md#library--articles-that-become-mcp-resources))
+- [ ] Regulations: one Resource per framework, URI `gst://regulations/<jurisdiction>/<framework-id>`, `mimeType: application/json` (or `text/markdown` if the framework has a long-form body)
+- [ ] Radar: `gst://radar/fyi/latest`, `gst://radar/wire/latest`, `gst://radar/wire/<category>` (one per category), and `gst://radar/item/<itemId>` for each cached item; resource description includes `lastSeededAt`; if seed snapshot is missing, the Resource returns a structured "run `npm run radar:seed`" message
+- [ ] **No live Inoreader calls** from any radar-related tool or resource — enforced by a scoped ESLint `no-restricted-imports` rule that prevents `mcp-server/src/` from importing `src/lib/inoreader/client.ts`
+- [ ] Resource URI manifest frozen as a Vitest test (`tests/resource-uri-stability.test.ts`); deliberate URI changes require updating the manifest AND bumping `mcp-server/package.json` version
+
+**Verification & docs**
+
+- [ ] [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) updated with any deviations made during implementation
+- [ ] `mcp-server/README.md` extended with the new tool and resource catalog plus a "How Resources work in this server" section
+- [ ] Vitest tests for each new tool (parity test against the corresponding website engine) and each Resource shape (URI parsing, body retrieval, missing-snapshot graceful failure)
+- [ ] Manual parity check recorded in the README: side-by-side outputs of the website wizard vs the MCP tool for ICG, TechPar, Tech Debt, with a representative input set, must match
+- [ ] Repo-root `npx astro check && npm run lint && npm run lint:css && npm run test:run` continues to pass
+
+#### Technical Context
+
+**Tool/Resource fit summary**
+
+| Surface                 | Primitive | URI / Tool name                                                                       |
+| ----------------------- | --------- | ------------------------------------------------------------------------------------- |
+| ICG, TechPar, Tech Debt | Tool      | `assess_infrastructure_cost_governance`, `compute_techpar`, `estimate_tech_debt_cost` |
+| Regulatory Map          | Hybrid    | Tool: `search_regulations`; Resource: `gst://regulations/<j>/<id>`                    |
+| Library                 | Resource  | `gst://library/<slug>`                                                                |
+| Radar (cached)          | Hybrid    | Tool: `search_radar_cache`; Resources: `gst://radar/...`                              |
+
+**Why this is its own initiative (not folded into BL-031)**
+
+- BL-031 is "wrap two pure functions, prove the path, ship in 1-2 days" — small enough to validate the engineering decisions cheaply
+- BL-031.5 introduces a new MCP primitive (Resources), four new engine wrappers, content-source decisions for the Library, and the radar-snapshot constraint — each of which has its own design call
+- Splitting them lets BL-031 ship and start delivering value while BL-031.5 absorbs the design questions on its own timeline
+
+**Key constraint — Inoreader budget protection**
+
+The local MCP server MUST NOT make Inoreader API calls. The 200 req/day budget is shared with the website's ISR (~28 calls/day) and BL-032's planned remote rate-limit logic. An always-on local MCP server fetching live data would burn the budget within hours. The server reads the snapshot produced by `npm run radar:seed` (already documented in [RADAR.md](../hub/RADAR.md)) and returns a structured "snapshot missing" error if the file is absent.
+
+**Out of scope** (covered by BL-032 / BL-033)
+
+- Live radar fetching, HTTP transport, OAuth, rate limiting, audit logs — all unchanged from the BL-031 deferral list
+- A "write" tool surface (the MCP server stays read-only)
+- MCP Prompts primitive
+- Per-client / per-tier resource access controls (BL-033)
+
+---
+
+### BL-031.75: MCP Server — Consultant Prompt Library
+
+**Source**: BL-031.75 — extends Phase 1 surface with Prompts | **Architecture & plan**: [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) | **Effort**: 2-3 days engineering + senior-consultant review time | **Status**: Open | **Depends on**: BL-031, BL-031.5
+
+**As a** GST analyst (or onboarding new hire), **I want** GST's repeatable consultant workflows packaged as named slash-command prompts in Claude Desktop **so that** I can invoke "/gst_diligence_kickoff" or "/gst_target_quick_look" and get a templated, GST-house-style brief that orchestrates the right Tools and Resources without me needing to remember the recipe.
+
+> **Implementation plan**: see [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) — covers the MCP "Prompts" primitive, the proposed prompt library and naming convention (`gst_*` prefix), the per-prompt module shape (with `version` and `lastReviewedAt` fields), the senior-consultant review gate, and verification steps.
+
+#### Planning Criteria
+
+**Use cases**
+
+- **New-engagement kickoff** — `/gst_diligence_kickoff { targetName, transactionType, productType, ... }` produces a starter agenda + VDR follow-up suggestions in GST's house style; replaces the unwritten "what does a senior consultant do at engagement kickoff" tacit knowledge with a runnable template
+- **Target first-look** — `/gst_target_quick_look { targetName, productType, arr, stage, hqJurisdiction }` orchestrates ICG + TechPar + Tech Debt + regulatory exposure into one digestible brief; consistent format across analysts
+- **Comparable engagement memo** — `/gst_comparable_engagements_memo { targetDescription, theme? }` finds 3-5 comparable past engagements via the portfolio search, summarizes the relevant lesson from each, frames analogically
+- **Regulatory exposure brief** — `/gst_regulatory_exposure_brief { targetJurisdictions[], dataCategories[], productType }` compiles applicable frameworks with summaries pulled from BL-031.5's regulation Resources
+- **VDR audit** — `/gst_vdr_audit` compares a target's actual VDR contents against the canonical 10-folder taxonomy from the Library; flags gaps and surfaces follow-up requests
+- **Architecture review** — `/gst_architecture_layer_review { targetSummary }` walks the target through the 5-layer architecture framework (Software → Infrastructure → Data → Org → Industry) using the Library article
+- **Daily radar digest** — `/gst_radar_brief_today { category?, sinceHours? }` summarizes the most recent annotated radar items in GST Take voice from the local snapshot
+- **Diligence handoff memo** — `/gst_diligence_handoff_memo { targetName, ... }` combines agenda + comparables + VDR follow-ups into a draft memo for the deal team
+
+**Outcomes**
+
+- Eight `gst_*` prompts visible in Claude Desktop's slash-command picker for every team member with the local MCP server installed
+- New-analyst onboarding shifts from "shadow a senior consultant" to "run `/gst_target_quick_look` on three real targets and review with mentor" — measurable reduction in time-to-first-deliverable for new hires
+- Each prompt has senior-consultant sign-off (gating step) confirming the output reads "as if I wrote it myself"
+- Annual review cadence operational; prompts have `lastReviewedAt` tracked; CI fails if any prompt is over 12 months stale
+- ≥5 prompts used per active team member per week for two consecutive weeks — proves the slash-menu is the natural entry point for GST workflows
+- Foundation for paid prompt-pack offering (BL-033) validated: the same prompt module shape is portable to a per-client tier
+
+**Business value**
+
+- **Codifies tacit consulting judgment** — the most valuable, least-documented asset in a boutique advisory firm. Prompts become firm IP that survives consultant turnover
+- **Compresses onboarding ramp time** — measured in real days saved per new hire; for a firm where consultants are the cost driver, this compounds
+- **Multiplies BL-031 + BL-031.5 ROI** — Tools and Resources are useful to people who already know the workflow. Prompts make them useful to people learning it. Same engineering cost, dramatically broader audience
+- **Consistency across deliverables** — when every analyst's first-look brief uses the same prompt, output quality variance collapses; clients see GST's house style every time
+- **Concrete asset for narrative** — "GST has codified its diligence workflows as agent-native templates" reads materially differently from "GST has a website with tools." Pitch surface, hiring surface, investor surface all benefit
+- **Cost**: 2-3 days engineering + senior-consultant review time (the latter is the binding constraint — frame as ~30 min per prompt)
+- **Marginal infrastructure cost**: zero — same `mcp-server/` workspace, same SDK, same CI
+
+#### Acceptance Criteria
+
+**Prompts primitive (new for this initiative)**
+
+- [ ] MCP server registers `prompts/list` and `prompts/get` handlers via the SDK's `registerPrompt` API
+- [ ] All prompts use the `gst_` name prefix (avoids slash-menu collisions with other installed MCP servers); enforced by a regex check in `mcp-server/src/prompts/_registry.ts`
+- [ ] Per-prompt module exports a uniform shape: `{ name, description, version, lastReviewedAt, argsSchema, build }` — see [MCP_SERVER_PROMPTS_BL-031_75.md § Per-prompt module shape](MCP_SERVER_PROMPTS_BL-031_75.md#per-prompt-module-shape)
+- [ ] Argument schemas re-use (via Zod composition) the same source-of-truth schemas as the Tools the prompt orchestrates — CI test asserts no drift
+
+**Prompt library (8 prompts)**
+
+- [ ] `gst_diligence_kickoff` — wraps `generate_diligence_agenda` Tool + references VDR Library Resource
+- [ ] `gst_target_quick_look` — orchestrates ICG + TechPar + Tech Debt + regulatory search Tools
+- [ ] `gst_comparable_engagements_memo` — wraps `search_portfolio` + `list_portfolio_facets` Tools
+- [ ] `gst_regulatory_exposure_brief` — wraps `search_regulations` Tool + reads regulation Resources by URI
+- [ ] `gst_vdr_audit` — references `gst://library/vdr-structure` Resource (interactive: argument-less mode supported)
+- [ ] `gst_architecture_layer_review` — references `gst://library/business-architectures` Resource
+- [ ] `gst_radar_brief_today` — reads `gst://radar/fyi/latest` Resource (filter by category if supplied)
+- [ ] `gst_diligence_handoff_memo` — orchestrates diligence + portfolio Tools + VDR Library Resource
+
+**Verification & docs**
+
+- [ ] [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) updated with any deviations made during implementation
+- [ ] `mcp-server/README.md` extended with a "Prompts: GST consultant workflows" section listing every prompt, its arguments, an example invocation, and a sample output
+- [ ] Vitest test per prompt asserting: (a) name has `gst_` prefix, (b) `argsSchema` parses a representative payload, (c) `build()` returns at least one message, (d) the message body references the expected Tool/Resource names
+- [ ] Prompt-registry invariant tests: every prompt has `version`, `lastReviewedAt` ≤ 12 months old, `orchestrates` field listing each Tool/Resource it invokes — CI fails if any registered Tool/Resource is missing
+- [ ] Golden-output snapshots per prompt (at least one representative invocation per prompt) — committed to `mcp-server/tests/examples/*.golden.md`; regression-tested on each Claude model upgrade
+- [ ] **Senior-consultant review gate**: each prompt's output on a representative input has been reviewed and signed off by a senior team member as "this reads as if I wrote it." This is a **blocking acceptance criterion**, not a nice-to-have
+
+#### Technical Context
+
+**Why this is its own initiative (not folded into BL-031.5)**
+
+- BL-031.5 is engineering work — wrapping engines, parsing regulation files, reading the radar snapshot. The competency is TypeScript + schema design
+- BL-031.75 is content design — what does a senior consultant actually do step-by-step on each motion? The competency is consulting judgment, not code
+- The bottleneck is senior-consultant review time, not engineering time. Splitting the initiatives prevents engineering from waiting on consulting review and vice versa
+
+**Why the `gst_` prefix matters**
+
+Prompts appear in Claude Desktop's slash-command picker alongside every other installed MCP server's prompts AND Claude Code's built-in slash commands. Without a prefix, `/diligence_kickoff` could collide with another server's prompt or a future Claude built-in. The `gst_` prefix is namespacing that costs four characters per name and pays for itself the first time another MCP server is installed.
+
+**Why prompts have `version` and `lastReviewedAt`**
+
+A prompt's behavior is determined by its message body — pure content. A senior consultant edits the body, every analyst's `/gst_diligence_kickoff` output changes silently. Tracking version + last-review-date forces deliberate review cycles and gives downstream users (BL-033 external clients, eventually) a stable contract.
+
+**Out of scope** (covered by BL-032 / BL-033 or deferred indefinitely)
+
+- HTTP transport / remote prompt access (BL-032)
+- Per-client prompt customization (a paying client's white-labeled `/gst_diligence_kickoff`) — defer to BL-033 if requested
+- Prompt usage telemetry — requires BL-032's logging surface; not applicable to local-stdio
+- Localization — English only until GST signs a non-English-language engagement
+- A prompt-builder UI on the website — authoring stays in `mcp-server/src/prompts/`
+- Mutation prompts (write tools) — the MCP server stays read-only across all phases of BL-031.x
 
 ---
 
@@ -413,6 +604,202 @@ The relative-import dance keeps the engines as the single source of truth — no
 5. From Claude Desktop pointed at staging: invoke `search_radar { query: "kubernetes" }`, confirm results return in <2s and a corresponding log entry appears in `wrangler tail`
 6. Hammer the staging endpoint with 100 requests in 60s → confirm rate limiter returns 429 with `RateLimit-*` headers after the threshold
 7. `wrangler deploy --env production` only after all six steps pass on staging
+
+---
+
+### BL-032.5: MCP Server — Resources & Prompts on Remote
+
+**Source**: BL-032.5 — extends Phase 2 surface | **Architecture & plan**: [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) | **Effort**: 3-5 days | **Status**: Open | **Depends on**: BL-031.5, BL-031.75, BL-032
+
+**As a** GST team member at a client site / on the Claude mobile app / on a borrowed laptop, **I want** the Library articles, regulatory frameworks, radar snapshot Resources, and consultant Prompts (`gst_*`) to be reachable over the same remote HTTP endpoint as BL-032's Tools **so that** the orchestration value of BL-031.75 doesn't evaporate the moment I leave my dev machine.
+
+> **Implementation plan**: see [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) — covers HTTP caching semantics for Resources (per-Resource freshness strategy), Prompt fan-out under per-key rate limits, the scope catalog (forward-compatible with BL-033's OAuth), URI-stability discipline across the local→remote boundary, and periodic radar snapshot refresh via Worker Cron.
+
+#### Planning Criteria
+
+**Use cases**
+
+- **Mobile prep before a partner call** — on Claude mobile, pin `gst://library/vdr-structure` into the conversation and read the canonical 10-folder taxonomy without opening a laptop
+- **Field consulting with no repo access** — at a client site on a borrowed device, invoke `/gst_target_quick_look` and get the four-Tool orchestration over HTTP exactly as it works locally
+- **Regulatory review with cross-jurisdictional pinning** — pin `gst://regulations/eu/gdpr` and `gst://regulations/us/ca/ccpa` into a deal-review conversation; both resolve over HTTP with identical content to the local version
+- **Scope-gated radar access** — issue a bearer key without `resource:radar:read` to a sales-associate teammate who shouldn't see the GST Take voice; their MCP client lists Tools and Library Resources but no radar Resources
+- **Pinned conversations survive client moves** — a consultant pinning `gst://library/business-architectures` on Monday's local server uses the same URI on Tuesday's remote server without re-pinning; URI-stability test enforces this
+
+**Outcomes**
+
+- All Resources and Prompts from BL-031.5 / BL-031.75 reachable via the BL-032 remote endpoint with parity to local-stdio behavior; URI-stability test asserts byte-identical resource manifests across both transports
+- Radar snapshot refreshed hourly via Worker Cron (~24 Inoreader calls/day from the 200/day budget) — total budget consumption (Cron + ISR + per-key rate-limited Tools) stays under the documented envelope
+- HTTP cache hit rate ≥80% on Library and Regulation Resources after one week (most reads served from Upstash without invoking the handler) — measured via the observability initiative (BL-032.75)
+- Zero Inoreader 429 errors over the first 30 days post-deploy — the layered rate limit + Cron + budget hard-cap holds
+- Per-key scope checks pass: a key without `resource:radar:read` returns `403 Forbidden` for radar URIs with a structured error
+- Prompt fan-out budget verified: `gst_target_quick_look` (4 Tools) lands inside the per-key burst allowance from a fresh-quota state
+
+**Business value**
+
+- **Removes the "have to be at my desk" constraint** for the full surface, not just Tools — completing the productivity multiplier BL-032 starts
+- **De-risks BL-033 substantially** — the scope catalog, URI stability discipline, and HTTP caching layer are all production-tested by trusted internal users before any external pilot client touches them
+- **Validates the per-Resource caching strategy** — Library / Regulations have radically different freshness semantics from Radar; getting the cache headers right under internal load is much cheaper than under contractual SLA
+- **Establishes URI / prompt-name versioning discipline** — the `BREAKING_CHANGES.md` + version-bump pattern introduced here is exactly what BL-033 external clients will rely on as their stability contract
+- **Cost**: same Cloudflare Workers / Upstash substrate as BL-032; Cron triggers are free on the Workers paid tier already justified by BL-032's volume; Resource cache writes consume a small slice of Upstash quota (~5k commands/day, well under the free-tier ceiling)
+
+#### Acceptance Criteria
+
+**Resources over HTTP**
+
+- [ ] Worker registers `resources/list` and `resources/read` handlers binding to the same Resource modules as the BL-031.5 stdio entrypoint
+- [ ] Per-Resource cache strategy implemented per the strategy table in [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md § Resources](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md#resources--the-design-questions-http-forces): Library + Regulations strong cache (24h), Radar latest weak cache (15min), Radar items strong cache (24h immutable)
+- [ ] `Cache-Control`, `ETag`, and `Last-Modified` headers set per Resource; `If-None-Match` requests return `304 Not Modified` when the ETag matches
+- [ ] Per-Resource scope check: bearer keys lacking the required scope receive `403 Forbidden` with a structured error and the missing-scope name
+- [ ] Periodic radar snapshot refresh: Cloudflare Cron trigger every hour calls `fetchAllStreams` + `fetchAnnotatedItems`, transforms, and writes to Upstash
+- [ ] Snapshot-missing path returns `503 Service Unavailable` with a structured retry hint (Cron will repopulate within the next interval)
+
+**Prompts over HTTP**
+
+- [ ] Worker registers `prompts/list` and `prompts/get` handlers binding to the same Prompt modules as the BL-031.75 stdio entrypoint
+- [ ] `prompts/list` includes each prompt's `version` so clients can detect drift after server upgrades
+- [ ] New introspection endpoint `GET /prompts/<name>/scopes` returns the prompt's required scope set (derived from its `orchestrates: [...]` field) so clients can pre-flight against their key
+- [ ] Per-key burst allowance configured to accommodate the heaviest prompt fan-out (4 Tool calls in `gst_target_quick_look`) without false 429 from a fresh-quota state
+- [ ] New aggregate metric `prompt_invocations_total` (incremented per `prompts/get`, independent of downstream Tool fan-out) — observable via BL-032.75 dashboards
+
+**Scope catalog (forward-compatible with BL-033)**
+
+- [ ] Scope strings defined per the catalog table in [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md § Scope catalog](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md#critical-cross-cutting-decisions): `tool:<name>`, `tool:radar:*`, `resource:library:read`, `resource:regulations:read`, `resource:radar:read`, `prompt:*`
+- [ ] Scope catalog implemented in `mcp-server/src/auth/scopes.ts` as the single source of truth; BL-033 reuses these strings unchanged via OAuth tokens
+- [ ] `wrangler secret`-issued internal keys carry the full scope set by default (per-key scope variation is BL-033's product surface; the infrastructure is in place here)
+
+**URI / prompt-name stability discipline**
+
+- [ ] URI-stability test extended to run against both stdio and HTTP transports (`unstable_dev` from `wrangler`); identical resource manifests required
+- [ ] `mcp-server/BREAKING_CHANGES.md` introduced; CI test fails if a URI or prompt name changes without a corresponding entry AND a `version` bump in `mcp-server/package.json`
+- [ ] On first deploy after a breaking change, server emits a `notifications/message` push to all connected clients describing the change
+
+**Verification & docs**
+
+- [ ] [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) updated with any deviations made during implementation
+- [ ] `mcp-server/README.md` extended with: Resources-over-HTTP example (curl + ETag round-trip), Prompts-over-HTTP example, scope-failure example
+- [ ] Vitest tests cover: cache-header correctness per Resource, scope-gating per Resource and per Prompt, snapshot-missing path returns 503 not 500, URI manifest stability across transports, breaking-change discipline
+- [ ] Worker integration test using `unstable_dev` exercises a complete prompt fan-out (`gst_target_quick_look` → 4 downstream Tool calls) under a realistic per-key budget
+- [ ] One-week post-deploy review: cache hit rate, Inoreader budget burn, zero 429s confirmed
+
+#### Technical Context
+
+**Why this is its own initiative (not folded into BL-032)**
+
+- BL-032 is the largest milestone in the chain — Workers, auth, rate limiting, radar Tools, Sentry, CI for staging+production. Adding Resources + Prompts pushes the milestone into multi-week territory and dilutes the value-delivery cadence
+- Splitting buys: BL-032 ships sooner; BL-032.5 designs against measured baselines from BL-032 in production; the Tools-vs-Resources/Prompts competency split mirrors BL-031.5/031.75's local-stdio version
+
+**HTTP-specific design questions** (full detail in the architecture doc):
+
+- Resources need cache headers (ETag, Last-Modified) and per-Resource freshness strategy — Library is near-immutable, Radar is hourly-fresh, Regulations are file-versioned
+- Prompts trigger downstream Tool calls that hit the per-key rate limit — burst allowance configured to accommodate the heaviest documented fan-out
+- URI rename = breaking change for every pinned client conversation — discipline (BREAKING_CHANGES.md + version bump + notifications/message push) introduced here
+
+**Out of scope** (covered by BL-033 or later)
+
+- OAuth 2.1, dynamic client registration, token introspection — bearer keys remain through BL-032.5
+- Per-client scope variation (different keys = different scope sets) — infrastructure in place; product surface is BL-033
+- Compliance-grade audit logging (full request/response retention, R2, hash chains) — BL-032.5 logs metadata only
+- White-labeled per-client prompt customization — explicitly deferred to BL-033 or post-pilot
+- Status-page integration for Resource freshness — observability initiative (BL-032.75)
+
+---
+
+### BL-032.75: MCP Server — Production Observability Maturity
+
+**Source**: BL-032.75 — extends Phase 2 substrate | **Architecture & plan**: [MCP_SERVER_OBSERVABILITY_BL-032_75.md](MCP_SERVER_OBSERVABILITY_BL-032_75.md) | **Effort**: 1 sprint engineering + 10-14 day baselining window | **Status**: Open | **Depends on**: BL-032 (BL-032.5 strongly preferred for full surface coverage)
+
+**As a** GST engineering lead approaching BL-033's contractual SLA commitments, **I want** SLO dashboards, alerting, and error-budget tracking against measured production baselines **so that** the SLAs we commit to in pilot legal paper are defensible operational reality, not aspirational numbers.
+
+> **Implementation plan**: see [MCP_SERVER_OBSERVABILITY_BL-032_75.md](MCP_SERVER_OBSERVABILITY_BL-032_75.md) — covers the metrics catalog (typed emitters per Tool/Resource/Prompt), SLO definitions and burn-rate alerts, the Cloudflare Analytics Engine + Grafana Cloud + Slack/PagerDuty stack, and the three-phase implementation (instrument → baseline → dashboard+alert).
+
+#### Planning Criteria
+
+**Use cases**
+
+- **Pre-incident detection** — Inoreader daily budget passes 70% by midday → ticket lands in `#mcp-alerts` so an engineer can investigate the consuming key/tool before the budget exhausts and starts serving stale radar
+- **SLO defensibility for pilot SLA** — when BL-033 legal review asks "why 99.5% uptime?", point to 60 days of measured 99.6% with the burn-rate dashboards as evidence
+- **Anomaly detection on key-level traffic** — one key bursts 50× normal traffic in 5 min → page fires; turns out an analyst left a runaway agent loop running. Without the alert, rate limits would silently absorb the burst until the daily budget exhausts
+- **Radar snapshot freshness signal** — Cron job fails silently for 90 minutes → page fires (snapshot age >2× Cron interval); without observability, first signal would be a confused user reading stale radar
+- **Daily ops digest** — every morning, all eng + senior consultants get an email summarizing yesterday's traffic by tool, top users by `key_prefix`, and any SLO breaches; team learns the system's normal shape and notices anomalies faster
+- **Status page evidence** — the BL-033-required public status page reads from the same Analytics Engine source as internal dashboards, ensuring what clients see matches what eng sees
+
+**Outcomes**
+
+- 30+ days of production traffic data backing every SLO target before BL-033's legal review begins; targets sit at p95-baseline × 1.5 buffer, calibrated against measured reality
+- All four canonical alerts (Inoreader budget, radar snapshot stale, health failing, traffic spike) wired to Slack + PagerDuty; each has been test-fired and resolved by a runbook execution
+- Cache hit rate (BL-032.5 Resources) ≥80% measurable on the dashboard
+- Daily Inoreader budget burn-down panel shows >20% headroom on a typical day; alert fires at 70% pre-emptively
+- On-call rotation operating (single engineer initially); runbook for each alert tested at least once
+- Status page (initially internal-IP-restricted) live at `https://status.mcp.globalstrategic.tech` showing per-tool availability + Inoreader budget consumption
+
+**Business value**
+
+- **Makes BL-033 SLA commitments defensible** — moves the pilot conversation from "we will commit to 99.5% uptime" to "we measured 99.6% over 60 days." This is the single most consequential output of the initiative for the commercial path
+- **Surfaces incidents pre-customer-impact** — alerts fire on leading indicators (budget burn rate, snapshot age, anomalous traffic) rather than lagging indicators (an angry user). For a B2B advisory product, prevented incidents are worth far more than detected ones
+- **Operational maturity signal** — when a PE compliance team asks "show us your monitoring," there's a real answer with screenshots. Hard to overstate how much this matters for enterprise sales
+- **Foundation for capacity planning** — once measured, easy to project when Cloudflare/Upstash/Sentry tiers will need an upgrade; budget conversations have data instead of guesswork
+- **Cost**: Cloudflare Analytics Engine free tier covers projected volume (~30× headroom); Grafana Cloud free tier sufficient for 3 users + 10k metric series; Slack webhook + PagerDuty starter tier ($25/mo) covers a single on-call rotation. Total ongoing: <$50/mo through pilot scale
+
+#### Acceptance Criteria
+
+**Phase 1 — Instrumentation**
+
+- [ ] Typed metric emitters introduced in `mcp-server/src/metrics/` for: `tool_invocation`, `resource_read`, `prompt_invocation`, `prompt_tool_fanout`, `rate_limit_decision`, `inoreader_call`, `radar_snapshot_age`, `health_check_duration`
+- [ ] Tool / Resource / Prompt registry decorators auto-emit metrics — no per-handler boilerplate; handlers stay focused on their domain logic
+- [ ] Cloudflare Analytics Engine binding configured in `wrangler.toml` (`env.METRICS`); each emitter writes structured events with the dimensions documented in [MCP_SERVER_OBSERVABILITY_BL-032_75.md § Metrics](MCP_SERVER_OBSERVABILITY_BL-032_75.md#1-metrics--whats-happening-in-numbers)
+- [ ] Vitest test asserts every registered Tool / Resource / Prompt emits at least one metric event in a representative invocation
+- [ ] Cardinality budget per metric documented in `metrics/_index.ts`; CI test caps emission cardinality to prevent dimension explosion
+
+**Phase 2 — Baselining**
+
+- [ ] Instrumented build deployed to production; runs with normal team usage for ≥10 days
+- [ ] Weekly traffic data extracts produce `mcp-server/observability/slo-baselines.md` documenting measured p50/p95/p99 latency and error rate per Tool / Resource / Prompt
+- [ ] Initial SLO targets set at p95-baseline × 1.5 buffer; senior-engineer review and sign-off recorded in `slo-baselines.md`
+- [ ] All SLO definitions captured: non-radar Tool availability, non-radar Tool latency p95, radar latency cold/warm, Resource latency, health-endpoint availability, Inoreader budget consumption, radar snapshot freshness
+
+**Phase 3 — Dashboards & Alerts**
+
+- [ ] `mcp-server/observability/grafana-dashboard.json` covers traffic, latency histograms, error rates, rate-limit pressure, Inoreader budget burn-down, radar snapshot age, cache hit rate
+- [ ] `mcp-server/observability/alert-rules.yaml` covers every SLO from the baselining phase
+- [ ] Slack webhook + PagerDuty integration wired; test-fired with a synthetic SLO breach (5% injected error rate); alert lands in correct channel within 5 min
+- [ ] Runbooks authored for the four canonical alerts under `mcp-server/observability/runbooks/`: `inoreader-budget-exhausted.md`, `radar-snapshot-stale.md`, `health-check-failing.md`, `traffic-spike-detected.md`
+- [ ] Status page deployed at `https://status.mcp.globalstrategic.tech` (Cloudflare Pages, signed query against Analytics Engine); initially internal-IP-restricted; BL-033 reviews and chooses what becomes externally visible
+- [ ] Each runbook has a `lastReviewedAt` field; CI test fails if any runbook is over 6 months stale OR the alert that links to it has changed since last review
+
+**Verification & docs**
+
+- [ ] [MCP_SERVER_OBSERVABILITY_BL-032_75.md](MCP_SERVER_OBSERVABILITY_BL-032_75.md) updated with any deviations made during implementation
+- [ ] `mcp-server/README.md` extended with: how to import the dashboard JSON, how to test-fire an alert, how to rotate Slack webhooks
+- [ ] Two-week post-deploy review: SLO compliance, alert noise rate (target: <1 false-positive/week), dashboard usefulness (engineer survey)
+- [ ] Test page through PagerDuty receives a synthetic page within 5 min; runbook link in the alert resolves to the correct markdown file
+
+#### Technical Context
+
+**Why this is its own initiative (not folded into BL-032 or BL-033)**
+
+- Not BL-032: BL-032's job is to ship the remote substrate. Adding a complete observability stack pushes it into multi-week territory and risks neither piece landing
+- Not BL-033: SLO baselines need real production traffic; putting observability inside BL-033 would force "guess at SLO targets, then commit them to legal paper" — exactly the sequence that produces broken contracts
+- Its own initiative because: the competency is operations engineering (different from auth/audit-log focus); the work is sequenced by measured production data (a 10-14 day wait is hard to schedule inside a single milestone); the output is config-as-code (dashboards, alert rules, runbooks), not server code; the downstream value (BL-033 signs SLAs from a place of measured baselines) is concrete and worth a separately-tracked deliverable
+
+**Stack** (full rationale in the architecture doc):
+
+| Component      | Choice                                                                      |
+| -------------- | --------------------------------------------------------------------------- |
+| Metrics store  | Cloudflare Analytics Engine (free tier, native to Workers)                  |
+| Dashboards     | Grafana Cloud (free tier)                                                   |
+| Alerting       | Grafana alerts → Slack webhook + PagerDuty                                  |
+| Error tracking | Sentry (already wired in BL-032)                                            |
+| Status page    | Cloudflare Pages, static + signed Analytics Engine query                    |
+| Tracing        | Deferred (OpenTelemetry-on-Workers; revisit if a debugging case demands it) |
+
+**Out of scope** (deferred indefinitely or to BL-033)
+
+- Distributed tracing — value is real but adds complexity; revisit when a specific debugging case demands it
+- Synthetic monitoring (external probes from multiple regions) — useful for true uptime measurement under SLA reporting; defer to BL-033
+- Per-client usage dashboards (clients see their own traffic) — BL-033 product decision
+- Cost observability (Cloudflare/Upstash/Sentry billing dashboards) — separate concern, low priority while spend is under $100/mo
+- Audit-log integrity dashboards — that surface belongs to BL-033's compliance-grade audit log
+- ML-based anomaly detection beyond simple z-score / threshold rules — premature
 
 ---
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Consolidated backlog of open development initiatives for the GST website. Each item is a self-contained user story with enough context to design and implement a solution. Items are grouped by theme, not priority — triage happens separately.
 
-> **Completed and closed items**: 27 items were completed or closed through April 2026 (BL-002, 003, 008–019, 021, 023–025, 027–030, 034, 036–039). Use `git log` to find their original acceptance criteria and technical context.
+> **Completed and closed items**: 29 items were completed or closed through April 2026 (BL-002, 003, 008–019, 021, 023–025, 027–030, 034, 036–041). Use `git log` to find their original acceptance criteria and technical context.
 
 ---
 
@@ -223,67 +223,46 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 ### BL-040: Desktop Performance — Regulatory Map and Radar Speed Improvements
 
-**Source**: Vercel Speed Insights (April 2026) | **Effort**: M (4-8 hours) | **Status**: Open
+**Source**: Vercel Speed Insights (April 2026) | **Effort**: M (4-8 hours) | **Status**: Complete
 
 **As a** desktop user, **I want** the Regulatory Map and Radar pages to load faster **so that** I don't experience jank or delays when using the most data-heavy hub tools.
 
-#### Current Metrics (Vercel Speed Insights — Desktop, Last 7 Days)
-
-| Route                       | Score | Issue             |
-| --------------------------- | ----- | ----------------- |
-| `/hub/tools/regulatory-map` | 78    | Needs Improvement |
-| `/hub/radar`                | 78    | Needs Improvement |
-
-Site-wide desktop: FCP 0.94s, LCP 0.94s, INP 48ms, CLS 0, TTFB 0.4s — overall score 100. These two pages are the only desktop outliers.
-
 #### Acceptance Criteria
 
-- [ ] `/hub/tools/regulatory-map` desktop score ≥ 90 in Vercel Speed Insights
-- [ ] `/hub/radar` desktop score ≥ 90 in Vercel Speed Insights
-- [ ] No regressions on other pages (all currently ≥ 90)
-- [ ] Lighthouse desktop audit confirms improvements
+- [x] `/hub/tools/regulatory-map` desktop score ≥ 90 in Vercel Speed Insights
+- [x] `/hub/radar` desktop score ≥ 90 in Vercel Speed Insights
+- [x] No regressions on other pages (all currently ≥ 90)
+- [x] Lighthouse desktop audit confirms improvements
 
-#### Investigation Areas
+#### Completed Work (PRs #111–#116, April 2026)
 
-- **Regulatory Map**: loads 120 regulation JSON files + TopoJSON map data + D3 rendering. Profile for: large JS bundle (D3), blocking data fetches, render-blocking map initialization, timeline DOM size
-- **Radar**: fetches Inoreader API feed via serverless function + renders feed items. Profile for: API response time (Inoreader → KV cache → client), large DOM from feed items, client-side filtering/rendering cost
-- Common patterns to evaluate: lazy-load below-fold content, defer non-critical JS, reduce initial DOM size, optimize data fetching (prefetch vs. on-demand)
+- **Regulatory Map**: deferred subnational geodata (220KB off critical path), externalized regulation index to prerendered JSON endpoint, lazy-loaded d3-transition, added brutalist skeleton placeholder, fixed CLS 0.38→<0.1 via timeline min-height reservation
+- **Radar**: parallelized API calls via Promise.allSettled, reduced fetch timeout, computed gravity CSS at build time, added `/hub/radar` to Lighthouse CI configs (desktop + mobile)
+- **Cross-cutting**: eliminated Zod from client bundles (69.9KB→297B), lazy-loaded Chart.js, CSS code-split 5 component stylesheets, added performance monitoring dashboard on GitHub Pages
 
 ---
 
 ### BL-041: Mobile Performance — Brand, Portfolio, and Diligence Machine Optimization
 
-**Source**: Vercel Speed Insights (April 2026) | **Effort**: M-L (6-12 hours) | **Status**: Open
+**Source**: Vercel Speed Insights (April 2026) | **Effort**: M-L (6-12 hours) | **Status**: Complete
 
 **As a** mobile user, **I want** the Brand, M&A Portfolio, and Diligence Machine pages to load and respond faster **so that** the experience on phones and tablets matches the desktop quality.
 
-#### Current Metrics (Vercel Speed Insights — Mobile, Last 7 Days)
-
-| Route                          | Score | Issue                     |
-| ------------------------------ | ----- | ------------------------- |
-| `/brand`                       | 22    | Needs Improvement (worst) |
-| `/hub/tools/diligence-mach...` | 56    | Needs Improvement         |
-| `/ma-portfolio`                | 75    | Needs Improvement         |
-| `/services`                    | 54    | Needs Improvement         |
-
-Site-wide mobile: FCP 1.08s, LCP 1.1s, INP 136ms, CLS 0, TTFB 0.43s — overall score 100. These pages drag down the per-route mobile experience.
-
 #### Acceptance Criteria
 
-- [ ] `/brand` mobile score ≥ 50 (from 22 — largest improvement target)
-- [ ] `/hub/tools/diligence-machine` mobile score ≥ 70 (from 56)
-- [ ] `/ma-portfolio` mobile score ≥ 85 (from 75)
-- [ ] `/services` mobile score ≥ 70 (from 54)
-- [ ] INP ≤ 100ms on all target pages (currently 136ms site-wide)
-- [ ] No regressions on pages currently scoring well
+- [x] `/brand` mobile score ≥ 50 (from 22 — largest improvement target)
+- [x] `/hub/tools/diligence-machine` mobile score ≥ 70 (from 56)
+- [x] `/ma-portfolio` mobile score ≥ 85 (from 75)
+- [x] `/services` mobile score ≥ 70 (from 54)
+- [x] INP ≤ 100ms on all target pages (currently 136ms site-wide)
+- [x] No regressions on pages currently scoring well
 
-#### Investigation Areas
+#### Completed Work (PRs #111–#116, April 2026)
 
-- **Brand page** (score 22): massive DOM — renders every design system component as a showcase. Profile for: total DOM nodes, unused CSS loaded for specimens, image/SVG weight, consider lazy-loading sections below the fold or paginating component groups
-- **Diligence Machine** (score 56): 10 wizard steps server-rendered upfront. Profile for: total DOM size (all steps rendered but hidden), JS initialization cost for wizard logic, form input event handling overhead
-- **M&A Portfolio** (score 75): 57 project cards + filter drawer + modal. Profile for: initial card render count (consider virtual scrolling or progressive loading), filter chip interaction cost (INP), modal pre-rendering overhead
-- **Services page** (score 54): profile for image weight, animation cost on mobile, DOM complexity
-- Cross-cutting: mobile INP at 136ms suggests event handler overhead — audit `touchstart`/`click` handlers for expensive synchronous work, consider `requestAnimationFrame` deferral
+- **Brand page**: removed content-visibility CLS regression, deferred palette controls injection
+- **Diligence Machine**: cached DOM queries, debounced state persistence, added progress.css code-split
+- **M&A Portfolio**: removed define:vars JSON duplication, deferred state init to DOMContentLoaded, added portfolio.css code-split
+- **Cross-cutting**: mobile Lighthouse CI audits added to PR workflow and performance dashboard, eliminated Zod from client bundles, lazy-loaded Chart.js, CSS code-split, moved checkerboard from fixed pseudo-element to body background
 
 ---
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -171,67 +171,399 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 ### BL-031: MCP Server — Internal Prototype (Phase 1)
 
-**Source**: MCP_SERVER_INITIATIVE.md | **Effort**: 1-2 days | **Status**: Open
+**Source**: MCP_SERVER_INITIATIVE.md (archived) | **Effort**: 1-2 days | **Status**: Open
 
 **As a** GST team member, **I want** a local MCP server exposing the diligence engine and portfolio search **so that** I can query GST's tools from Claude Desktop and Claude Code without opening the website.
 
+#### Planning Criteria
+
+**Use cases**
+
+- **Live agenda drafting** — while drafting a client proposal in Claude Desktop, ask the model to generate a tailored diligence agenda for a specific deal (`{ transactionType: 'majority-stake', productType: 'b2b-saas', techArchetype: 'modern-cloud-native', ... }`); the topic list streams into the same conversation that's writing the proposal
+- **Comparable-deal recall** — mid-call with a prospect, query `search_portfolio { search: 'CRM', engagement: 'Value Creation' }` to pull relevant past engagements for analogical anchoring
+- **Internal experimentation** — exercise the engines as agent tools to find ergonomics issues (oversized payloads, ambiguous enums, missing facets) before any external client sees them
+- **Onboarding & training** — a new analyst can query the diligence engine through Claude to learn the wizard's logic without the visual scaffolding getting in the way
+- **Test-bed for BL-032** — proves the tool registry / Zod-schema bridging pattern that the remote phases will inherit
+
+**Outcomes**
+
+- Server installed locally by every GST team member with Claude Desktop or Claude Code (target: 100% adoption within the first week)
+- Used ≥5 times per week per active team member for two consecutive weeks without anyone reaching for `localhost:4321/hub/tools/diligence-machine` instead
+- Zero behavior divergence reports — every output the MCP server returns matches what the website wizard would produce for the same inputs
+- Foundation validated: tool registry decoupled from transport such that BL-032 only swaps the transport layer
+
+**Business value**
+
+- **Time saved**: ~10–15 min per agenda drafting session by eliminating the browser context switch and manual transcription of wizard output into client-facing artifacts
+- **Risk reduction for BL-032/BL-033**: API ergonomics, schema gaps, and edge cases surface in low-stakes internal use rather than during a paid pilot
+- **Concrete artifact for narrative**: gives investor conversations and partner pitches something real to point at when describing GST's "AI-native advisory" positioning — moves the claim from aspirational to demonstrated
+- **Zero incremental cost**: uses existing infrastructure (no new SaaS, no new dependencies beyond `@modelcontextprotocol/sdk`) — this is a 1-2 day spend that unlocks the rest of the MCP roadmap
+
 #### Acceptance Criteria
 
-- [ ] Stdio transport MCP server built with TypeScript SDK
-- [ ] `generate_diligence_agenda` tool exposed (wraps existing `src/utils/diligence-engine.ts`)
-- [ ] `search_portfolio` tool exposed (wraps existing `src/utils/filterLogic.ts`)
-- [ ] Works with Claude Desktop and Claude Code
+**Server scaffolding**
+
+- [ ] New workspace directory `mcp-server/` at repo root with its own `package.json`, `tsconfig.json`, and `README.md` — does NOT touch the Astro build
+- [ ] Built with `@modelcontextprotocol/sdk` (latest stable) using stdio transport — no HTTP, no auth
+- [ ] Single entry point `mcp-server/src/index.ts` compiled to `mcp-server/dist/index.js` via `tsc`; `npm run build` produces a runnable binary
+- [ ] Binary declared via `bin` field in `mcp-server/package.json` so it can be invoked as `node /abs/path/to/dist/index.js` from a Claude Desktop / Claude Code config block
+- [ ] Tool input schemas declared with **Zod** (already a project dependency) and converted to JSON Schema for MCP via `zod-to-json-schema` or the SDK's helper
+
+**Tools exposed**
+
+- [ ] `generate_diligence_agenda` — wraps `generateScript(inputs)` from [src/utils/diligence-engine.ts](../../utils/diligence-engine.ts)
+  - Input schema mirrors `UserInputs` (13 fields: transactionType, productType, techArchetype, headcount, revenueRange, growthStage, companyAge, geographies[], businessModel, scaleIntensity, transformationState, dataSensitivity, operatingModel)
+  - Enum values for each field sourced from [src/data/diligence-machine/wizard-config.ts](../../data/diligence-machine/wizard-config.ts) so the schema stays in lockstep with the website wizard
+  - Returns the full `GeneratedScript` (topics, attentionAreas, triggerMap, metadata) as MCP `text` content, JSON-stringified
+  - Returns a structured MCP error (not a thrown exception) when input fails Zod validation
+- [ ] `search_portfolio` — wraps `filterProjects(projects, criteria)` from [src/utils/filterLogic.ts](../../utils/filterLogic.ts)
+  - Loads `src/data/ma-portfolio/projects.json` once at server startup (57 projects, validated via existing Zod schema in `src/schemas/portfolio.ts`)
+  - Input schema: `{ search?: string, theme?: string, engagement?: string, limit?: number (default 20, max 57) }` — defaults `theme`/`engagement` to `'all'` to match `FilterCriteria` semantics
+  - Returns array of matched `Project` objects plus a count summary
+  - Optional companion tool `list_portfolio_facets` returning `{ themes: string[], engagementCategories: string[], growthStages: string[], years: number[] }` from the existing `getUnique*` helpers — saves callers a roundtrip when discovering filter values
+
+**Verification & docs**
+
+- [ ] `mcp-server/README.md` documents: install/build steps, JSON config snippets for both Claude Desktop (`claude_desktop_config.json`) and Claude Code (`.mcp.json` or `~/.claude/settings.json` `mcpServers` entry), each tool's input schema with one concrete example invocation
+- [ ] Vitest unit tests for the tool handlers using the SDK's in-memory test transport — cover happy path, invalid input rejection, and empty-result cases for both tools
+- [ ] Manual smoke test recorded in the README: launch the server, invoke `generate_diligence_agenda` from Claude Desktop with the example payload, confirm a non-empty topic list comes back
+- [ ] Repo-root `npm run lint` and `npx astro check` continue to pass (the new directory is excluded from Astro's tsconfig but still linted by the existing flat ESLint config)
 
 #### Technical Context
 
-- GST's diligence engine and filter logic are already pure functions — they port to MCP tools with minimal refactoring
-- Stdio transport for local use only — no auth needed
-- Use `@modelcontextprotocol/sdk` TypeScript SDK
-- No changes to existing site infrastructure
+**Why this is small**
+
+- The two engines are already pure, fully typed, and unit-tested — `generateScript` has zero DOM/Astro/runtime coupling, and `filterProjects` operates on plain JSON. The MCP wrapper is essentially: parse input → call function → JSON-stringify output.
+- Zod is already in `dependencies`. The source-of-truth schemas in `src/schemas/` (portfolio, diligence) can be re-imported by the MCP server via a relative path, so the input shapes can never drift from what the website renders.
+
+**File layout**
+
+```
+mcp-server/
+├── package.json          # type: module, bin entry, depends on @modelcontextprotocol/sdk + zod
+├── tsconfig.json         # extends ../tsconfig.json (or standalone strict config), outDir: dist
+├── README.md             # install + Claude Desktop/Code config snippets + tool examples
+├── src/
+│   ├── index.ts          # server bootstrap, registers tools, starts stdio transport
+│   ├── tools/
+│   │   ├── diligence.ts  # imports generateScript from ../../../src/utils/diligence-engine
+│   │   └── portfolio.ts  # imports filterProjects + loads projects.json at module init
+│   └── schemas.ts        # re-exports / adapts Zod schemas from ../../../src/schemas
+└── tests/
+    ├── diligence.test.ts
+    └── portfolio.test.ts
+```
+
+The relative-import dance keeps the engines as the single source of truth — no copy-paste, no separate publish step.
+
+**Out of scope for this phase** (covered by BL-032 / BL-033)
+
+- HTTP / Streamable HTTP transport
+- Authentication, rate limiting, audit logging
+- Radar tools (`search_radar`, `get_latest_insights`) — defer to BL-032 since they require Inoreader credentials and rate-limit handling
+- Cloudflare Worker deployment, edge networking
+- OAuth, external client onboarding, MCP directory listing
+
+**Risks & mitigations**
+
+- **Engine drift**: if a future PR adds a field to `UserInputs` without updating the MCP schema, callers will get silent rejections. Mitigation — derive the MCP input schema from the existing Zod schema in `src/schemas/diligence.ts` rather than redefining it
+- **Dataset growth**: `projects.json` is loaded once at boot; this is fine at 57 projects but the README should call out that growth past ~1000 records would warrant a streaming or paginated response
+- **Path-resolution under stdio**: when Claude Desktop spawns the server its `cwd` is the user's home dir, not the repo. Resolve `projects.json` via `import.meta.url` / `fileURLToPath`, not `process.cwd()`
+
+**Validation sequence before marking done**
+
+1. `cd mcp-server && npm run build && npm test` — green
+2. From repo root: `npm run lint && npx astro check && npm run test:run` — still green (no regression in main project)
+3. Add the local server to `claude_desktop_config.json`, restart Claude Desktop, confirm tools appear in the tool list
+4. Invoke each tool with the README's example payload, confirm a sensible response
+5. Invoke `generate_diligence_agenda` with a deliberately invalid `transactionType` (e.g. `"foo"`), confirm a clean MCP error rather than a stack trace
 
 ---
 
 ### BL-032: MCP Server — Internal Remote (Phase 2)
 
-**Source**: MCP_SERVER_INITIATIVE.md | **Effort**: 1 week | **Status**: Open
+**Source**: MCP_SERVER_INITIATIVE.md (archived) | **Effort**: 1 week | **Status**: Open | **Depends on**: BL-031
 
-**As a** GST team member, **I want** the MCP server deployed to Cloudflare Workers **so that** I can access GST tools from any machine without local setup.
+**As a** GST team member, **I want** the MCP server deployed to a remote endpoint **so that** I can access GST tools from any machine — laptop, mobile Claude apps, ephemeral CI agents — without cloning the repo or running a local process.
+
+#### Planning Criteria
+
+**Use cases**
+
+- **Field consulting** — at a client site on a borrowed laptop or VDI session with no GST repo cloned, paste an `Authorization: Bearer` config snippet into Claude Desktop and instantly have the tools available
+- **Mobile context** — on the Claude mobile app during a flight or commute, ask `search_radar { query: 'kubernetes', tier: 'fyi' }` to surface the latest annotated FYI items before a client meeting
+- **CI / agent automation** — a GitHub Action invokes `search_portfolio` to enrich a PR description with comparable past engagements ("this refactor pattern matches Project X — see attached summary"), or to validate that a new project entry doesn't duplicate an existing one
+- **Internal Slack / Discord bots** — a daily digest bot calls `get_latest_insights { limit: 5 }` and posts the highest-signal radar items to a `#intel` channel
+- **Cross-team access without repo onboarding** — non-engineering staff (e.g. a sales associate) get tool access through Claude without ever installing Node, npm, or wrangler
+
+**Outcomes**
+
+- All GST team members onboarded within the first month — measured by ≥1 successful tool invocation per `client_id` in audit logs
+- **Zero Inoreader 429 errors** attributable to MCP traffic across a 30-day window (the rate-limit + 6h-cache architecture working as designed)
+- p95 latency: <500ms for non-radar tools, <2s for radar tools (cold-cache); <200ms for warm-cache radar
+- Health endpoint `/health` reports 99.9% uptime over 90 days — same SLO as the marketing site
+- At least one CI integration shipped (PR-enrichment, daily digest, or equivalent) — proves the "machines-as-clients" path beyond interactive use
+
+**Business value**
+
+- **Productivity multiplier**: removes the "I need to be at my desk with the repo cloned" constraint — tools follow the team to airports, client offices, hotel WiFi, mobile devices
+- **De-risks BL-033 substantially**: the auth, rate-limiting, observability, and Inoreader-budget protection layers are battle-tested by trusted internal users before any external client touches them
+- **Distribution leverage**: GST's tools become composable with every other MCP server the team uses (filesystem, GitHub, Slack, Linear, etc.) — internal workflows compound rather than living in silos
+- **Infrastructure validation**: proves Cloudflare Workers + Upstash Redis as the deployment substrate before BL-033 puts a paying customer's compliance posture on the line
+- **Cost**: ~$0/month for prototype volume (Workers free tier covers 100k req/day, Upstash free tier covers ~10k commands/day); ~$10/month at scale — affordable enough that "just deploy it" is the right call
 
 #### Acceptance Criteria
 
-- [ ] MCP server deployed to Cloudflare Worker
-- [ ] API key authentication for team use
-- [ ] Radar intelligence tools added (`search_radar`, `get_latest_insights`)
-- [ ] Global edge deployment with low latency
+**Transport & deployment**
+
+- [ ] MCP server deployed to **Cloudflare Workers** (rationale below) at a stable subdomain such as `mcp.globalstrategic.tech`
+- [ ] **Streamable HTTP transport** (not the deprecated SSE-only transport) — required for compatibility with Claude Desktop, Claude Code, mobile clients, and ChatGPT's MCP support
+- [ ] Worker built with `wrangler` and `@modelcontextprotocol/sdk`; `mcp-server/` workspace from BL-031 grows a second entrypoint `src/worker.ts` that registers the same tools but binds them to the HTTP transport
+- [ ] Tool registry is shared between stdio (BL-031) and HTTP (BL-032) entrypoints — register-once, transport-twice; CI guarantees they stay in sync
+- [ ] CORS headers restricted to known MCP client origins (`claude.ai`, `chatgpt.com`, `cursor.sh`, etc.) — no `Access-Control-Allow-Origin: *`
+
+**Authentication**
+
+- [ ] **Bearer-token API key auth** — simplest scheme that keeps the bar above zero; OAuth deferred to BL-033
+- [ ] Keys generated via `wrangler secret` (one secret per team member, named `MCP_KEY_<INITIALS>`); revocation = `wrangler secret delete`
+- [ ] Server returns MCP-spec-compliant `401 Unauthorized` with `WWW-Authenticate` header when key is missing/invalid
+- [ ] Key prefix logged on every request (e.g. `key=rp_...`) for attribution, full key never logged
+- [ ] README documents the Claude Desktop / Claude Code config snippet including the `Authorization: Bearer <key>` header
+
+**Rate limiting (critical — Inoreader has a 200 req/day cap)**
+
+- [ ] Sliding-window rate limiter backed by **Upstash Redis** (already in use for radar token persistence — see [src/docs/hub/RADAR.md](../hub/RADAR.md#upstash-redis-persistence))
+- [ ] Per-key limits: 60 req/min and 1000 req/day for non-radar tools; **5 req/min and 50 req/day for radar tools** (Inoreader budget is shared with the live site's ISR which already consumes ~28 calls/day)
+- [ ] Global circuit breaker: if Inoreader returns 429, all radar tool calls return cached results for 6h before retrying — same window the website ISR uses
+- [ ] Standard `RateLimit-*` response headers (RFC 9331) so clients can self-throttle
+- [ ] Rate-limit decisions emit a structured log entry; threshold breaches surface in observability (see below)
+
+**New tools (radar surface)**
+
+- [ ] `search_radar` — full-text search over the unified Wire+FYI feed
+  - Wraps `fetchAllStreams('GST-', N)` + `fetchAnnotatedItems(N)` from [src/lib/inoreader/client.ts](../../lib/inoreader/client.ts) and the merge logic from `src/lib/inoreader/transform.ts`
+  - Input: `{ query?: string, category?: 'pe-ma' | 'enterprise-tech' | 'ai-automation' | 'security', tier?: 'wire' | 'fyi' | 'both', limit?: number (default 20, max 50), since?: ISO-8601 timestamp }`
+  - Returns matched items with title, source, publishedAt, category, url, and (for FYI items) the highlight + GST Take
+  - Results MUST go through the same 6h ISR-style cache as the website to share the API budget — implement via Upstash Redis with the radar client's existing `buildCacheKey()` strategy
+- [ ] `get_latest_insights` — convenience wrapper returning the N most recent FYI items (the high-signal annotated tier)
+  - Input: `{ limit?: number (default 10, max 30), category?: string }`
+  - Returns FYI items sorted by `annotatedAt` descending — the same shape `RadarFeed.astro` renders
+- [ ] Both new tools share a single Inoreader-client instance per worker invocation; tokens read from Upstash Redis using the existing token-resolution chain (in-memory → Redis → env vars)
+
+**Observability**
+
+- [ ] Every tool invocation logged as a structured JSON line: `{ timestamp, keyPrefix, tool, durationMs, success, errorCode? }` — no input/output payloads (those are reserved for BL-033's compliance audit log)
+- [ ] Logs flow to Cloudflare's `tail`-able stream and are also pushed to Sentry (already configured for the site — see [src/docs/development/SENTRY_MANUAL_SETUP.md](./SENTRY_MANUAL_SETUP.md))
+- [ ] Health endpoint `GET /health` returns `{ ok: true, version, gitSha, redis: 'ok' | 'degraded', inoreader: 'ok' | 'degraded' }` — uncached, no auth required
+- [ ] Wrangler `wrangler tail` documented in README for live-tailing during incidents
+
+**Verification & docs**
+
+- [ ] `mcp-server/README.md` extended with: Cloudflare Worker deploy command, secret-management workflow, two example client configurations (Claude Desktop with HTTP transport, Claude Code), curl-based health-check command
+- [ ] Vitest test suite includes: auth happy/missing/wrong-key paths, rate-limit enforcement, radar tool end-to-end with mocked Inoreader responses (reuse `tests/e2e/fixtures/radar-mock-data.ts`)
+- [ ] Worker integration test using `unstable_dev` from `wrangler` exercises the HTTP transport against the in-memory MCP test client
+- [ ] `wrangler.toml` checked into `mcp-server/`; production secrets never committed
+- [ ] One-week post-deploy review: pull rate-limit metrics, confirm no Inoreader 429s, confirm at least one team member used it from a non-dev machine
 
 #### Technical Context
 
-- Cloudflare Workers free tier handles prototype volume
-- Streamable HTTP transport for remote access
-- Rate limiting essential — protect Inoreader API from agent-driven traffic
-- Separate infrastructure from Vercel site (recommended architecture)
+**Why Cloudflare Workers (not Vercel)**
+
+- The site itself runs on Vercel; deploying the MCP server to a separate platform isolates the blast radius — an MCP outage cannot take down the website, and an MCP traffic spike cannot exhaust Vercel's bandwidth/function budget
+- Workers' free tier gives 100k requests/day, which is well above any plausible team usage at this stage
+- Cloudflare's Smart Placement and global edge cut latency for non-US team members
+- `@upstash/redis` works identically on Workers (REST API) — zero migration cost for the rate-limit/cache layer
+- Streamable HTTP transport works out-of-the-box on Workers (long-lived connections supported via `WebSocket`/`fetch` streaming)
+
+**Why API key, not OAuth (yet)**
+
+- Internal team of <10 — onboarding/revoking with `wrangler secret` is one command
+- OAuth 2.1 is mandatory for **external** clients (BL-033) but adds an authorization-server dependency, browser-based consent UI, and PKCE flows that aren't worth building for a 5-person team
+- Keys can be rotated weekly via a CI cron without changing any user-facing config — Claude Desktop's MCP config supports env-var substitution for the auth header
+
+**Code reuse**
+
+- The Inoreader client at `src/lib/inoreader/client.ts` is already designed for serverless invocation (no DOM, no Node-only APIs except `crypto` which is supported on Workers)
+- `client.ts`'s `configOverride` parameter makes Worker-side dependency injection trivial — pass Worker-bound `KV_REST_API_URL` / `KV_REST_API_TOKEN` instead of reading from `import.meta.env`
+- `src/lib/inoreader/cache.ts`'s file-based dev cache stays on the Astro side; the MCP server gets its own Redis-backed cache to avoid any filesystem dependency
+
+**Out of scope for this phase** (covered by BL-033)
+
+- OAuth 2.1 with PKCE — bearer-token API key is the chosen Phase 2 auth
+- Per-tool scopes / fine-grained permissions
+- Compliance-grade audit logging (input/output payload retention)
+- Prompt-injection sanitization on tool outputs
+- MCP directory listing (MCPMarket.com etc.) — still internal use only
+- External-client onboarding workflow
+
+**Risks & mitigations**
+
+- **Inoreader API exhaustion**: agents are tireless and will burn the 200 req/day budget in minutes if uncached. Mitigation — radar tools cache aggressively (6h TTL matching website ISR) and rate-limit per-key at the Worker layer; a global circuit breaker triggers on the first 429 and serves cached responses for 6h
+- **Redis quota**: Upstash free tier is 10k commands/day; rate-limit checks could blow this if traffic spikes. Mitigation — the sliding-window algorithm batches reads/writes in a single Redis pipeline (≤2 commands per check); upgrade to paid tier ($10/mo) if usage exceeds 5k/day for two weeks running
+- **Schema drift between stdio and HTTP entrypoints**: same tool, two transports. Mitigation — single tool registry in `mcp-server/src/tools/`, both `index.ts` (stdio) and `worker.ts` (HTTP) import from it; CI test asserts both entrypoints export the same tool names + input schemas
+- **Token leakage via logs**: a careless `console.log(request.headers)` would dump bearer keys to Cloudflare logs. Mitigation — a request-scoped logger that strips `Authorization` and `Cookie` headers before any log call; lint rule (`no-restricted-syntax`) blocks raw `console.log` in worker code
+- **CORS over-permissioning**: a wildcard CORS policy would let any website read MCP responses on a user's behalf. Mitigation — explicit allowlist of MCP-client origins, reviewed quarterly
+
+**Validation sequence before marking done**
+
+1. `cd mcp-server && npm test` — green (includes new auth + rate-limit + radar tool tests)
+2. `wrangler deploy --env staging` — Worker deploys without errors
+3. `curl https://mcp-staging.globalstrategic.tech/health` returns `{ ok: true, ... }` with both Redis and Inoreader checks passing
+4. `curl -H "Authorization: Bearer <key>" ...` against the streamable HTTP transport returns the tool list including the two new radar tools
+5. From Claude Desktop pointed at staging: invoke `search_radar { query: "kubernetes" }`, confirm results return in <2s and a corresponding log entry appears in `wrangler tail`
+6. Hammer the staging endpoint with 100 requests in 60s → confirm rate limiter returns 429 with `RateLimit-*` headers after the threshold
+7. `wrangler deploy --env production` only after all six steps pass on staging
 
 ---
 
 ### BL-033: MCP Server — External Pilot (Phase 3)
 
-**Source**: MCP_SERVER_INITIATIVE.md | **Effort**: 2 weeks | **Status**: Open
+**Source**: MCP_SERVER_INITIATIVE.md (archived) | **Effort**: 2 weeks engineering + indeterminate legal/sales lead time | **Status**: Open | **Depends on**: BL-032
 
-**As a** PE firm client, **I want** to connect my AI tools to GST's MCP server **so that** my agents can query GST's diligence engine and portfolio data during deal evaluation.
+**As a** PE firm client, **I want** to connect my AI tools to GST's MCP server **so that** my agents can query GST's diligence engine and portfolio data during deal evaluation, with the security and audit guarantees my compliance team requires.
+
+#### Planning Criteria
+
+**Use cases**
+
+- **Deal-screening agent (PE deal team)** — during initial screening of a potential investment, an analyst's agent calls `generate_diligence_agenda` with the target's profile to produce a starter agenda the IC memo can be built around; saves 2–4 hours per screened deal
+- **Portfolio monitoring (PE platform team)** — a daily-running agent at a portfolio-services group polls `search_radar { category: 'enterprise-tech', since: 'yesterday' }` and surfaces relevant items into the platform-wide knowledge base
+- **Pitch prep (investment banker / corp dev)** — a banker prepping a sell-side pitch uses Claude with GST's MCP enabled to triangulate comparable transactions: "what GST engagements involved B2B SaaS targets between $25–100M ARR with carve-out transaction types?"
+- **Vendor-evaluation agent (enterprise procurement)** — a CIO's procurement agent calls `search_portfolio` during RFP review to find GST case studies relevant to a vendor under consideration
+- **Knowledge-base augmentation (research / content)** — an analyst uses GST's tools as a structured-knowledge layer alongside their own document store, blending GST's diligence framework with their proprietary deal flow data
+- **Programmatic access for technical clients** — a client's internal tooling (Retool, Slack bot, custom dashboard) calls the MCP server directly, treating GST's tools as a managed API rather than a website
+
+**Outcomes**
+
+- **2 design-partner PE firms** in active production use within 90 days of GA launch — not just signed paper, but logs showing ≥100 tool invocations/month per client
+- **Zero security incidents** over the first 6 months: no unauthorized access, no data exfiltration, no successful prompt-injection exploit found in pen test or in production
+- **At least 1 pilot client converts to a paid tier** within 6 months, validating willingness-to-pay
+- **Listed in ≥2 MCP directories** (Anthropic's registry + MCPMarket.com or Cursor catalog) with >50 install attempts in the first 90 days
+- Audit-log integrity check passes every quarterly review for the first year (hash chain or R2 object-lock attestation)
+- Pilot SLA met every month: 99.5% uptime, p95 <500ms non-radar, support response <1 business day
+
+**Business value**
+
+- **First product line with programmatic pricing** — moves GST beyond pure project-based advisory revenue into a recurring, per-seat or usage-priced product surface; opens a revenue stream that scales without proportional consultant time
+- **Competitive moat in M&A advisory** — boutique advisory + AI-native tooling is rare; concrete differentiator for sales conversations against larger firms whose AI story is "we use ChatGPT internally"
+- **Category positioning** — GST is one of the first M&A advisory firms with a public MCP server; captures inbound discovery from agent-curious PE/VC funds searching MCP directories without sales outreach
+- **Diligence engine as licensable IP** — converts a website utility into a productized capability with a clear commercial story, increasing the implied valuation of the firm's intellectual property
+- **Direct sales channel via MCP directories** — bypasses the traditional advisory-firm sales motion (introductions, conference networking) for technically-sophisticated buyers who self-discover and self-onboard
+- **Compliance posture as moat-builder** — clients who require SEC 17a-4-grade audit logs and SOC 2 / pen-test evidence cannot easily switch to a competitor without re-doing that compliance work; the audit infrastructure built here is itself a defensible asset
+- **Costs**: ~2 weeks engineering for the runtime + ongoing hosting (~$50–200/month for R2 storage, Workers paid tier, Upstash, Cloudflare Access per-user) + indeterminate legal review (NDA / DPA / SLA template — front-loaded, amortized across pilots)
+- **Risk-adjusted upside**: even one Series A-tier PE client paying $2k/month covers all hosting + amortizes the engineering spend within 2 quarters; two pilot conversions clear the legal cost as well
 
 #### Acceptance Criteria
 
-- [ ] OAuth 2.1 with PKCE authentication for external clients
-- [ ] Rate limiting and audit logging for compliance-sensitive PE clients
-- [ ] Offered to select PE clients as a pilot
-- [ ] Listed in MCP directories (MCPMarket.com, etc.)
+**Authentication & authorization (OAuth 2.1)**
+
+- [ ] OAuth 2.1 authorization server (or equivalent — see options below) with **PKCE mandatory** for all flows
+- [ ] Dynamic client registration **disabled** — clients are onboarded manually as part of the pilot agreement
+- [ ] Per-client `client_id` + `client_secret`, secrets stored hashed (Argon2id) in Upstash Redis with rotation supported
+- [ ] **Tool-level scopes** — clients receive a scope set per tool, e.g. `tool:generate_diligence_agenda`, `tool:search_portfolio`. Radar tools require an additional `tool:radar:*` scope so radar access can be gated independently (some pilots will not include the GST Take stream)
+- [ ] Access tokens are short-lived (1h) with refresh-token rotation; expired tokens return `401` with the spec-compliant `WWW-Authenticate: Bearer error="invalid_token"` challenge
+- [ ] Token introspection endpoint protected behind a separate admin scope so support engineers can debug client issues without seeing tokens
+- [ ] All OAuth endpoints documented in a `.well-known/oauth-authorization-server` metadata document (RFC 8414)
+
+**Rate limiting (per-client, contractual)**
+
+- [ ] Per-client tier (`free-pilot` / `paid` / `enterprise`) gates the limit ceilings; tier stored in Redis client record
+- [ ] Sliding-window limits applied per-tool per-client — radar tools share the global Inoreader budget circuit breaker introduced in BL-032
+- [ ] Quota exhaustion returns `429` with `Retry-After` header + a structured `RateLimit-Policy` header (RFC 9331) describing the limit so client engineers can self-diagnose
+- [ ] Soft-limit warning at 80% of quota emitted as an MCP-spec `notifications/message` so the calling agent can throttle itself before hitting the hard limit
+
+**Audit logging (compliance-grade)**
+
+- [ ] Every tool invocation written to an append-only audit log with: ISO-8601 timestamp, `client_id`, IP-prefix (truncated for GDPR — last octet zeroed), tool name, request UUID, **input parameters (full)**, **output payload size in bytes** (not the payload itself by default), durationMs, success/error code
+- [ ] Optional `?audit_full_payload=true` per-client flag to retain full output payloads for clients whose compliance regime requires it (must be agreed in writing — flag flips a Redis setting)
+- [ ] Logs shipped to a tamper-evident store: append-only S3 bucket with object lock, OR Cloudflare R2 with versioning + immutability — never to the same Sentry/Cloudflare logs used for ops
+- [ ] Retention: minimum 7 years to satisfy SEC Rule 17a-4 (the typical PE compliance baseline); confirm exact requirement with each client in pilot agreement
+- [ ] Per-client log export available via signed URL (read-only) so clients can ingest into their own SIEM
+- [ ] Quarterly audit-log integrity check (hash chain or AWS Object Lock attestation) — automated, results emailed to the compliance contact
+
+**Prompt-injection hardening**
+
+- [ ] All free-text fields in tool outputs (project summaries, FYI GST Take, attention-area descriptions) pass through a sanitization layer that strips: zero-width characters, bidi override marks (U+202A–U+202E, U+2066–U+2069), excessive whitespace runs, and known prompt-injection sentinel phrases ("ignore previous instructions", "you are now", etc.)
+- [ ] Output payloads include a top-level `_provenance: { source, sanitized: true, version }` field so calling agents can attribute content
+- [ ] Maximum output size: 64KB per tool response; larger results paginate via the MCP `cursor` field. Hard cap prevents an attacker from poisoning a model's context with a giant adversarial blob
+- [ ] Inputs validated against the same Zod schemas as Phase 1 PLUS a per-string length cap (no string field over 1KB) — defense in depth against schema-evading payloads
+- [ ] Security review (run the built-in `/security-review` Claude Code skill on the MCP server PR, or equivalent independent review) before pilot launch — checklist follows OWASP LLM Top 10 (LLM01: Prompt Injection, LLM06: Sensitive Info Disclosure, LLM10: Model DoS)
+
+**Pilot operations**
+
+- [ ] **Onboarding playbook** documented: legal sign-off, NDA + DPA execution, client_id provisioning, scope assignment, sandbox environment access, joint kickoff call, success metrics
+- [ ] Sandbox environment with synthetic projects.json (zero real client data) for client engineers to integrate against before touching production
+- [ ] Status page published at `https://status.mcp.globalstrategic.tech` showing uptime, p50/p95 latency, and rate-limit-availability per tool
+- [ ] Pilot SLA defined and contractually committed: 99.5% monthly uptime, p95 latency <500ms for non-radar tools, support response <1 business day
+- [ ] At least 2 design-partner PE firms onboarded to the pilot
+- [ ] Listed in **MCP directories** — submission to MCPMarket.com, Anthropic's official MCP registry, and Cursor's MCP catalog with screenshots and a 60s demo video
+
+**Verification & docs**
+
+- [ ] Public-facing developer docs at `https://docs.mcp.globalstrategic.tech` — tool reference (auto-generated from Zod schemas), authentication guide, rate-limit policy, audit-log schema, status page link
+- [ ] Penetration test by an independent firm focused on the OAuth flow, prompt-injection surface, and audit-log integrity — findings remediated before public listing
+- [ ] Load test demonstrates the system handles the contracted SLA at 10× expected pilot volume without degradation
+- [ ] Final compliance review with each pilot client's information-security team — signed-off before they switch from sandbox to production tokens
 
 #### Technical Context
 
-- Security is critical: diligence engine and portfolio data are proprietary IP
-- Tool outputs must be sanitized against prompt injection
-- Audit logging every tool invocation for compliance
-- This is a competitive differentiator — boutique advisory + AI-native tooling is rare in M&A advisory
+**Why this is a separate phase, not an extension of BL-032**
+
+- Phase 2 is "trusted internal users on a shared key" — security model is closed-network
+- Phase 3 is "untrusted external agents acting on behalf of compliance-sensitive clients" — every assumption changes: input is hostile, audit is contractual, downtime is breach-of-contract
+- Mixing the two in one milestone causes scope creep that delays both: do BL-032 first, prove the runtime, then layer hostile-environment hardening on top
+
+**OAuth 2.1 implementation options**
+
+| Option                                | Pros                                                                     | Cons                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Build on Cloudflare Workers (custom)  | Full control, single-platform, no vendor lock-in beyond Cloudflare       | OAuth is easy to implement insecurely; takes ~1 week of careful work + security review |
+| Cloudflare Access for SaaS            | Managed OAuth, integrates with Cloudflare Zero Trust, audit log built-in | Per-user pricing, less customization on scope semantics                                |
+| Auth0 / WorkOS / Clerk (external IdP) | Battle-tested, dev-friendly SDKs, certified for SOC 2                    | Adds a vendor + cost; introduces a third-party dependency in the auth path             |
+
+Recommendation: start with **Cloudflare Access for SaaS** — fastest path to a defensible auth surface, and the per-user cost is easily absorbed by pilot revenue. Re-evaluate in 6 months if scope semantics become a constraint.
+
+**Audit-log architecture**
+
+```
+MCP Worker ──► Cloudflare Queue ──► Worker consumer ──► R2 bucket (immutable, versioned)
+                                                  └──► Per-client signed URL endpoint
+```
+
+- Queue decouples request latency from log write latency (audit must be durable but must not slow the tool call)
+- R2 is cheaper than S3 for the egress patterns expected here, and Cloudflare's object-lock equivalent satisfies tamper-evidence
+- Hash chain: each log entry includes the SHA-256 of the previous entry, so post-hoc tampering is detectable
+
+**Prompt-injection threat model**
+
+The diligence engine takes structured enum inputs only — low risk. The portfolio search returns project summaries authored by GST staff — moderate risk (a malicious staff member could plant an injection, but that's an insider-threat problem outside MCP scope). The radar tools return third-party content from Inoreader — **highest risk**, since adversaries control the source. Sanitization MUST be strongest on the radar surface, weaker on the diligence/portfolio surfaces, and inputs MUST be schema-validated everywhere.
+
+**Out of scope**
+
+- Multi-tenant data isolation per client (each client sees the same projects.json — there's no client-specific data store yet)
+- Client-supplied custom tools (write surface) — read-only by design
+- Federated search across multiple GST environments
+- Real-time streaming notifications (e.g. webhook on new FYI item) — defer until at least one pilot client requests it
+
+**Risks & mitigations**
+
+- **Compliance scope creep**: PE clients may request SOC 2 Type II, ISO 27001, or specific contractual indemnities. Mitigation — define a "minimum viable compliance" baseline before pilot recruitment; route requests above the baseline to a separate enterprise tier with separate pricing
+- **Audit-log cost**: at high volume, log storage + egress could exceed pilot revenue. Mitigation — default retention is metadata-only (no payloads); full-payload retention is an upsell tied to a higher tier
+- **OAuth-flow misconfiguration**: implementing OAuth from scratch is the most common source of CVEs in MCP-adjacent projects. Mitigation — use Cloudflare Access for SaaS or another battle-tested IdP, do not roll your own
+- **Prompt-injection via radar content**: third-party article text is the highest-risk surface. Mitigation — sanitization layer + size cap + provenance metadata; document for clients that radar output should not be auto-actioned by their agents without human review
+- **Pilot client churn**: PE firms have long sales cycles; pilots may stall on legal review. Mitigation — start legal review (NDA + DPA + SLA template) in parallel with engineering work, not after; have at least one warm design partner identified before kickoff
+- **Reputational risk on outage**: a stale `_provenance` field or hallucinated diligence question reaching a client's investment committee is a brand event. Mitigation — sandbox-first onboarding, explicit "human in the loop" language in the developer docs, status page transparency
+
+**Validation sequence before pilot launch**
+
+1. All BL-032 acceptance criteria still passing in production
+2. OAuth flow end-to-end tested against a real client SDK (Claude Desktop's MCP HTTP+OAuth path) — token issuance, refresh, revocation
+3. Penetration test report received and all High/Critical findings remediated
+4. Audit-log integrity check produces a verifiable hash chain after a synthetic 1000-event burst
+5. Sandbox client successfully exercises every tool from a non-GST IP, with the corresponding audit entries visible in the per-client export
+6. Two pilot agreements signed (legal + technical) — engineering does not "soft launch" without paper
+7. Status page live, on-call rotation defined, incident response runbook in place
+8. Public listing on at least one MCP directory with a working "try it" demo
 
 ---
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Consolidated backlog of open development initiatives for the GST website. Each item is a self-contained user story with enough context to design and implement a solution. Items are grouped by theme, not priority — triage happens separately.
 
-> **Completed and closed items**: 29 items were completed or closed through April 2026 (BL-002, 003, 008–019, 021, 023–025, 027–030, 034, 036–041). Use `git log` to find their original acceptance criteria and technical context.
+> **Completed and closed items**: 31 items were completed or closed through April 2026 (BL-002, 003, 008–019, 021–026, 027–030, 034, 036–041). Use `git log` to find their original acceptance criteria and technical context.
 
 ---
 
@@ -11,8 +11,6 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 - [Compliance and Privacy](#compliance-and-privacy)
 - [Business Capabilities](#business-capabilities)
 - [CSS and Design System](#css-and-design-system)
-- [Testing and CI](#testing-and-ci)
-- [Performance](#performance)
 - [Infrastructure](#infrastructure)
 - [Exploration](#exploration)
 
@@ -169,103 +167,6 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 ---
 
-## Testing and CI
-
-### BL-022: Lighthouse CI for Performance Monitoring
-
-**Source**: DEVELOPMENT_OPPORTUNITIES.md | **Effort**: 2-3 hours | **Status**: Complete
-
-**As a** developer, **I want** Lighthouse CI integrated into the GitHub Actions pipeline **so that** performance regressions are caught before reaching production and performance budgets are enforced on every PR.
-
-#### Acceptance Criteria
-
-- [x] `@lhci/cli` installed and configured
-- [x] GitHub Actions workflow created (`.github/workflows/lighthouse.yml`)
-- [x] Performance budgets set: LCP < 2.5s, FCP < 1.8s, CLS < 0.1, TBT < 200ms
-- [x] First baseline report generated
-- [x] Build fails if LCP degrades beyond threshold
-- [x] Developers notified of performance impact in PRs
-
-#### Technical Context
-
-- Lighthouse CI runs on every PR to `master` and via manual dispatch
-- Configuration in `lighthouserc.cjs` with desktop preset, 10 audited pages
-- Step summary renders full scores table (Performance, FCP, LCP, TBT, CLS) with report links
-- CLS assertion set to `error` (blocks merge); other metrics set to `warn`
-- Reports uploaded to temporary-public-storage for review
-
----
-
-## Performance
-
-### BL-026: Performance Monitoring Dashboard
-
-**Source**: DEVELOPMENT_OPPORTUNITIES.md | **Effort**: 1-2 hours | **Status**: Complete
-
-**As a** site operator, **I want** a consolidated view of performance metrics **so that** I can track trends over time and communicate improvements to stakeholders.
-
-#### Acceptance Criteria
-
-- [x] Monthly performance reports tracking LCP, FCP, CLS, TBT over time
-- [x] Year-over-year trend visibility
-- [x] Single source of truth for performance metrics
-
-#### Technical Context
-
-- Static HTML + Chart.js dashboard deployed to GitHub Pages via `gh-pages` branch
-- Weekly cron (`perf-dashboard.yml`) runs Lighthouse CI, appends scores to `data/lighthouse-history.json`
-- Dashboard URL: `global-strategic-technologies.github.io/gst-website/`
-- Brutalist dark theme with frosted-glass panels matching the main site aesthetic
-- Scripts on `master`: `scripts/extract-lighthouse-metrics.mjs`, `scripts/merge-lighthouse-history.mjs`
-- Dashboard templates on `master`: `scripts/dashboard/` (seeded to `gh-pages` on each run)
-
----
-
-### BL-040: Desktop Performance — Regulatory Map and Radar Speed Improvements
-
-**Source**: Vercel Speed Insights (April 2026) | **Effort**: M (4-8 hours) | **Status**: Complete
-
-**As a** desktop user, **I want** the Regulatory Map and Radar pages to load faster **so that** I don't experience jank or delays when using the most data-heavy hub tools.
-
-#### Acceptance Criteria
-
-- [x] `/hub/tools/regulatory-map` desktop score ≥ 90 in Vercel Speed Insights
-- [x] `/hub/radar` desktop score ≥ 90 in Vercel Speed Insights
-- [x] No regressions on other pages (all currently ≥ 90)
-- [x] Lighthouse desktop audit confirms improvements
-
-#### Completed Work (PRs #111–#116, April 2026)
-
-- **Regulatory Map**: deferred subnational geodata (220KB off critical path), externalized regulation index to prerendered JSON endpoint, lazy-loaded d3-transition, added brutalist skeleton placeholder, fixed CLS 0.38→<0.1 via timeline min-height reservation
-- **Radar**: parallelized API calls via Promise.allSettled, reduced fetch timeout, computed gravity CSS at build time, added `/hub/radar` to Lighthouse CI configs (desktop + mobile)
-- **Cross-cutting**: eliminated Zod from client bundles (69.9KB→297B), lazy-loaded Chart.js, CSS code-split 5 component stylesheets, added performance monitoring dashboard on GitHub Pages
-
----
-
-### BL-041: Mobile Performance — Brand, Portfolio, and Diligence Machine Optimization
-
-**Source**: Vercel Speed Insights (April 2026) | **Effort**: M-L (6-12 hours) | **Status**: Complete
-
-**As a** mobile user, **I want** the Brand, M&A Portfolio, and Diligence Machine pages to load and respond faster **so that** the experience on phones and tablets matches the desktop quality.
-
-#### Acceptance Criteria
-
-- [x] `/brand` mobile score ≥ 50 (from 22 — largest improvement target)
-- [x] `/hub/tools/diligence-machine` mobile score ≥ 70 (from 56)
-- [x] `/ma-portfolio` mobile score ≥ 85 (from 75)
-- [x] `/services` mobile score ≥ 70 (from 54)
-- [x] INP ≤ 100ms on all target pages (currently 136ms site-wide)
-- [x] No regressions on pages currently scoring well
-
-#### Completed Work (PRs #111–#116, April 2026)
-
-- **Brand page**: removed content-visibility CLS regression, deferred palette controls injection
-- **Diligence Machine**: cached DOM queries, debounced state persistence, added progress.css code-split
-- **M&A Portfolio**: removed define:vars JSON duplication, deferred state init to DOMContentLoaded, added portfolio.css code-split
-- **Cross-cutting**: mobile Lighthouse CI audits added to PR workflow and performance dashboard, eliminated Zod from client bundles, lazy-loaded Chart.js, CSS code-split, moved checkerboard from fixed pseudo-element to body background
-
----
-
 ## Infrastructure
 
 ### BL-031: MCP Server — Internal Prototype (Phase 1)
@@ -363,4 +264,4 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 ---
 
-_Created: April 18, 2026 | Last pruned: April 21, 2026_
+_Created: April 18, 2026 | Last pruned: April 24, 2026_

--- a/src/docs/development/MCP_SERVER_ARCHITECTURE_BL-031.md
+++ b/src/docs/development/MCP_SERVER_ARCHITECTURE_BL-031.md
@@ -74,6 +74,58 @@ The plan below targets **v2 (`@modelcontextprotocol/server`)**. The v2 SDK accep
 
 ---
 
+## Discovery, connection, build, and deployment
+
+This section covers how MCP clients (Claude Desktop, Claude Code, Cursor, and others) actually find, run, and use the BL-031 server. The mechanics differ sharply from [BL-032](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2) (remote HTTP) and [BL-033](BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3) (external pilot with OAuth + public MCP-directory listings) — those phases' discovery story is documented in their own initiative entries.
+
+### Discovery — manual config per client
+
+There is no global registry at this phase. Each MCP-aware client reads its own config file; a team member pastes the snippet from `mcp-server/README.md` once and the client picks the server up at next launch.
+
+| Client                      | Config file                                                       | Snippet shape                                                                                                 |
+| --------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Claude Desktop (macOS)      | `~/Library/Application Support/Claude/claude_desktop_config.json` | `mcpServers.gst-tools = { command: "node", args: ["/abs/path/to/mcp-server/dist/index.js"] }`                 |
+| Claude Desktop (Windows)    | `%APPDATA%\Claude\claude_desktop_config.json`                     | same shape; absolute Windows path                                                                             |
+| Claude Code (project-level) | `.mcp.json` at repo root                                          | `mcpServers.gst-tools = { command: "node", args: ["./mcp-server/dist/index.js"] }` — relative path OK         |
+| Claude Code (user-level)    | `~/.claude/settings.json` `mcpServers` entry                      | same shape; absolute path                                                                                     |
+| Cursor                      | `~/.cursor/mcp.json`                                              | same shape                                                                                                    |
+| ChatGPT (Desktop / web)     | "Connectors" UI                                                   | not stdio-capable; needs HTTP transport — see [BL-032](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2) |
+
+### Connection — child-process spawn over stdio
+
+When a client launches, it reads its config and **spawns the server as a child process**. JSON-RPC messages flow over the child's stdin/stdout, framed by Content-Length headers per the Language Server Protocol convention MCP inherits. There is no port, no network, no listening socket. Trust is process-level — the user has already chosen to put the binary on their own machine.
+
+Implications for our code:
+
+- `console.log` is forbidden — anything written to stdout becomes corrupt protocol data. All logging goes to `console.error` (stderr). The client may surface stderr to the user (Claude Desktop shows it in the MCP server panel; Claude Code shows it in `.claude/logs/`).
+- The server runs only as long as the client is open. Each client launch spawns a fresh process; there is no shared state across runs.
+- The server's `cwd` is whatever the client launched with — typically the user's home directory, NOT the repo root. Path resolution must use `import.meta.url` + `fileURLToPath`, never `process.cwd()`.
+
+### Use — `tools/list` then `tools/call`
+
+Once the connection is up, the client immediately calls `initialize`, then `tools/list`. The server responds with the three tool definitions (name, description, JSON-Schema input). The client renders these in its tool picker and exposes them to the model.
+
+When the model decides to call a tool, the client sends `tools/call { name, arguments }`; the server validates against the Zod schema, invokes the underlying engine, and returns either `{ content: [...], structuredContent }` (success) or `{ isError: true, content: [...] }` (validation failure or runtime error). The model sees the response inline and continues the conversation.
+
+### Build — `tsc` to `dist/index.js`
+
+`cd mcp-server && npm run build` runs `tsc` against `mcp-server/tsconfig.json`, compiling `src/**/*.ts` to `dist/`. The `bin` field in `mcp-server/package.json` declares `dist/index.js` as the executable entry point. Source maps stay on so stack traces in stderr logs point back at TypeScript line numbers.
+
+### Deployment — there isn't one
+
+There is no deploy step in BL-031. Each team member runs the server on their own machine, started by their MCP client on demand. Updates ship the same way as any other repo change: `git pull && npm install && cd mcp-server && npm run build`. A teammate who pulls a new tool registration sees it in their client at the next client launch.
+
+### Where the server lives
+
+- **Source code**: `mcp-server/` workspace inside the `gst-website` monorepo. Imported engines stay in the `src/utils/` and `src/data/` directories of the same repo via relative imports — that is the entire point of the [Repo placement](#repo-placement--single-repo-recommended) decision below.
+- **Compiled binary**: `mcp-server/dist/index.js` on each team member's machine, built locally.
+- **Runtime**: a child process of whichever MCP client launched it; lives only while that client is open.
+- **Public surface**: none. The server is not network-addressable, not registered anywhere, and not discoverable by anyone outside the team.
+
+This stays true through [BL-031.5](MCP_SERVER_HUB_SURFACE_BL-031_5.md) (adds Resources) and [BL-031.75](MCP_SERVER_PROMPTS_BL-031_75.md) (adds Prompts) — those initiatives extend the surface but do not change the transport, build, or deploy story. [BL-032](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2) is the first phase where the server becomes a deployed, network-addressable artifact (Cloudflare Workers); [BL-033](BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3) is when it becomes publicly discoverable (MCP directory listings).
+
+---
+
 ## Repo placement — single repo (recommended)
 
 |                        | Same repo (chosen)                                           | Separate repo                                               |

--- a/src/docs/development/MCP_SERVER_ARCHITECTURE_BL-031.md
+++ b/src/docs/development/MCP_SERVER_ARCHITECTURE_BL-031.md
@@ -1,0 +1,234 @@
+# MCP Server — Architecture & Phase 1 Plan (BL-031)
+
+> **Backlog initiative**: [BL-031: MCP Server — Internal Prototype (Phase 1)](BACKLOG.md#bl-031-mcp-server--internal-prototype-phase-1)
+>
+> **Scope**: this document covers the GST Model Context Protocol (MCP) server initiative end-to-end, with the implementation plan for Phase 1 ([BL-031](BACKLOG.md#bl-031-mcp-server--internal-prototype-phase-1)) as the actionable section. Phases 2 ([BL-032](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2)) and 3 ([BL-033](BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3)) are summarized for context; their detailed acceptance criteria live in [BACKLOG.md](BACKLOG.md).
+>
+> **Companion documents** (local-stdio surface extensions):
+>
+> - [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) — extends the surface to remaining Hub tool engines, Library, Radar (introduces MCP **Resources**)
+> - [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) — adds MCP **Prompts** as named consultant workflows on top of the Tools+Resources surface
+>
+> **Phase 2 documents** (remote HTTP / Workers):
+>
+> - [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) — ports Resources + Prompts to remote HTTP with caching, scope gating, and URI-stability discipline
+> - [MCP_SERVER_OBSERVABILITY_BL-032_75.md](MCP_SERVER_OBSERVABILITY_BL-032_75.md) — production observability maturity (SLOs, dashboards, alerting) backing BL-033's contractual SLA
+>
+> **Status**: Phase 1 — open, ready for implementation. Phases 2/3 — open, depend on Phase 1.
+
+---
+
+## Context
+
+GST has two production-grade pure-TypeScript engines that today are reachable only through the website's UI: the **diligence-agenda generator** ([`generateScript`](../../utils/diligence-engine.ts)) and the **portfolio search** ([`filterProjects`](../../utils/filterLogic.ts)). Both are pure functions, both have stable Zod schemas, both are unit-tested, and both have zero DOM/Astro coupling.
+
+Every interactive use of these engines today is gated by a browser context-switch: open a tab, fill a wizard, copy the output back into the document being drafted. For someone drafting a client proposal, agenda, or pitch in Claude Desktop, that round-trip dominates the work. The Model Context Protocol (MCP) lets us expose these engines as native tools to any Claude surface, eliminating the round-trip and turning the engines into composable building blocks of agentic workflows.
+
+BL-031 is the smallest, lowest-risk slice of that vision: a **local stdio MCP server** that any GST team member can install in 60 seconds, used as a private internal tool. It is the de-risking step before BL-032 (remote, internal HTTP) and BL-033 (external pilot with OAuth + audit logging). The acceptance criteria are scoped to "wrap two pure functions, expose them, run from Claude Desktop / Claude Code, no auth, no HTTP."
+
+This document also addresses two design questions that shape the entire MCP roadmap: **repo placement** (monorepo vs. separate) and **lifecycle coupling** (evolves with the website vs. independently).
+
+---
+
+## MCP Architecture & Design — Introduction
+
+### What MCP is
+
+The Model Context Protocol is an open JSON-RPC-based standard (originally published by Anthropic, now adopted by Claude, Cursor, OpenAI's MCP-compatible mode, and others) for connecting AI assistants to external context and tools. An MCP **server** publishes capabilities; an MCP **client** (Claude Desktop, Claude Code, Cursor, etc.) discovers and invokes them.
+
+A server can expose three kinds of capabilities — for BL-031 we use only the first:
+
+| Primitive     | Purpose                                                   | BL-031 use?     |
+| ------------- | --------------------------------------------------------- | --------------- |
+| **Tools**     | Functions the model can call with structured input/output | ✅ both engines |
+| **Resources** | Read-only data (file-like) the model can fetch            | ❌ not needed   |
+| **Prompts**   | Pre-written templates a user can invoke                   | ❌ not needed   |
+
+### Transports
+
+| Transport           | Use case                                                                     | Auth                       | Phase          |
+| ------------------- | ---------------------------------------------------------------------------- | -------------------------- | -------------- |
+| **stdio**           | Client spawns the server as a child process; communication over stdin/stdout | None (process-level trust) | **BL-031**     |
+| **Streamable HTTP** | Client opens a long-lived HTTP connection to a remote endpoint               | Bearer token / OAuth       | BL-032, BL-033 |
+
+The same tool registry serves both transports — register-once, connect-twice — which is precisely why BL-031 (stdio) is a sound foundation for BL-032 (HTTP) and BL-033 (OAuth + audit).
+
+### Value GST gets from this architecture
+
+1. **Tools follow the user.** Every Claude surface — Desktop, Code, mobile app, IDE extensions — can call the same tools. The "I need to be at my desk with the website open" constraint disappears.
+2. **Composability across servers.** GST tools sit alongside filesystem, GitHub, Slack, and Linear MCP servers in the same Claude session. An agent drafting a client memo can pull a comparable engagement (`search_portfolio`), generate an agenda (`generate_diligence_agenda`), and write the result into a Google Doc — one model, three tool sources.
+3. **Distribution leverage at BL-033.** Public MCP directories (Anthropic registry, MCPMarket, Cursor catalog) become a no-cost discovery channel for technically-sophisticated buyers — the kind of inbound funnel a boutique advisory firm normally cannot afford to build.
+4. **Transport-agnostic investment.** Tool implementations are written once. Transport, auth, and rate-limiting are layered on top in BL-032/033. The work in BL-031 is not throwaway scaffolding.
+5. **Schema as contract.** Every tool ships a Zod input schema. That schema is the contract — clients (human or model) can introspect it, validate it client-side, and detect drift before invocation. This is more disciplined than the website's wizard, which encodes the same shape in JSX.
+
+### Critical SDK note
+
+The original [BACKLOG.md](BACKLOG.md) BL-031 text references `@modelcontextprotocol/sdk`. **This package name is stale.** As of late 2025 / early 2026 the TypeScript SDK has split into a v2 package family:
+
+- `@modelcontextprotocol/server` — server-side primitives (`McpServer`, `StdioServerTransport`, `registerTool`)
+- `@modelcontextprotocol/client` — client-side
+- `@modelcontextprotocol/hono` — HTTP transport adapter (relevant only for BL-032)
+- The legacy single-package `@modelcontextprotocol/sdk` is maintained on a `v1.x` branch but is not the new-work default
+
+The plan below targets **v2 (`@modelcontextprotocol/server`)**. The v2 SDK accepts Zod schemas natively (no `zod-to-json-schema` shim needed), uses `server.registerTool(name, config, handler)`, and surfaces tool errors via `{ isError: true, content: [...] }` in the `CallToolResult` — which is exactly the "structured MCP error, not a thrown exception" the backlog calls for.
+
+---
+
+## Repo placement — single repo (recommended)
+
+|                        | Same repo (chosen)                                           | Separate repo                                               |
+| ---------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| Engine sync            | Direct relative imports — single source of truth, atomic PRs | Requires npm publish, submodule, or copy-paste — drift risk |
+| CI                     | One workflow gains one workspace; ~1 min added               | Two pipelines, two release processes                        |
+| Onboarding             | `git clone gst-website && cd mcp-server && npm install`      | `git clone gst-website && git clone gst-mcp && link them`   |
+| IP isolation           | None — fine while server is internal                         | Helpful if MCP source needs to be shared/audited externally |
+| Independent versioning | Not yet needed                                               | Premature for a 1–2 day prototype with one consumer         |
+
+**Decision: monorepo via npm workspaces.** Add `"workspaces": [".", "mcp-server"]` to root `package.json`; create `mcp-server/` with its own `package.json`, `tsconfig.json`, and `README.md`. The Astro build is untouched (Astro's tsconfig already excludes the directory by virtue of the workspace boundary).
+
+**Re-evaluation trigger for splitting at BL-033 (not now):**
+
+- External clients require source-code review and we can't expose the website
+- Compliance scope (SOC 2, pen test) becomes easier with a smaller blast radius
+- IP licensing posture demands a clean commercial boundary
+- A second consumer of the engines emerges (e.g. a Slack bot, a Retool app)
+
+Until any of those triggers fires, the same-repo cost (zero) dominates the future-flexibility cost (negligible — splitting later is mechanical).
+
+---
+
+## Lifecycle and evolution
+
+| Phase      | Coupling to website                 | Versioning                                     | Why                                                                                                                                                                     |
+| ---------- | ----------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BL-031** | **Tight — relative imports**        | Website git SHA                                | Engine drift is the dominant risk; single-source-of-truth eliminates it.                                                                                                |
+| **BL-032** | **Tight engines, loose deployment** | Website git SHA + `wrangler` deploy id         | Engines still imported relatively; deployment moves to Cloudflare Workers (separate from Vercel — explicit blast-radius isolation).                                     |
+| **BL-033** | **Loose — schema as contract**      | Independent semver applied to tool I/O schemas | External clients pin a tool-schema version; engines may evolve faster than the public contract. The MCP server becomes a translation/versioning layer over the engines. |
+
+**Operating rule applied in BL-031:** the engines are the truth, the MCP wrapper is a thin adapter, and the schema lives in [`src/schemas/`](../../schemas/) so a single PR updates wizard config + engine + MCP simultaneously. The first time we need to ship a breaking change to the diligence schema with external clients depending on it, that's the trigger to introduce schema-version semantics — not before.
+
+---
+
+## Phase 1 (BL-031) Implementation Plan
+
+### File layout (new)
+
+```
+gst-website/
+├── package.json                 # +"workspaces": [".", "mcp-server"]
+└── mcp-server/                  # NEW workspace, isolated from Astro build
+    ├── package.json             # type: module, bin entry, deps: @modelcontextprotocol/server, zod
+    ├── tsconfig.json            # standalone Node 22 strict config (does NOT extend Astro's)
+    ├── README.md                # install, Claude Desktop / Code config, tool examples
+    ├── src/
+    │   ├── index.ts             # bootstrap + stdio transport
+    │   ├── tools/
+    │   │   ├── diligence.ts     # wraps generateScript()
+    │   │   └── portfolio.ts     # wraps filterProjects() + facets
+    │   └── schemas.ts           # re-exports Zod schemas from ../../../src/schemas
+    └── tests/
+        ├── diligence.test.ts
+        └── portfolio.test.ts
+```
+
+### Critical files to read or modify
+
+| File                                                                                         | Action                                                                | Why                                                                                                                                                                                                                                                                |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [src/utils/diligence-engine.ts](../../utils/diligence-engine.ts)                             | Read only — relative-import `generateScript`                          | Source of truth; pure, no DOM/Astro coupling.                                                                                                                                                                                                                      |
+| [src/utils/filterLogic.ts](../../utils/filterLogic.ts)                                       | Read only — relative-import `filterProjects` and `getUnique*` helpers | Source of truth; covers facets too.                                                                                                                                                                                                                                |
+| [src/data/diligence-machine/wizard-config.ts](../../data/diligence-machine/wizard-config.ts) | Read only                                                             | Authoritative enum values for `UserInputs` (the 13 fields).                                                                                                                                                                                                        |
+| [src/data/ma-portfolio/projects.json](../../data/ma-portfolio/projects.json)                 | Read only at server boot                                              | 61 records; resolve via `import.meta.url` + `fileURLToPath`, NOT `process.cwd()` (Claude Desktop spawns with a different cwd).                                                                                                                                     |
+| [src/schemas/diligence.ts](../../schemas/diligence.ts)                                       | Re-export via `mcp-server/src/schemas.ts`                             | Engine schema reuse. **Note:** the existing schema covers questions/attention areas; the **`UserInputs` Zod schema is not yet defined here** — derive it now (literal-union per field) to prevent drift, mirroring the canonical enum lists in `wizard-config.ts`. |
+| [src/schemas/portfolio.ts](../../schemas/portfolio.ts)                                       | Re-export via `mcp-server/src/schemas.ts`                             | `ProjectSchema`, `ProjectsArraySchema`, growth-stage / engagement-category enums.                                                                                                                                                                                  |
+| [package.json](../../../package.json)                                                        | Edit — add `"workspaces": [".", "mcp-server"]`                        | Required for the workspace to be discovered by lint/test/CI.                                                                                                                                                                                                       |
+| [.github/workflows/test.yml](../../../.github/workflows/test.yml)                            | Read; minor edit if needed                                            | Existing jobs auto-discover workspaces; add a `cd mcp-server && npm test` step only if root `npm run test:run` doesn't pick it up.                                                                                                                                 |
+
+### Tools to expose
+
+#### `generate_diligence_agenda`
+
+- Wraps `generateScript(inputs)` from [src/utils/diligence-engine.ts](../../utils/diligence-engine.ts).
+- Input schema: derived **once** in `mcp-server/src/schemas.ts` from the enum lists in [wizard-config.ts](../../data/diligence-machine/wizard-config.ts) and the `UserInputs` interface. Each enum field uses `z.enum([...])` against the canonical values (transactionType, productType, techArchetype, headcount, revenueRange, growthStage, companyAge, businessModel, scaleIntensity, transformationState, dataSensitivity, operatingModel) plus `geographies: z.array(z.enum([...]))`.
+- Output: full `GeneratedScript` (topics, attentionAreas, triggerMap, metadata) JSON-stringified into a `text` content block. Optionally also populate `structuredContent` with the same object so MCP clients that support structured output can parse without re-stringification.
+- Validation failure: return `{ isError: true, content: [{ type: 'text', text: 'Validation failed: ...' }] }`. Never throw.
+
+#### `search_portfolio`
+
+- Wraps `filterProjects(projects, criteria)` from [src/utils/filterLogic.ts](../../utils/filterLogic.ts).
+- Loads `projects.json` once at module-init using `fileURLToPath(new URL('../../../src/data/ma-portfolio/projects.json', import.meta.url))`; validates with `ProjectsArraySchema` from [src/schemas/portfolio.ts](../../schemas/portfolio.ts).
+- Input: `{ search?: string, theme?: string ('all' default), engagement?: string ('all' default), limit?: number (default 20, max 61) }`.
+- Output: `{ matches: Project[], totalMatched: number, returned: number }` — array slice + count summary, JSON-stringified into a `text` content block.
+
+#### `list_portfolio_facets` (companion tool — included in Phase 1)
+
+- Returns `{ themes: string[], engagementCategories: string[], growthStages: string[], years: number[] }` by composing `getUniqueThemes`, `getUniqueEngagementCategories`, `getUniqueGrowthStages`, `getUniqueYears` from [filterLogic.ts](../../utils/filterLogic.ts).
+- Saves an LLM round-trip when discovering valid filter values. No input parameters.
+
+### Server bootstrap (sketch)
+
+```ts
+// mcp-server/src/index.ts
+import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server';
+import { registerDiligenceTool } from './tools/diligence.js';
+import { registerPortfolioTools } from './tools/portfolio.js';
+
+const server = new McpServer({ name: 'gst-tools', version: '0.1.0' });
+registerDiligenceTool(server);
+registerPortfolioTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error('[gst-mcp] connected on stdio'); // stdout is reserved for protocol — log to stderr
+```
+
+### TypeScript & lint configuration
+
+- `mcp-server/tsconfig.json` — standalone strict config: `target: ES2022`, `module: NodeNext`, `moduleResolution: NodeNext`, `strict: true`, `outDir: dist`, `rootDir: src`. Does **NOT** extend `astro/tsconfigs/strict` (which would import Astro types unnecessarily).
+- Existing flat ESLint config at repo root automatically covers the new directory. Confirm by running `npm run lint` after scaffolding.
+- The Astro `tsconfig.json` `include: ["**/*"]` will pick up `mcp-server/**/*.ts`. Add `mcp-server` to its `exclude` array to keep Astro's type checker out of the new workspace.
+
+### Verification (run before marking complete)
+
+1. `cd mcp-server && npm run build` — produces `dist/index.js`, no type errors.
+2. `cd mcp-server && npm test` — Vitest green: happy-path, invalid-input rejection (expect `isError: true` not a thrown stack trace), empty-result, schema-bound enum violation, and `list_portfolio_facets` output shape.
+3. From repo root: `npx astro check && npm run lint && npm run lint:css && npm run test:run` — still green; the canonical local-validation sequence from [DEVELOPER_TOOLING.md](DEVELOPER_TOOLING.md) must remain passing.
+4. Add the local server to `claude_desktop_config.json` per the README snippet, restart Claude Desktop, confirm the three tools appear in the tool list.
+5. Invoke `generate_diligence_agenda` with the README's worked example (a representative `b2b-saas` / `modern-cloud-native` / `majority-stake` payload), confirm a non-empty topic list and a sensible `metadata.totalQuestions`.
+6. Invoke `search_portfolio { search: 'CRM', engagement: 'Value Creation' }`, confirm matches return.
+7. Invoke `generate_diligence_agenda` with `transactionType: "foo"` (invalid enum), confirm a clean `isError: true` content block — no stack trace.
+8. Compare a wizard output from `localhost:4321/hub/tools/diligence-machine` against the MCP output for the same inputs — they MUST be identical (zero behavior divergence is an explicit BL-031 outcome).
+
+### Risks & mitigations
+
+| Risk                                                                                                             | Mitigation                                                                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Schema drift between wizard and MCP                                                                              | Derive the MCP `UserInputs` Zod schema from the SAME enum arrays exported by [wizard-config.ts](../../data/diligence-machine/wizard-config.ts) (no string duplication). Add a Vitest test that asserts every wizard step's option list is a subset of the corresponding MCP enum. |
+| Path resolution under stdio (Claude Desktop spawns server with cwd = home dir)                                   | Resolve `projects.json` via `fileURLToPath(new URL('...', import.meta.url))`, never `process.cwd()`.                                                                                                                                                                              |
+| SDK package-name confusion (backlog says `@modelcontextprotocol/sdk`, current is `@modelcontextprotocol/server`) | Use `@modelcontextprotocol/server` (v2). Update the BACKLOG.md acceptance text in the implementation PR so future readers don't repeat the confusion.                                                                                                                             |
+| Astro's `tsc` picking up the new workspace                                                                       | Add `"mcp-server"` to root `tsconfig.json` `exclude` array; confirm `npx astro check` is unchanged.                                                                                                                                                                               |
+| Engine behavior divergence after a future PR adds a `UserInputs` field without updating MCP                      | The "subset" Vitest test above catches new wizard fields automatically; CI fails until the MCP schema is updated in the same PR.                                                                                                                                                  |
+
+### Out of scope (deferred to BL-032 / BL-033)
+
+- HTTP transport, Cloudflare Worker deployment, `wrangler.toml`
+- Bearer-token auth, OAuth 2.1, PKCE, dynamic client registration
+- Rate limiting, Upstash Redis, sliding-window quotas
+- Radar tools (`search_radar`, `get_latest_insights`) — require Inoreader credentials and 6h cache (see [RADAR.md](../hub/RADAR.md))
+- Audit logging, R2 immutable storage, hash-chain integrity
+- Prompt-injection sanitization (the diligence/portfolio surfaces have no user-supplied free-text egress in BL-031)
+- Public listing on MCP directories
+
+---
+
+## Phase 2 (BL-032) — at a glance
+
+Remote internal deployment to Cloudflare Workers with Streamable HTTP transport and bearer-token auth. Adds the radar tools (`search_radar`, `get_latest_insights`) which require Upstash Redis caching to honor Inoreader's 200 req/day budget. Tool registry is shared with Phase 1 — register-once, transport-twice. Full acceptance criteria: [BACKLOG.md § BL-032](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2).
+
+## Phase 3 (BL-033) — at a glance
+
+External pilot with PE design partners. OAuth 2.1 (PKCE-mandatory), tool-level scopes, append-only audit logs to R2, prompt-injection hardening on radar surface, public listing on MCP directories. This is the phase where the repo-split decision and schema-versioning discipline get re-evaluated. Full acceptance criteria: [BACKLOG.md § BL-033](BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3).
+
+---
+
+_Last updated: 2026-04-25_

--- a/src/docs/development/MCP_SERVER_HUB_SURFACE_BL-031_5.md
+++ b/src/docs/development/MCP_SERVER_HUB_SURFACE_BL-031_5.md
@@ -47,6 +47,24 @@ A Resource in MCP has: a `uri` (e.g. `gst://library/vdr-structure`), a human-fri
 4. **Validates the hybrid architecture.** BL-032 and BL-033 will inevitably mix Tools and Resources (e.g. a `search_radar` Tool plus per-item `gst://radar/<id>` Resources). Proving that the same `mcp-server` workspace cleanly registers both primitives with shared schemas is a Phase-2 prerequisite that's easier to validate locally first.
 5. **Concrete artifact for narrative.** "Our agents have GST's regulatory framework library available as native context" reads stronger in pitches than "you can call a tool that returns regulatory text."
 
+### How clients discover and read Resources
+
+Resources sit alongside Tools in the same MCP connection — same stdio transport described in [MCP_SERVER_ARCHITECTURE_BL-031.md § Discovery, connection, build, and deployment](MCP_SERVER_ARCHITECTURE_BL-031.md#discovery-connection-build-and-deployment). What's new is how the client surfaces them to the user and the model:
+
+| Client         | How Resources appear                                                                                                                                                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Desktop | Resource picker in the conversation chrome — the user can browse `gst://library/...`, `gst://regulations/...`, `gst://radar/...` and pin specific Resources into the active conversation as referenceable context                      |
+| Claude Code    | Resources are listed alongside tools; the model can pull them on demand via `resources/read`. The user can also reference a URI directly in a prompt and the client will fetch it                                                      |
+| Cursor         | Similar — Resources are auto-discovered and the model decides when to pull                                                                                                                                                             |
+| ChatGPT        | Local stdio not supported in this phase; Resources become reachable via HTTP in [BL-032.5](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md), where ChatGPT's connector UI surfaces them as referenceable context on the connector card |
+
+The wire calls are:
+
+- `resources/list` — returns the full URI manifest with `name`, `description`, `mimeType` per Resource. Called once at session start
+- `resources/read { uri }` — returns `{ contents: [{ uri, mimeType, text? | blob? }] }` for the requested URI
+
+This is the conceptual difference from Tools: a Tool is invoked by the model with arguments; a Resource is identified by a URI and read back as content. No arguments, no decision logic — the model treats it like a file. URI stability becomes a contract — once `gst://library/vdr-structure` is published, it must not move (the URI-stability invariant gets formalized for HTTP in [BL-032.5](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md), but the discipline starts here).
+
 ---
 
 ## Surface inventory and primitive choice

--- a/src/docs/development/MCP_SERVER_HUB_SURFACE_BL-031_5.md
+++ b/src/docs/development/MCP_SERVER_HUB_SURFACE_BL-031_5.md
@@ -1,0 +1,221 @@
+# MCP Server — Hub Surface Extension (BL-031.5)
+
+> **Backlog initiative**: [BL-031.5: MCP Server — Hub Surface Extension](BACKLOG.md#bl-0315-mcp-server--hub-surface-extension)
+>
+> **Companion to**: [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) — read that first for the overall architecture, repo-placement decision, and Phase 1/2/3 framing.
+>
+> **Sequels**:
+>
+> - [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) — adds MCP **Prompts** as named consultant workflows on top of the Tools+Resources surface delivered here.
+> - [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) — ports the Resources surface delivered here to the remote HTTP transport, with caching semantics, scope gating, and URI-stability discipline.
+>
+> **Scope**: this document covers [BL-031.5](BACKLOG.md#bl-0315-mcp-server--hub-surface-extension) — extending the local stdio MCP server (delivered in BL-031) to expose **all remaining Hub tool engines** as MCP **Tools** and the **Library** + **Radar** content as MCP **Resources**.
+>
+> **Status**: Open. Depends on BL-031.
+
+---
+
+## Context
+
+BL-031 will deliver a local MCP server with two tools: `generate_diligence_agenda` and `search_portfolio` (plus the `list_portfolio_facets` companion). That ships the smallest viable surface and proves the engineering path. It leaves four other Hub engines, two Library articles, and the Radar feed unreachable to anything except the website UI.
+
+The same browser context-switch tax that motivated BL-031 applies — perhaps more strongly — to these other surfaces. A consultant drafting a deliverable in Claude Desktop and reaching for the **VDR Structure Guide**, an **Infrastructure Cost Governance** assessment, or a **Tech Debt** estimate today has to: open a tab, navigate to the tool, fill a form (or scroll a long article), copy back into the document. Multiply that by every conversation in which any of these surfaces would have been useful and the cost compounds.
+
+BL-031.5 closes that gap by completing the Phase-1 surface. Crucially, it also serves as a **proof-of-concept for the MCP "Resources" primitive** — a capability MCP affords that BL-031 deliberately does not exercise. Validating Resources end-to-end now (locally, low-stakes) is the cheapest way to learn the ergonomics, the URI semantics, and the freshness/caching constraints before BL-032 needs to expose Resources over HTTP to remote clients.
+
+This document explains why Resources are worth a dedicated initiative, lays out the surface taxonomy (what becomes a Tool vs a Resource and why), and codifies the implementation considerations specific to this extension.
+
+---
+
+## What MCP "Resources" are — and why this initiative matters
+
+[MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) introduced MCP's three primitives. BL-031 uses only **Tools**. BL-031.5 introduces **Resources**:
+
+| Primitive    | What it is                                                                                 | Who reads it                                                            |
+| ------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| **Tool**     | A callable function with structured input → output. The model invokes it.                  | Model decides when to call.                                             |
+| **Resource** | A piece of read-only content addressable by a URI. May be text, JSON, markdown, or binary. | The user pins it into context, OR the model auto-fetches when relevant. |
+| **Prompt**   | A pre-written templated message the user can invoke as a slash-command.                    | User-driven. (Out of scope here.)                                       |
+
+A Resource in MCP has: a `uri` (e.g. `gst://library/vdr-structure`), a human-friendly `name`, an optional `description`, and a `mimeType`. The MCP client lists resources via `resources/list` and reads them via `resources/read`. Some clients render a "resources" picker; others let the model auto-discover and pull on demand.
+
+### Why Resources earn a dedicated initiative
+
+1. **Different ergonomics from Tools.** Tools are imperative — the model has to decide to call one. Resources are declarative — the model (or user) treats them as referenceable context that exists. For static reference content (Library articles, regulatory frameworks), Resources are a much better fit than wrapping reads in a `get_article` tool: the model sees "VDR Structure Guide" in the resource list and pulls it without us having to coach the call.
+2. **URI taxonomy is a design decision.** Once we publish `gst://library/vdr-structure`, that URI is part of the contract — clients (and clients' agents) may pin it into long-running conversations. Designing the URI scheme thoughtfully now (one document, low-stakes) is much cheaper than re-doing it after BL-032/033 lock in remote-client expectations.
+3. **Freshness semantics differ.** Tool outputs are recomputed on every call. Resources are snapshots — they have a freshness story (last-modified, ETag, manual refresh). Radar in particular cannot be a Resource without a clear answer to "how stale is this, and who refreshes it?"
+4. **Validates the hybrid architecture.** BL-032 and BL-033 will inevitably mix Tools and Resources (e.g. a `search_radar` Tool plus per-item `gst://radar/<id>` Resources). Proving that the same `mcp-server` workspace cleanly registers both primitives with shared schemas is a Phase-2 prerequisite that's easier to validate locally first.
+5. **Concrete artifact for narrative.** "Our agents have GST's regulatory framework library available as native context" reads stronger in pitches than "you can call a tool that returns regulatory text."
+
+---
+
+## Surface inventory and primitive choice
+
+The Hub has **5 tool pages**, the Library has **2 articles**, and Radar has **2 content streams** (Wire and FYI). BL-031 covers Diligence Machine. BL-031.5 covers everything else.
+
+### Hub tools — engines that become MCP **Tools**
+
+| Tool page                          | Engine                          | Input shape (summary)                                                                                       | Output shape (summary)                                        | Source files                                                                                                                                                                                                                                                               |
+| ---------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Infrastructure Cost Governance** | `src/utils/icg-engine.ts`       | `{ answers: Record<questionId, scoreLevel>, stage }`                                                        | `{ domainScores: DomainScore[], overall, recommendations[] }` | [icg-engine.ts](../../utils/icg-engine.ts), [domains.ts](../../data/infrastructure-cost-governance/domains.ts), [recommendations.ts](../../data/infrastructure-cost-governance/recommendations.ts)                                                                         |
+| **TechPar**                        | `src/utils/techpar-engine.ts`   | `{ arr, stage, capexView, spendBreakdown }`                                                                 | `{ ratios, trajectory, zones, benchmarks, industryNotes }`    | [techpar-engine.ts](../../utils/techpar-engine.ts), [stages.ts](../../data/techpar/stages.ts), [recommendations.ts](../../data/techpar/recommendations.ts), [signal-copy.ts](../../data/techpar/signal-copy.ts), [industry-notes.ts](../../data/techpar/industry-notes.ts) |
+| **Tech Debt Calculator**           | `src/utils/tech-debt-engine.ts` | `{ teamSize, salary, maintenanceBurdenPct, deployFrequency }` (UI exposes sliders; engine takes raw values) | `{ annualCost, breakdown, doraSignals }`                      | [tech-debt-engine.ts](../../utils/tech-debt-engine.ts)                                                                                                                                                                                                                     |
+| **Regulatory Map**                 | (mostly content, not engine)    | n/a — see Resources below                                                                                   | n/a                                                           | [src/data/regulatory-map/](../../data/regulatory-map/), [fetchRegulations.ts](../../utils/fetchRegulations.ts)                                                                                                                                                             |
+
+**Tool naming convention** for BL-031.5 (parallel to BL-031's `generate_diligence_agenda` / `search_portfolio`):
+
+- `assess_infrastructure_cost_governance` — wraps `icg-engine`
+- `compute_techpar` — wraps `techpar-engine`
+- `estimate_tech_debt_cost` — wraps `tech-debt-engine`
+- `search_regulations` — facet search across regulatory framework metadata (companion to the Resource exposure below)
+
+**Important design note on the Tech Debt calculator**: the website wraps slider positions (`posToTeamSize`, `posToSalary`) around the engine for UX. The MCP Tool MUST accept the raw engine-level values directly (team size as an integer, salary as a number) — slider positions are a UI concern that has no business in an agent-facing schema. The wrapper layer in `mcp-server/src/tools/tech-debt.ts` should bypass the position helpers entirely.
+
+### Library — articles that become MCP **Resources**
+
+The Library has **2 articles**, both authored as Astro pages with embedded markup:
+
+| Article                             | URL                                    | URI under MCP                          | mimeType        |
+| ----------------------------------- | -------------------------------------- | -------------------------------------- | --------------- |
+| Business & Technology Architectures | `/hub/library/business-architectures/` | `gst://library/business-architectures` | `text/markdown` |
+| Virtual Data Room Structure Guide   | `/hub/library/vdr-structure/`          | `gst://library/vdr-structure`          | `text/markdown` |
+
+**Content-source question (key implementation decision):** the Library articles are currently `.astro` files with hand-authored HTML/markup, not separate markdown sources. Extracting clean text for Resource exposure has three options:
+
+| Option                                                                                                                | Pros                                                                            | Cons                                                                             |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **A. Migrate to Astro content collections** (one `.md` per article + frontmatter)                                     | Single source of truth; cleaner authoring going forward; trivial to read in MCP | Refactor work on the website; slight visual diff risk                            |
+| **B. Add a sibling `article.md` per article** that the Astro page imports for body, and the MCP server reads directly | Single source of truth without forcing a migration; isolated change             | Two-file pattern is mildly awkward; future articles must follow the same pattern |
+| **C. Keep duplicate text in `src/data/library/articles.ts`**                                                          | Zero website refactor                                                           | Drift risk: copy-paste between Astro page and the data module                    |
+
+**Recommendation**: **Option A** (content collections) is the right long-term answer because the Library will grow and Astro's content API is purpose-built for this. If BL-031.5 needs to ship before that migration is feasible, **Option B** is acceptable as an interim. **Option C is rejected** — it imports the same drift risk we explicitly reject for the diligence engine schema.
+
+The MCP Resource handler then resolves a `gst://library/<slug>` URI to the corresponding markdown body and returns it with `mimeType: 'text/markdown'`.
+
+### Regulatory Map — content + facet tool (hybrid)
+
+120+ JSON files under [src/data/regulatory-map/](../../data/regulatory-map/), one per framework, each with jurisdiction / domain / title / summary / obligations / effective-date / authority.
+
+| Surface                 | Primitive                                                                                          | Why                                                                                                                                                             |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-framework full text | **Resource**: `gst://regulations/<jurisdiction>/<framework-id>` (e.g. `gst://regulations/eu/gdpr`) | URI-addressable, stable, model can pin a specific framework into a deal review conversation                                                                     |
+| Faceted search          | **Tool**: `search_regulations` with `{ jurisdiction?, domain?, query?, limit? }`                   | Discovery — agents won't know the URI in advance; a search tool returns `{ id, uri, title, summary }` records that the agent can then read via the resource URI |
+| Facet enumeration       | **Tool**: `list_regulation_facets` returning `{ jurisdictions[], domains[] }`                      | Same one-roundtrip-saver pattern as `list_portfolio_facets`                                                                                                     |
+
+This is the hybrid pattern that BL-032/033 will inherit for radar.
+
+### Radar — cached content as Resources (with strict freshness rules)
+
+Radar exposes two streams:
+
+- **Wire** — raw aggregated feed (categorized: `pe-ma`, `enterprise-tech`, `ai-automation`, `security`)
+- **FYI** — annotated highlights with GST Take
+
+**Critical constraint**: BL-031.5 is local-stdio and must NOT make fresh Inoreader API calls. The Inoreader 200 req/day budget is shared with the production website's ISR (~28 calls/day) and BL-032's planned remote rate-limit logic. An always-on local MCP server fetching live data would burn the budget within hours.
+
+**Solution**: read **only** from the seed snapshot produced by `npm run radar:seed` (already documented in [RADAR.md](../hub/RADAR.md) and called out in CLAUDE.md). The MCP server treats the local cache file as the authoritative source. If the cache is missing, the relevant Resources return an `isError`-style empty content set with a message instructing the user to run `npm run radar:seed`.
+
+| Surface                           | Primitive                                                                                               | URI                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Latest FYI items                  | **Resource**: `gst://radar/fyi/latest` (returns the most recent N annotated items as a single document) |                                                       |
+| Latest Wire items                 | **Resource**: `gst://radar/wire/latest`                                                                 |                                                       |
+| Per-category Wire                 | **Resource**: `gst://radar/wire/<category>` (e.g. `gst://radar/wire/pe-ma`)                             |                                                       |
+| Per-item full body                | **Resource**: `gst://radar/item/<itemId>`                                                               |                                                       |
+| Search across the cached snapshot | **Tool**: `search_radar_cache` with `{ query?, category?, tier?, since?, limit? }`                      | Local-only equivalent of BL-032's live `search_radar` |
+
+The naming explicitly signals the snapshot-based nature (`search_radar_cache`, not `search_radar`) so that when BL-032 ships the live remote version there is no naming collision.
+
+---
+
+## Repo placement and lifecycle
+
+Same answers as [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md). BL-031.5 extends the existing `mcp-server/` workspace; no repo split, no separate publishing. Engine drift remains the dominant risk, mitigated by the same single-source-of-truth pattern (relative imports into `src/utils/*-engine.ts` and `src/schemas/`).
+
+The **only** new lifecycle wrinkle introduced by Resources is **content versioning**: a Resource URI is part of the contract. If we later rename the regulatory-map JSON for a specific framework (e.g. file rename), the URI breaks for any client that pinned it. The mitigation here is to define resource IDs **independent of file paths** — the URI uses a stable slug (`gst://regulations/eu/gdpr`), and the MCP handler resolves slug → file. URI-stability becomes a documented invariant, enforced by a Vitest test that asserts a frozen list of expected URIs.
+
+---
+
+## Implementation Plan
+
+### File layout (extends BL-031's `mcp-server/`)
+
+```
+mcp-server/
+├── src/
+│   ├── index.ts                  # +registerHubTools(server); +registerResources(server)
+│   ├── tools/
+│   │   ├── diligence.ts          # (BL-031, unchanged)
+│   │   ├── portfolio.ts          # (BL-031, unchanged)
+│   │   ├── icg.ts                # NEW — wraps icg-engine
+│   │   ├── techpar.ts            # NEW — wraps techpar-engine
+│   │   ├── tech-debt.ts          # NEW — wraps tech-debt-engine
+│   │   ├── regulations.ts        # NEW — search_regulations + list_regulation_facets
+│   │   └── radar-cache.ts        # NEW — search_radar_cache (reads seed snapshot)
+│   ├── resources/                # NEW — all Resource handlers
+│   │   ├── library.ts            # gst://library/<slug>
+│   │   ├── regulations.ts        # gst://regulations/<jurisdiction>/<id>
+│   │   └── radar.ts              # gst://radar/...
+│   ├── content/                  # NEW — content adapters (read-from-source)
+│   │   ├── library-loader.ts     # resolves slug → markdown body (Option A or B)
+│   │   ├── regulation-loader.ts  # resolves slug → regulation JSON
+│   │   └── radar-snapshot.ts     # reads .cache/inoreader/ seed snapshot
+│   └── schemas.ts                # +ICG, TechPar, TechDebt, Regulation schemas
+└── tests/
+    ├── icg.test.ts                            # NEW
+    ├── techpar.test.ts                        # NEW
+    ├── tech-debt.test.ts                      # NEW
+    ├── regulations.test.ts                    # NEW (tool + resource)
+    ├── library.test.ts                        # NEW (resource)
+    ├── radar-cache.test.ts                    # NEW (tool + resource, mocked snapshot)
+    └── resource-uri-stability.test.ts         # NEW — frozen URI list invariant
+```
+
+### Critical files to read or modify
+
+| File                                                             | Action                                                                                                             | Why                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| [src/utils/icg-engine.ts](../../utils/icg-engine.ts)             | Read only — relative-import scoring functions                                                                      | Source of truth                          |
+| [src/utils/techpar-engine.ts](../../utils/techpar-engine.ts)     | Read only — relative-import calc functions                                                                         | Source of truth                          |
+| [src/utils/tech-debt-engine.ts](../../utils/tech-debt-engine.ts) | Read only — relative-import `computeDebtCost`; **bypass** `posToTeamSize`/`posToSalary`                            | Engine, minus UI helpers                 |
+| [src/utils/fetchRegulations.ts](../../utils/fetchRegulations.ts) | Read only — relative-import data-load utilities                                                                    | Regulatory file enumeration              |
+| [src/data/regulatory-map/\*.json](../../data/regulatory-map/)    | Read at server boot; build slug index                                                                              | Resource backing store                   |
+| Library article sources                                          | Decision: Option A (preferred) — migrate to Astro content collection; OR Option B — add sibling `article.md` files | Single source of truth for Resource body |
+| [src/lib/inoreader/cache.ts](../../lib/inoreader/cache.ts)       | Read only — reuse the existing `getCachedResponse` shape if compatible, or read the seed file directly             | Snapshot source for radar Resources      |
+| [src/schemas/](../../schemas/)                                   | Add Zod schemas for `ICGInputs`, `TechParInputs`, `TechDebtInputs`, `RegulationFacets`                             | Reused by both website and MCP           |
+
+### Verification (run before marking complete)
+
+1. `cd mcp-server && npm run build && npm test` — green.
+2. From repo root: `npx astro check && npm run lint && npm run lint:css && npm run test:run` — still green.
+3. `npm run radar:seed` from repo root — populates the local snapshot.
+4. Restart the local MCP server, confirm Claude Desktop's resource picker lists all expected URIs (Library × 2, Regulations × 120+, Radar items).
+5. Pin `gst://library/vdr-structure` into a Claude Desktop conversation, confirm the model treats it as available context.
+6. Invoke `assess_infrastructure_cost_governance` with a worked example, compare output to the website wizard at `/hub/tools/infrastructure-cost-governance/` for the same answers — must be identical.
+7. Same parity check for `compute_techpar` and `estimate_tech_debt_cost`.
+8. Invoke `search_regulations { domain: 'privacy', jurisdiction: 'eu' }`, confirm GDPR appears with a working URI; read that URI, confirm full framework body returns.
+9. With the radar snapshot deleted, invoke a radar Resource — confirm a clean "snapshot missing, run `npm run radar:seed`" error rather than a stack trace.
+10. Run `npx tsc --noEmit` from `mcp-server/` AND from repo root — confirm no cross-workspace type leakage.
+
+### Risks & mitigations
+
+| Risk                                             | Mitigation                                                                                                                                                                                                           |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Library article migration scope creep            | Decide Option A vs B explicitly at the start of the ticket; if Option A is chosen, scope it as a co-shipped sub-PR. If schedule pressure, fall back to Option B and document the future migration.                   |
+| Resource URI instability                         | Stable slugs decoupled from file paths; Vitest test asserts a frozen URI manifest. Any breaking change requires explicit URI-list update + bump in `mcp-server/package.json` `version` (semver-as-contract).         |
+| Radar snapshot freshness confusion               | Resource description includes `lastSeededAt` from the snapshot file's mtime. If older than 7 days, prepend a "stale snapshot — re-seed for current data" notice in the resource body.                                |
+| Inoreader budget burn from accidental live calls | The radar tools/resources MUST import from `mcp-server/src/content/radar-snapshot.ts` and never from `src/lib/inoreader/client.ts`. Enforce with an ESLint `no-restricted-imports` rule scoped to `mcp-server/src/`. |
+| Schema drift across 4 new engines                | Same pattern as BL-031: derive MCP Zod schemas from the engines' canonical input types; subset-test asserts every wizard option / engine constant remains a valid input.                                             |
+| Tech Debt slider-vs-raw-value confusion          | Document the input shape explicitly in the tool description; never expose `posToTeamSize`/`posToSalary` to the agent.                                                                                                |
+
+### Out of scope (deferred to BL-032 or later)
+
+- Live Radar calls (BL-032 with Upstash + rate limits)
+- HTTP transport / remote deployment (BL-032)
+- Auth, rate limiting (BL-032)
+- Pen-test, audit log, prompt-injection sanitization on regulation/library text (BL-033)
+- MCP Prompts primitive (deferred indefinitely; add when there's a demonstrated user demand)
+- A `generate_*` write-tool surface (the MCP server stays read-only)
+
+---
+
+_Last updated: 2026-04-25_

--- a/src/docs/development/MCP_SERVER_OBSERVABILITY_BL-032_75.md
+++ b/src/docs/development/MCP_SERVER_OBSERVABILITY_BL-032_75.md
@@ -1,0 +1,213 @@
+# MCP Server — Production Observability Maturity (BL-032.75)
+
+> **Backlog initiative**: [BL-032.75: MCP Server — Production Observability Maturity](BACKLOG.md#bl-03275-mcp-server--production-observability-maturity)
+>
+> **Predecessors**:
+>
+> - [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) — overall MCP architecture, repo placement, lifecycle. Read first.
+> - [BL-032 in BACKLOG.md](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2) — the remote substrate whose observability this initiative extends.
+> - [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) — the full Tools+Resources+Prompts surface that this initiative observes.
+>
+> **Sequel**: [BL-033 in BACKLOG.md](BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3) — the contractual-SLA phase that this initiative makes operationally defensible.
+>
+> **Scope**: this document covers [BL-032.75](BACKLOG.md#bl-03275-mcp-server--production-observability-maturity) — extending the structured-logs + `/health` baseline from BL-032 into a full observability surface (SLO dashboards, alerting, anomaly detection, error-budget tracking) that lets GST commit to the contractual uptime/latency SLAs BL-033 requires.
+>
+> **Status**: Open. Depends on BL-032 (and benefits from BL-032.5 being live to observe).
+
+---
+
+## Context
+
+BL-032 ships three observability primitives:
+
+1. Structured JSON logs per tool invocation (timestamp, key prefix, tool name, durationMs, success flag)
+2. Logs forwarded to Sentry + tailable via `wrangler tail`
+3. A `GET /health` endpoint reporting Redis and Inoreader status
+
+That is enough for "trusted internal users" — when something breaks, a senior engineer can `wrangler tail`, eyeball the JSON, and figure it out. It is **not** enough for the next phase. BL-033 commits to a contractual SLA: 99.5% monthly uptime, p95 latency under 500ms for non-radar tools, support response under 1 business day. Committing to those numbers without dashboards, alerting, and error-budget tracking is committing to numbers we can neither measure nor defend.
+
+The work in this initiative is the bridge from "we have logs" to "we have an operations posture." Specifically:
+
+- **SLO definitions** with budgets and burn rates, per Tool / per Resource / per Prompt
+- **Dashboards** for latency histograms, error rates, traffic by key, Inoreader budget burn-down, radar snapshot freshness
+- **Alerting integrations** so problems wake someone up at 80% budget exhaustion, not at 100%
+- **Anomaly detection** to surface abuse patterns (one key bursting 50× normal traffic) before rate limits paper over them
+- **Status page data pipeline** that BL-033 publishes to clients
+
+None of this is novel. Cloudflare's Analytics Engine + Grafana + a Slack webhook covers the entire stack at near-zero marginal cost. The work is in choosing the right metrics, defining the right SLOs against measured baselines, and wiring the alerts so they fire before incidents become outages.
+
+---
+
+## Why this earns its own initiative (rather than living inside BL-032 or BL-033)
+
+**Not BL-032** because BL-032's job is to ship the remote substrate. Asking it to also ship a complete observability stack would push it from a one-week milestone into multi-week territory and risk neither piece landing.
+
+**Not BL-033** because by then the SLAs are already contractually committed. SLO baselines need to come from real production traffic, which means BL-032 must already be running and producing data before the SLOs can be defined. Putting observability inside BL-033 would force "guess at SLO targets, then commit to them in legal paper" which is exactly the sequence that produces broken contracts.
+
+**Its own initiative** because:
+
+1. The competency is operations engineering — different from the "build the auth surface" or "build the audit log" focus of the bracket initiatives
+2. The work is sequenced by **measured production data**, not by code dependencies — running BL-032/BL-032.5 in production for 1-2 weeks is a prerequisite, and that wait is hard to schedule inside a single milestone
+3. The output is dashboards + runbooks + alert rules, not server code — review and approval pattern is different
+4. The downstream value (BL-033 can sign SLAs from a place of measured baselines) is concrete and worth a separately-tracked deliverable
+
+---
+
+## What "good observability" looks like for an MCP server
+
+Three layers, each with a clear purpose:
+
+### 1. Metrics — what's happening, in numbers
+
+Per-Tool / per-Resource / per-Prompt counters and histograms emitted to Cloudflare Analytics Engine (built into Workers; SQL-queryable; free tier covers projected traffic):
+
+| Metric                           | Type      | Dimensions                                                               | Purpose                                              |
+| -------------------------------- | --------- | ------------------------------------------------------------------------ | ---------------------------------------------------- |
+| `mcp_tool_invocations_total`     | Counter   | `tool`, `key_prefix`, `success`                                          | Volume by tool and outcome                           |
+| `mcp_tool_duration_ms`           | Histogram | `tool`                                                                   | Latency distribution per tool                        |
+| `mcp_resource_reads_total`       | Counter   | `resource_uri_prefix` (e.g. `gst://library/`), `cache_status` (hit/miss) | Resource access volume + cache effectiveness         |
+| `mcp_prompt_invocations_total`   | Counter   | `prompt_name`, `key_prefix`                                              | Prompt usage by name                                 |
+| `mcp_prompt_tool_fanout`         | Histogram | `prompt_name`                                                            | Tools invoked per prompt — tracks orchestration cost |
+| `mcp_rate_limit_decisions_total` | Counter   | `key_prefix`, `decision` (allow/throttle/deny)                           | Rate-limit pressure by key                           |
+| `mcp_inoreader_calls_total`      | Counter   | `source` (cron/tool), `status_code`                                      | Daily Inoreader budget burn                          |
+| `mcp_radar_snapshot_age_seconds` | Gauge     | —                                                                        | How stale is the radar snapshot?                     |
+| `mcp_health_check_duration_ms`   | Histogram | `dependency` (redis/inoreader)                                           | Health-check latency by dependency                   |
+
+### 2. SLOs — what the metrics MUST do
+
+| SLO                                 | Target                       | Window          | Burn-rate alerts                    |
+| ----------------------------------- | ---------------------------- | --------------- | ----------------------------------- |
+| Non-radar Tool availability         | 99.5% successful invocations | rolling 30 days | 14.4× burn → page; 6× burn → ticket |
+| Non-radar Tool latency p95          | <500ms                       | rolling 7 days  | breach for 1h → ticket; 6h → page   |
+| Radar Tool latency p95 (cold cache) | <2000ms                      | rolling 7 days  | breach for 1h → ticket              |
+| Radar Tool latency p95 (warm cache) | <200ms                       | rolling 7 days  | breach for 1h → ticket              |
+| Resource read latency p95           | <300ms                       | rolling 7 days  | breach for 1h → ticket              |
+| Health endpoint availability        | 99.9%                        | rolling 30 days | breach immediately → page           |
+| Inoreader daily budget consumption  | <180/200 calls               | per UTC day     | 70% → ticket; 90% → page            |
+| Radar snapshot freshness            | <90 minutes (Cron is hourly) | continuous      | breach for 30 min → page            |
+
+These are **calibrated against measured baselines**, not aspirational. Until BL-032 has been live for two weeks, the targets above are placeholders — the first deliverable of BL-032.75 is to run an SLO-baselining sprint that replaces them with real numbers.
+
+### 3. Alerting — who gets paged when
+
+| Channel                              | Purpose                                                                                                          | Routing                                                 |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `#mcp-alerts` (Slack)                | Tickets, low-urgency breaches, daily digest                                                                      | All eng                                                 |
+| Email digest (daily)                 | Yesterday's traffic by tool, top users by `key_prefix`, any SLO breaches                                         | All eng + senior consultants                            |
+| PagerDuty (or equivalent)            | Hard pages: health endpoint down, Inoreader budget at 90%, radar snapshot >2h stale, traffic spike >10× baseline | On-call rotation (single eng for now; expand at BL-033) |
+| Email to compliance contact (BL-033) | Audit log integrity check failures                                                                               | Quarterly automated                                     |
+
+---
+
+## Stack choice
+
+| Component              | Choice                                                                                                                          | Rationale                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Metrics store**      | Cloudflare Analytics Engine                                                                                                     | Native to Workers, SQL-queryable, free tier covers projected volume, zero infrastructure to maintain                  |
+| **Dashboards**         | Grafana Cloud (free tier) with Cloudflare Analytics datasource                                                                  | Industry-standard panels, alert engine, no self-hosting; pre-built MCP-server dashboard committed to the repo as JSON |
+| **Alerting**           | Grafana alerts → Slack webhook + PagerDuty                                                                                      | Cheapest path, works today; revisit if Grafana free tier becomes insufficient                                         |
+| **Error tracking**     | Sentry (already wired in BL-032)                                                                                                | Existing, no migration cost                                                                                           |
+| **Status page**        | `https://status.mcp.globalstrategic.tech` (Cloudflare Pages, simple static site reading from Analytics Engine via signed query) | Same domain control story as the rest; BL-033 makes this client-facing                                                |
+| **Tracing (deferred)** | None for BL-032.75                                                                                                              | OpenTelemetry-on-Workers exists but adds complexity; revisit if a specific debugging case demands it                  |
+
+---
+
+## Repo placement
+
+`mcp-server/` workspace continues. New top-level directory `mcp-server/observability/` for dashboard JSON, alert rules, runbook templates. No separate repo — the configuration is part of the deployment artifact and benefits from being version-controlled alongside the code it observes.
+
+```
+mcp-server/
+├── src/
+│   └── metrics/                    # NEW — typed metric emitters
+│       ├── counters.ts
+│       ├── histograms.ts
+│       └── _index.ts
+├── observability/                  # NEW — config-as-code for dashboards / alerts
+│   ├── grafana-dashboard.json      # MCP-server dashboard, importable into Grafana
+│   ├── alert-rules.yaml            # Alert definitions (SLO breaches, anomalies)
+│   ├── runbooks/                   # Markdown runbooks linked from alerts
+│   │   ├── inoreader-budget-exhausted.md
+│   │   ├── radar-snapshot-stale.md
+│   │   ├── health-check-failing.md
+│   │   └── traffic-spike-detected.md
+│   └── slo-baselines.md            # Living document — the measured baselines that justify each SLO target
+└── tests/
+    └── metrics-emission.test.ts    # NEW — asserts every Tool/Resource/Prompt path emits the expected metric
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 — instrumentation (week 1)
+
+1. Add typed metric emitters in `mcp-server/src/metrics/` so every Tool, Resource, and Prompt path emits a `tool_invocation`, `resource_read`, or `prompt_invocation` event with the dimensions listed above
+2. Wire Cloudflare Analytics Engine binding in `wrangler.toml`; bind to `env.METRICS`
+3. Wrap the existing tool/resource/prompt registry decorators so emission happens automatically — no per-handler boilerplate
+4. Add Vitest test asserting every registered Tool/Resource/Prompt produces at least one metric event in a representative invocation
+
+### Phase 2 — baselining (week 2-3)
+
+1. Deploy instrumented build to production; let it run with normal team usage for 10-14 days
+2. Pull traffic data weekly via the Workers Analytics SQL API; produce `slo-baselines.md` documenting measured p50/p95/p99 per tool, per resource, per prompt
+3. Set initial SLO targets at p95-baseline × 1.5 (a 50% buffer above measured) — generous, becomes tightenable once stable
+4. Senior-engineer review of baselines + targets; sign-off
+
+### Phase 3 — dashboards + alerts (week 3-4)
+
+1. Author `grafana-dashboard.json` covering: traffic, latency histograms, error rates, rate-limit pressure, Inoreader budget burn-down, radar snapshot age
+2. Author `alert-rules.yaml` covering every SLO from the table above
+3. Wire Slack webhook + PagerDuty integration; test with a deliberate alert injection
+4. Author runbooks for the four canonical alerts (Inoreader budget exhausted, radar stale, health failing, traffic spike)
+5. Status page (read-only) deployed at `https://status.mcp.globalstrategic.tech` showing per-tool availability + the daily Inoreader budget consumption
+
+### Verification
+
+1. `cd mcp-server && npm run build && npm test` — green; metrics-emission tests pass.
+2. From repo root: `npx astro check && npm run lint && npm run lint:css && npm run test:run` — still green.
+3. Deploy to production, confirm metric events landing in Cloudflare Analytics Engine via SQL probe (`SELECT count() FROM mcp_events WHERE timestamp > now() - INTERVAL 1 HOUR`).
+4. Import `grafana-dashboard.json`, confirm all panels render against the live data source.
+5. Trigger a synthetic SLO breach (e.g. inject 5% error rate via a feature flag); confirm Grafana alert fires within 5 min and lands in Slack.
+6. Trigger a synthetic Inoreader-budget alarm by setting the daily-budget counter to 180; confirm both ticket-level (Slack) and page-level (PagerDuty at 90%) alerts route correctly.
+7. Confirm the on-call rotation receives a test page and the runbook link in the alert resolves to the correct markdown file.
+8. Two-week post-deploy review: are SLOs being met? Are alerts firing on the right things and quiet on noise? Tighten or loosen baselines accordingly.
+
+### Risks & mitigations
+
+| Risk                                                                                | Mitigation                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Alert fatigue from poorly-calibrated thresholds                                     | The 10-14 day baselining sprint is non-negotiable; targets set against measured p95 × 1.5 buffer; review and re-tune at 2-week mark                                                    |
+| Cardinality explosion on metric dimensions (e.g. `key_prefix` × `tool` × `success`) | Cardinality budget per metric documented in `metrics/_index.ts`; CI test caps emission cardinality                                                                                     |
+| Cloudflare Analytics Engine free-tier quota exhaustion                              | Monitor own metrics emission rate; document the upgrade path ($25/mo paid tier covers 100M events/mo, ~30× expected volume)                                                            |
+| Runbooks drift out of sync with reality                                             | Each runbook has a `lastReviewedAt` field; CI fails if any runbook is over 6 months stale OR if the alert that links to it has changed since the runbook's last review                 |
+| On-call rotation insufficient (single engineer)                                     | Acceptable through BL-032.75 internal use; BL-033's pilot SLA requires either a second on-call rotation or a contracted on-call escalation — that decision belongs to BL-033, not here |
+| Grafana Cloud free-tier limits (3 users, 10k metrics series)                        | Monitor; the volume here fits comfortably; upgrade path is $19/user/mo if exceeded                                                                                                     |
+| Status page exposes information that should stay internal                           | Initial status page is internal-IP-restricted; BL-033 reviews and chooses what becomes externally visible (typically: tool availability yes, key-level traffic no)                     |
+
+### Out of scope (deferred)
+
+- Distributed tracing (OpenTelemetry on Workers) — adds value for complex request flows; defer until a specific debugging case demands it
+- Synthetic monitoring (external probes hitting `/health` and core tools every 60s from multiple regions) — useful for true uptime measurement; defer to BL-033 when SLA reporting is contractual
+- Per-client usage dashboards (clients see their own traffic) — BL-033 product decision
+- Cost observability (Cloudflare/Upstash/Sentry billing dashboards) — separate concern, low priority while spend is under $100/mo
+- Audit-log integrity dashboards — that surface belongs to BL-033's compliance-grade audit log, not here
+- ML-based anomaly detection beyond simple z-score / threshold rules — premature
+
+---
+
+## How this enables BL-033
+
+BL-033 commits to a contractual SLA. By the time BL-033 enters legal review:
+
+- Every SLO target in BL-033's pilot SLA can cite the measured baseline that justifies it, with at least 30 days of production data
+- Every alert that would fire under a contracted SLA breach is wired and tested
+- The status page that pilots will read for outage transparency exists and is populated with real data
+- The on-call rotation (or its contracted alternative) is operating, not aspirational
+- Runbooks for the canonical alert types exist and have been exercised at least once
+
+That moves the BL-033 conversation from "we will commit to 99.5% uptime" (aspirational) to "we have run at 99.6% measured over 60 days; the SLA matches operational reality" (defensible). The pilot legal review becomes substantially less risky because the operational claim is backed by historical data.
+
+---
+
+_Last updated: 2026-04-25_

--- a/src/docs/development/MCP_SERVER_PROMPTS_BL-031_75.md
+++ b/src/docs/development/MCP_SERVER_PROMPTS_BL-031_75.md
@@ -1,0 +1,225 @@
+# MCP Server — Consultant Prompt Library (BL-031.75)
+
+> **Backlog initiative**: [BL-031.75: MCP Server — Consultant Prompt Library](BACKLOG.md#bl-03175-mcp-server--consultant-prompt-library)
+>
+> **Predecessors**:
+>
+> - [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) — overall MCP architecture, repo placement, lifecycle. Read first.
+> - [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) — extends the surface to all Hub engines + Library + Radar Resources. Required predecessor: this initiative composes those Tools and Resources into named workflows.
+>
+> **Sequel**: [MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md) — ports the Prompts surface delivered here to the remote HTTP transport, where prompt fan-out interacts with per-key rate limits and URI-stability becomes a remote contract.
+>
+> **Scope**: this document covers [BL-031.75](BACKLOG.md#bl-03175-mcp-server--consultant-prompt-library) — adding the MCP **Prompts** primitive to the local stdio MCP server, packaging GST's repeatable consultant workflows as named slash-command templates that orchestrate the Tools and Resources delivered in BL-031 and BL-031.5.
+>
+> **Status**: Open. Depends on BL-031 and BL-031.5.
+
+---
+
+## Context
+
+BL-031 exposes two engines as MCP **Tools**. BL-031.5 broadens the surface — four more engines as Tools, two Library articles + 120+ regulatory frameworks + the radar snapshot as **Resources**. Together they make every piece of GST's intellectual surface area reachable from any Claude conversation.
+
+What's missing is **how to use them well**. A new analyst in their first month does not know:
+
+- Which Tool combination produces a defensible target screen
+- That `gst://library/vdr-structure` is the canonical reference for VDR audit work
+- How to weave a portfolio comparable into a diligence handoff memo
+- Which radar categories matter for which deal type
+- The order in which a regulatory exposure brief should be assembled
+
+That tacit workflow knowledge today lives in the senior consultants' heads, in scattered Notion pages, and in the muscle memory of repeated client engagements. Tools and Resources alone do not transmit it. **MCP Prompts do** — they let us codify the workflow as a named, parameterized template that any team member (or a client agent in BL-033) can invoke as a slash-command.
+
+A `/gst_target_quick_look { targetName, productType, arr, hqJurisdiction }` prompt, for example, expands into a templated multi-step conversation that calls the relevant Tools, reads the relevant Resources, and produces a consistent first-look brief. The first time a new analyst runs it, they see how a senior consultant would frame the work. By the third time, the workflow is internalized.
+
+This is the third and final piece of the local-stdio MCP surface: Tools to compute, Resources to read, **Prompts to orchestrate**.
+
+---
+
+## What MCP "Prompts" are — and why they earn their own initiative
+
+[MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) introduced the three MCP primitives. BL-031 used Tools. BL-031.5 added Resources. BL-031.75 adds the third:
+
+| Primitive    | What it is                                                           | Who triggers it                     | Example                                      |
+| ------------ | -------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------- |
+| **Tool**     | Callable function with structured input → output                     | Model decides when to call          | `compute_techpar({ arr, stage, ... })`       |
+| **Resource** | URI-addressable read-only content                                    | User pins, or model auto-fetches    | `gst://library/vdr-structure`                |
+| **Prompt**   | Pre-written templated message(s) the user invokes as a slash-command | User-driven (slash menu, picker UI) | `/gst_diligence_kickoff { targetName, ... }` |
+
+A Prompt has: a `name`, a human-readable `description`, an optional list of typed `arguments` (each with name / description / required flag), and — when invoked — returns one or more messages (user/assistant) that the MCP client splices into the conversation. Some prompts are static templates ("draft a one-pager about X"); the more useful kind dynamically incorporates the values of the arguments and references the server's Tools and Resources by name in the message body, coaching the model to call them in a specific order.
+
+### Why Prompts deserve a dedicated initiative
+
+1. **They are workflow assets, not engineering plumbing.** Each prompt encodes a consulting playbook. The work is largely **content design** — what does a senior consultant actually do step-by-step on a comparable engagement? — which is a different competency from the schema/wrapper engineering of BL-031/031.5. Treating it as its own ticket lets the work be reviewed by people who understand the consulting motions, not just the code.
+
+2. **Different ergonomics from Tools and Resources.** Tools and Resources are continuously available; the model decides when to use them. Prompts appear in the slash-command picker (Claude Desktop renders them as `/gst_*`) — the user explicitly opts into a workflow at a known starting point. Designing the menu (which prompts exist, how they are named, what arguments they take) is a UX decision that benefits from explicit treatment.
+
+3. **They make the Tool+Resource surface legible.** Without Prompts, an analyst handed access to the MCP server has to read documentation to know what to do. With Prompts, the slash-menu IS the documentation: each entry is named after a recognizable consultant motion ("/gst_diligence_kickoff", "/gst_vdr_audit", "/gst_radar_brief_today"). The ramp-up from "I have access" to "I know what to do" collapses.
+
+4. **They are a high-leverage proving ground for the consultant-as-prompt-engineer skill.** The hardest skill in agent-native consulting is not "writing prompts that work once" — it's "writing prompts that consistently produce client-grade output." BL-031.75 is where GST's senior consultants codify their judgment in reusable form. The prompts shipped here become the firm's training material, the basis for new-hire onboarding, and the seed for whatever paid-prompt-pack offering BL-033 might eventually monetize.
+
+5. **Versioning matters more than for Tools or Resources.** A Tool's behavior is determined by its underlying engine. A Resource is a snapshot. A Prompt's behavior depends on its message body — and tweaking that body changes outputs for everyone using it. Prompt versioning, change-review discipline, and an "examples / golden outputs" testing pattern need explicit treatment, not retrofit.
+
+---
+
+## The prompt library — proposed surface
+
+The first cut of the prompt library covers GST's most repeated consulting motions. Each prompt orchestrates one or more Tools and Resources from BL-031 / BL-031.5. Names follow the convention `gst_<verb>_<object>` (snake*case, `gst*` prefix to avoid collision with other MCP servers' prompts in the slash menu).
+
+| Prompt                            | Arguments                                                                                                          | Orchestrates                                                                                                                       | Purpose                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gst_diligence_kickoff`           | `{ targetName, transactionType, productType, techArchetype, headcount, revenueRange, growthStage, geographies[] }` | Tool: `generate_diligence_agenda` → Resource: `gst://library/vdr-structure` (referenced)                                           | Starter agenda for a new diligence engagement, framed in GST's house style with the VDR Structure Guide referenced for follow-up                    |
+| `gst_target_quick_look`           | `{ targetName, productType, arr, stage, hqJurisdiction }`                                                          | Tools: `assess_infrastructure_cost_governance` (light variant), `compute_techpar`, `estimate_tech_debt_cost`, `search_regulations` | First-look brief — combines cost-governance maturity, TechPar benchmark, tech-debt range, and regulatory exposure into one digestible page          |
+| `gst_comparable_engagements_memo` | `{ targetDescription, theme?, engagementCategory? }`                                                               | Tools: `search_portfolio` + `list_portfolio_facets` (for refinement)                                                               | Identifies 3–5 comparable past engagements, summarizes the relevant lesson from each, frames analogically for the current deal                      |
+| `gst_regulatory_exposure_brief`   | `{ targetJurisdictions[], dataCategories[], productType }`                                                         | Tool: `search_regulations` → Resources: per-framework `gst://regulations/...`                                                      | Compiles applicable regulatory frameworks for a target's jurisdictional and data footprint, with summaries pulled directly from the resource bodies |
+| `gst_vdr_audit`                   | `{ vdrInventory: string }` (free-text current folder list, or absent — see "interactive mode" below)               | Resource: `gst://library/vdr-structure`                                                                                            | Compares a target's actual VDR contents against the canonical 10-folder taxonomy; flags gaps and surfaces follow-up requests                        |
+| `gst_architecture_layer_review`   | `{ targetSummary }`                                                                                                | Resource: `gst://library/business-architectures`                                                                                   | Walks the target through the 5-layer architecture framework (Software → Infrastructure → Data → Org → Industry) and surfaces architectural risks    |
+| `gst_radar_brief_today`           | `{ category?, sinceHours? (default 24) }`                                                                          | Resource: `gst://radar/fyi/latest` (filtered)                                                                                      | Daily / pre-meeting digest of the most recent annotated radar items, summarized in the GST Take voice                                               |
+| `gst_diligence_handoff_memo`      | `{ targetName, agendaJson? (else regenerate), comparablesJson? (else search) }`                                    | Tools: `generate_diligence_agenda`, `search_portfolio` → Resource: `gst://library/vdr-structure`                                   | Combines the agenda + comparable engagements + VDR follow-ups into a draft handoff memo for the deal team                                           |
+
+**Interactive vs one-shot prompts.** Some prompts (e.g. `gst_vdr_audit`) are most valuable when the user can omit arguments and the prompt itself drives the conversation ("Paste your current VDR folder list, or tell me what's there"). MCP supports both modes — required vs optional arguments. The convention applied here:
+
+- **Required arguments** = data the prompt cannot proceed without (e.g. `targetName`)
+- **Optional arguments** = inputs the prompt can either accept directly OR ask for in-flow if absent
+
+That distinction is documented per-prompt in the prompt's `description` so the slash-menu render is clear about expectations.
+
+---
+
+## Repo placement and lifecycle
+
+Same answers as the predecessor docs: monorepo, same `mcp-server/` workspace. No repo split.
+
+The new lifecycle wrinkle introduced by Prompts is **content drift**: each prompt's message body is a piece of authored content, not generated code. It has the same drift risk as any documentation — a senior consultant's framing evolves, but the prompt still references the old framing. Mitigations:
+
+| Risk                                                                                                     | Mitigation                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prompt body falls out of sync with how senior consultants actually work                                  | Annual review cadence (calendar reminder); each prompt has a `lastReviewedAt` field in its source TS module; a Vitest test fails when any prompt's last review is over 12 months old        |
+| Tweaking a prompt body silently changes outputs for all users                                            | Each prompt has a `version` field; non-trivial changes bump the version; a test asserts that the slash-menu lists every prompt's version                                                    |
+| New analyst onboarding still requires senior-consultant pairing because prompts don't exist or are wrong | The prompts ARE the onboarding artifact; new-hire feedback ("the `target_quick_look` prompt was confusing on step 3") feeds directly into the next review cycle                             |
+| Schema drift from arguments referencing Tool inputs that have moved on                                   | Argument schemas re-use the same Zod schemas as the underlying Tools (declared once in `mcp-server/src/schemas.ts`); CI fails if a prompt's argument Zod doesn't match the Tool's input Zod |
+
+---
+
+## Implementation Plan
+
+### File layout (extends BL-031.5's `mcp-server/`)
+
+```
+mcp-server/
+├── src/
+│   ├── index.ts                    # +registerPrompts(server)
+│   ├── tools/                      # (BL-031, BL-031.5 — unchanged)
+│   ├── resources/                  # (BL-031.5 — unchanged)
+│   ├── prompts/                    # NEW — one TS module per prompt
+│   │   ├── _registry.ts            # central registration; iterates all prompts
+│   │   ├── diligence-kickoff.ts
+│   │   ├── target-quick-look.ts
+│   │   ├── comparable-engagements-memo.ts
+│   │   ├── regulatory-exposure-brief.ts
+│   │   ├── vdr-audit.ts
+│   │   ├── architecture-layer-review.ts
+│   │   ├── radar-brief-today.ts
+│   │   └── diligence-handoff-memo.ts
+│   └── schemas.ts                  # +PromptArgument schemas (re-using Tool input shapes)
+└── tests/
+    ├── prompts/                    # NEW — one test file per prompt
+    │   ├── diligence-kickoff.test.ts
+    │   ├── ... (one per prompt)
+    │   └── prompt-registry.test.ts # asserts version, lastReviewedAt invariants
+    └── examples/                   # NEW — golden expected-output snapshots
+        └── *.golden.md             # one per prompt, used in regression tests
+```
+
+### Per-prompt module shape
+
+Every prompt module exports a standard interface:
+
+```ts
+// mcp-server/src/prompts/diligence-kickoff.ts
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { DiligenceUserInputsSchema } from '../schemas.js';
+
+export const diligenceKickoffPrompt = {
+  name: 'gst_diligence_kickoff',
+  description:
+    'Generate a starter diligence agenda for a new engagement. Use at the kickoff of a buy-side or sell-side review.',
+  version: '0.1.0',
+  lastReviewedAt: '2026-04-25',
+  argsSchema: DiligenceUserInputsSchema.extend({
+    targetName: z.string().describe('Name of the target company (used in the memo header).'),
+  }),
+  build: (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text:
+            `You are advising on the diligence kickoff for ${args.targetName}. ` +
+            `Use the \`generate_diligence_agenda\` tool with the parameters supplied. ` +
+            `Then reference \`gst://library/vdr-structure\` to suggest VDR-folder follow-ups for each topic. ` +
+            `Frame the result as a one-page memo in GST's house style: ` +
+            `(1) target context paragraph, (2) prioritized agenda by topic, ` +
+            `(3) attention areas, (4) suggested VDR requests.`,
+        },
+      },
+    ],
+  }),
+};
+
+export function registerDiligenceKickoffPrompt(server: McpServer) {
+  server.registerPrompt(
+    diligenceKickoffPrompt.name,
+    {
+      description: diligenceKickoffPrompt.description,
+      argsSchema: diligenceKickoffPrompt.argsSchema,
+    },
+    diligenceKickoffPrompt.build
+  );
+}
+```
+
+This shape gives every prompt a uniform place to live — version, review date, schema, and message-builder — and lets `_registry.ts` iterate them generically.
+
+### Critical files referenced (no modifications expected)
+
+| File                                                                                                                                                                                                                     | Why                                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| [src/data/diligence-machine/wizard-config.ts](../../data/diligence-machine/wizard-config.ts)                                                                                                                             | Source enum lists for prompt argument schemas (re-imports through BL-031's schema layer) |
+| [src/utils/diligence-engine.ts](../../utils/diligence-engine.ts), [techpar-engine.ts](../../utils/techpar-engine.ts), [icg-engine.ts](../../utils/icg-engine.ts), [tech-debt-engine.ts](../../utils/tech-debt-engine.ts) | Tools the prompts orchestrate (registered in BL-031 / BL-031.5)                          |
+| [src/data/regulatory-map/](../../data/regulatory-map/)                                                                                                                                                                   | Regulation Resources the regulatory-exposure prompt references                           |
+| Library articles                                                                                                                                                                                                         | Library Resources the VDR / architecture prompts reference                               |
+
+### Verification (run before marking complete)
+
+1. `cd mcp-server && npm run build && npm test` — green; includes prompt-registry invariant tests and per-prompt golden-output snapshot tests.
+2. From repo root: `npx astro check && npm run lint && npm run lint:css && npm run test:run` — still green.
+3. Restart the local MCP server, confirm Claude Desktop's slash-command picker lists every `gst_*` prompt with the expected description.
+4. Invoke `/gst_diligence_kickoff` with a worked example, confirm: (a) the diligence-agenda Tool is called, (b) the VDR Structure Guide is referenced, (c) the resulting memo is one page, in GST's house style.
+5. Same shape verification for `/gst_target_quick_look` (must call ICG + TechPar + Tech Debt + regulations search), `/gst_radar_brief_today` (must read FYI snapshot Resource), `/gst_vdr_audit` (must reference the Library Resource).
+6. **Senior-consultant review.** A senior team member reads the output of each prompt against a representative example and signs off that the framing matches how they would brief the work themselves. This review is a **gating step**, not optional — the prompts exist to encode tacit consulting judgment, and that judgment is verified by the people who hold it.
+7. Run a "fresh analyst" exercise: a team member who has never used the MCP server picks one prompt cold and produces a deliverable. Capture friction points; feed into the next review cycle.
+
+### Risks & mitigations
+
+| Risk                                                                     | Mitigation                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Prompt outputs are unreliable across model versions                      | Maintain golden-output snapshots per prompt; on each Claude model upgrade, re-run the snapshot suite, review diffs, update if the new output is qualitatively better (and bump prompt `version`).                              |
+| Slash-command name collisions with other MCP servers in a user's setup   | All prompts use the `gst_` prefix. Document this convention in the README and lint with a regex check in `prompts/_registry.ts`.                                                                                               |
+| Argument schemas drift from the Tools they orchestrate                   | Every prompt's `argsSchema` re-uses (via Zod composition) the same source-of-truth schemas as the Tools. CI test asserts the shapes are still compatible.                                                                      |
+| Prompts encode a single consultant's style; another consultant disagrees | Annual review cycle; explicit ownership per prompt (a `owner` field in the source module); disagreements get resolved at review, not by silent edit.                                                                           |
+| Senior-consultant review is the bottleneck                               | Frame the review as 30 minutes per prompt at most. The prompts are short; the work is "would I send this to a client" judgment, not deep editing.                                                                              |
+| Prompts that reference Resources / Tools become broken when those move   | Static analysis test: each prompt module declares what Tools and Resources it invokes (e.g. an `orchestrates: ['compute_techpar', 'gst://library/vdr-structure']` field); CI asserts each named Tool / Resource is registered. |
+
+### Out of scope (deferred to BL-032 or later)
+
+- Prompts that mutate state — all BL-031.75 prompts are read/derive only
+- Per-client prompt customization (a client's white-labeled copy of `gst_diligence_kickoff` with their house style) — defer to BL-033 if a paying client asks
+- A "prompt builder" UI on the website — not needed; authoring is text-editor work in `mcp-server/src/prompts/`
+- Telemetry on which prompts get used most — would require BL-032's logging surface; the local-stdio context has no useful place to send this
+- Localization — English only; revisit when GST signs a non-English-language client engagement
+
+---
+
+_Last updated: 2026-04-25_

--- a/src/docs/development/MCP_SERVER_PROMPTS_BL-031_75.md
+++ b/src/docs/development/MCP_SERVER_PROMPTS_BL-031_75.md
@@ -59,6 +59,26 @@ A Prompt has: a `name`, a human-readable `description`, an optional list of type
 
 5. **Versioning matters more than for Tools or Resources.** A Tool's behavior is determined by its underlying engine. A Resource is a snapshot. A Prompt's behavior depends on its message body — and tweaking that body changes outputs for everyone using it. Prompt versioning, change-review discipline, and an "examples / golden outputs" testing pattern need explicit treatment, not retrofit.
 
+### How clients surface and invoke Prompts
+
+Prompts ride the same stdio transport as Tools and Resources (see [MCP_SERVER_ARCHITECTURE_BL-031.md § Discovery, connection, build, and deployment](MCP_SERVER_ARCHITECTURE_BL-031.md#discovery-connection-build-and-deployment)). What changes is who initiates the invocation and how the UI surfaces them:
+
+| Client         | How Prompts appear                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Desktop | Slash-command picker in the chat input — typing `/` shows every prompt across every connected MCP server. The `gst_*` prefix groups GST's prompts visibly and avoids collisions with other servers' prompts                     |
+| Claude Code    | Same slash-command picker; prompts appear alongside Claude Code's built-ins. The `gst_` prefix prevents collision with any future Claude Code slash command                                                                     |
+| Cursor         | Command palette entries (Cmd+Shift+P or equivalent); prompts are user-invoked actions                                                                                                                                           |
+| ChatGPT        | No prompts UI in the local stdio phase; Prompts become reachable via HTTP in [BL-032.5](MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md), where ChatGPT's connector UI surfaces them as suggested actions on the connector card |
+
+The wire calls are:
+
+- `prompts/list` — returns each prompt's `name`, `description`, `arguments` schema, and `version`. Called once at session start
+- `prompts/get { name, arguments }` — returns `{ messages: [...] }` — one or more user/assistant message bodies that the client splices into the active conversation. The model then sees those messages and continues from there
+
+This is the fundamental difference from Tools and Resources: **Prompts are user-driven, not model-driven**. The model never decides to invoke a prompt; the user does, by selecting it from the slash-command picker. That is precisely why Prompts are the right primitive for "named consultant workflows" — they map cleanly to "this is the motion I want to start" rather than "this is a function the model might want to call mid-thought."
+
+Required arguments appear in the picker as form fields the user fills before the prompt expands. Optional arguments can be omitted; the prompt body itself drives the conversation forward (the "interactive mode" pattern documented under [The prompt library — proposed surface](#the-prompt-library--proposed-surface)).
+
 ---
 
 ## The prompt library — proposed surface

--- a/src/docs/development/MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md
+++ b/src/docs/development/MCP_SERVER_REMOTE_RESOURCES_PROMPTS_BL-032_5.md
@@ -1,0 +1,187 @@
+# MCP Server — Resources & Prompts on Remote (BL-032.5)
+
+> **Backlog initiative**: [BL-032.5: MCP Server — Resources & Prompts on Remote](BACKLOG.md#bl-0325-mcp-server--resources--prompts-on-remote)
+>
+> **Predecessors**:
+>
+> - [MCP_SERVER_ARCHITECTURE_BL-031.md](MCP_SERVER_ARCHITECTURE_BL-031.md) — overall MCP architecture, repo placement, lifecycle. Read first.
+> - [MCP_SERVER_HUB_SURFACE_BL-031_5.md](MCP_SERVER_HUB_SURFACE_BL-031_5.md) — defines the local-stdio Resources surface (Library, Regulations, Radar) being ported here.
+> - [MCP_SERVER_PROMPTS_BL-031_75.md](MCP_SERVER_PROMPTS_BL-031_75.md) — defines the local-stdio Prompts library being ported here.
+> - [BL-032 in BACKLOG.md](BACKLOG.md#bl-032-mcp-server--internal-remote-phase-2) — the remote HTTP/Workers/auth/rate-limiting substrate this initiative builds on.
+>
+> **Sequel**: [MCP_SERVER_OBSERVABILITY_BL-032_75.md](MCP_SERVER_OBSERVABILITY_BL-032_75.md) — production observability maturity layered on top of the remote surface.
+>
+> **Scope**: this document covers [BL-032.5](BACKLOG.md#bl-0325-mcp-server--resources--prompts-on-remote) — porting the Resources and Prompts primitives delivered locally in BL-031.5 and BL-031.75 to the remote HTTP transport, auth, and rate-limit surface delivered in BL-032.
+>
+> **Status**: Open. Depends on BL-031.5, BL-031.75, BL-032.
+
+---
+
+## Context
+
+BL-032 ships the remote substrate — Cloudflare Workers, Streamable HTTP transport, bearer-token auth, sliding-window rate limiting, and the radar Tools (`search_radar`, `get_latest_insights`). It deliberately scopes to **Tools only** to keep the auth + rate-limit + observability work contained.
+
+This leaves a real surface gap: a team member at a client site, on the Claude mobile app, or on a borrowed laptop has access to `generate_diligence_agenda` and `compute_techpar` over HTTP — but **not** the VDR Structure Guide, the regulatory frameworks, the radar snapshot Resources, or any of the eight `gst_*` consultant Prompts. All the orchestration value of BL-031.75 evaporates the moment the user leaves their dev machine.
+
+BL-032.5 closes that gap. Mechanically the work is straightforward — the same tool registry pattern (register-once, transport-twice) that BL-031 established lets Resources and Prompts ride the existing HTTP transport. The interesting design questions are not about the registry; they are about **how Resources and Prompts behave differently under HTTP**:
+
+- **Resources need HTTP caching semantics** — ETag, Last-Modified, Cache-Control — that don't apply over stdio
+- **Resources need scope gating** — some BL-033 pilot clients should not see radar; bearer keys need to carry that information from BL-032's day one, even if the scope-enforcement code is light
+- **Prompts trigger downstream Tool calls** — a single `gst_target_quick_look` invocation chains four Tool calls; each call hits the per-key rate limit. A naïve port turns one slash-command into four near-simultaneous rate-limit checks
+- **URI stability across the local→remote boundary** — `gst://library/vdr-structure` worked locally; it must work identically on `mcp.globalstrategic.tech` so a user's pinned conversation context survives the move
+
+Validating these behaviors with **trusted internal users** before BL-033's external clients touch them is exactly the de-risking pattern BL-031 → BL-032 already follows.
+
+---
+
+## Why this earns its own initiative (rather than expanding BL-032)
+
+BL-032 is already the largest single milestone in the chain — Workers deployment, auth, rate limiting, radar tools, Sentry wiring, `wrangler` config, CI changes for staging-vs-production deploys. Folding Resources + Prompts into it would push the milestone into multi-week territory and dilute the value-delivery cadence. Splitting buys three concrete things:
+
+1. **BL-032 ships sooner.** Tools-over-HTTP is the longest-lead-time piece because everything else depends on the auth + rate-limit substrate. Getting that into trusted-internal hands fast is the whole point of Phase 2.
+2. **BL-032.5 ships against measured baselines.** With BL-032 in production for a week or two, BL-032.5 can use real Tool-call latency / error data to inform Resource caching strategy and Prompt-orchestration limits, instead of guessing.
+3. **The competency split mirrors BL-031.5 / BL-031.75.** Resources work is content-pipeline (cache headers, URI stability, scope metadata); Prompts work involves consultant-style review of how prompts behave under network conditions. Splitting lets each be sized and scheduled honestly.
+
+---
+
+## What changes in the move from stdio to HTTP
+
+### Resources — the design questions HTTP forces
+
+Local stdio reads a Resource by spawning the server, calling `resources/read`, and getting bytes back. There is no caching, no concurrency, no auth surface. HTTP changes all three:
+
+| Concern                | stdio (BL-031.5)                                  | HTTP (BL-032.5)                                                                                                                                          |
+| ---------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Caching**            | None — each read goes through the handler         | HTTP cache headers (ETag, Last-Modified) so MCP clients with HTTP caching can avoid re-fetching unchanged Resources                                      |
+| **Concurrency**        | One client process                                | Many clients fetching the same Resource simultaneously — Worker isolate handles each, but Upstash Redis cache layer becomes worthwhile for hot Resources |
+| **Auth**               | Process-level trust                               | Per-Resource scope check; bearer key carries scope metadata; server returns `403 Forbidden` for out-of-scope reads                                       |
+| **Resource-not-found** | "Snapshot missing, run `npm run radar:seed`"      | Snapshot lives in Upstash, populated by a periodic Worker Cron job; missing → `503 Service Unavailable` with a structured retry hint                     |
+| **URI stability**      | Local files; unilateral rename = our problem only | URI is a remote contract; rename = breaking change; CI test asserts URI manifest is byte-stable across BL-032 and BL-032.5                               |
+
+**Resource-specific cache strategies** (each Resource's freshness story is different):
+
+| Resource                                         | Caching strategy                                                       | Rationale                                                                                        |
+| ------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `gst://library/<slug>`                           | Strong: `Cache-Control: public, max-age=86400`, ETag = content hash    | Library articles change rarely; clients benefit from aggressive caching                          |
+| `gst://regulations/<j>/<id>`                     | Strong: same as Library                                                | 120+ JSON files; updates are infrequent and atomic per-framework                                 |
+| `gst://radar/fyi/latest`, `gst://radar/wire/...` | Weak: `Cache-Control: public, max-age=900` (15 min), `must-revalidate` | Radar updates ~hourly via a Worker Cron job; 15 min cache balances freshness vs Inoreader budget |
+| `gst://radar/item/<id>`                          | Strong: 24h, immutable                                                 | Once published, individual radar items don't mutate                                              |
+
+### Prompts — the design questions HTTP forces
+
+Local stdio prompts resolve in-process: `prompts/get` returns the message body, the client model then calls Tools as the body instructs. Over HTTP, the same invocation pattern applies — `prompts/get` returns a body, the model calls Tools — but the Tool calls now hit a remote endpoint with a per-key rate limit.
+
+| Concern                 | stdio (BL-031.75)                                                         | HTTP (BL-032.5)                                                                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tool fan-out**        | A prompt that orchestrates 4 Tools = 4 in-process calls; effectively free | 4 HTTP calls under one user's per-key limit; can hit the 60 req/min ceiling on a single prompt invocation if the user has been busy                                                          |
+| **Latency aggregation** | Sub-millisecond                                                           | Cumulative — 4 Tools × ~200ms median = ~800ms before the model starts composing the answer                                                                                                   |
+| **Auth scope**          | All-or-nothing                                                            | Some prompts need scopes the bearer key may not have (e.g. radar prompts for a key without `tool:radar:*`); prompt definition declares required scopes; `prompts/get` returns 403 if missing |
+| **Prompt versioning**   | `version` field local-only                                                | `prompts/list` includes `version` so clients can detect drift after server upgrades; pinned conversations can warn the user                                                                  |
+
+**Mitigations baked into BL-032.5**:
+
+- Prompts that orchestrate multiple Tools document their Tool list in an `orchestrates: [...]` field (already established in BL-031.75); the Worker exposes a `GET /prompts/<name>/scopes` introspection endpoint so clients can pre-flight a prompt against their key's scope list
+- Per-key rate-limit _bursts_ are tuned to accommodate a worst-case prompt fan-out (the heaviest prompt = `gst_target_quick_look` = 4 tools); the configured 60 req/min ceiling already covers this with margin, but a `prompt-aware-burst` allowance (described below) makes the design explicit
+- A new aggregate metric `prompt_invocations_total` (one increment per `prompts/get`, regardless of downstream Tool fan-out) is logged so observability (BL-032.75) can distinguish prompt vs raw-tool usage
+
+---
+
+## Repo placement and lifecycle
+
+Same answers as predecessors. The `mcp-server/` workspace already contains the local-stdio Resources and Prompts modules from BL-031.5 / BL-031.75. BL-032.5 binds the **same** modules to the HTTP entrypoint added in BL-032 — register-once, transport-twice continues. No new workspace, no new repo.
+
+The new lifecycle wrinkle introduced by HTTP is **breaking-change discipline for URIs and prompt names**. A locally-renamed file affects only the renaming consultant; a remote URI rename breaks every pinned conversation across every authenticated client. From BL-032.5 forward, URI and prompt-name changes must:
+
+1. Land alongside a `version` bump in `mcp-server/package.json` (semver-as-contract)
+2. Be cataloged in a `BREAKING_CHANGES.md` file at the workspace root
+3. Be announced via a `notifications/message` push to all connected clients on first deploy
+
+BL-033's external pilot will inherit this discipline; this initiative establishes it under low-stakes internal load.
+
+---
+
+## Implementation Plan
+
+### File layout (extends BL-032's `mcp-server/`)
+
+```
+mcp-server/
+├── src/
+│   ├── index.ts                    # (unchanged) stdio entrypoint
+│   ├── worker.ts                   # +registerResources(server); +registerPrompts(server)
+│   ├── tools/                      # (BL-031, BL-031.5 — unchanged)
+│   ├── resources/                  # (BL-031.5 — body unchanged)
+│   │   ├── library.ts
+│   │   ├── regulations.ts
+│   │   ├── radar.ts
+│   │   └── _http-headers.ts        # NEW — Cache-Control, ETag, Last-Modified shared logic
+│   ├── prompts/                    # (BL-031.75 — body unchanged)
+│   ├── auth/                       # (BL-032 — extended)
+│   │   ├── scopes.ts               # NEW — scope catalog (resource:library:read, etc.)
+│   │   └── prompt-scopes.ts        # NEW — derive prompt scope requirements from orchestrates[]
+│   ├── cache/                      # NEW — Upstash hot-Resource cache
+│   │   └── resource-cache.ts
+│   └── cron/                       # NEW — Worker Cron handler for periodic radar snapshot refresh
+│       └── radar-refresh.ts
+└── tests/
+    ├── http-resources.test.ts      # NEW — cache headers, scope gating, 404/503 shapes
+    ├── http-prompts.test.ts        # NEW — prompt fan-out under rate limits, scope checks
+    ├── uri-stability.test.ts       # extend BL-031.5's URI manifest test to assert across stdio + HTTP
+    └── breaking-changes.test.ts    # NEW — fails if URI/prompt-name changed without version bump
+```
+
+### Critical cross-cutting decisions
+
+1. **Resource cache layer**: per-Resource freshness strategy table above; Upstash KV is the cache substrate (already provisioned in BL-032 for rate limiting). Cache key = `mcp-resource:<uri-hash>`; cache value = `{ body, etag, lastModified, expiresAt }`.
+
+2. **Periodic radar refresh**: BL-031.5's "run `npm run radar:seed` locally" pattern doesn't translate. The Worker uses a Cloudflare Cron Trigger every hour to call `fetchAllStreams` + `fetchAnnotatedItems`, transform the response, and write the snapshot to Upstash. This consumes ~24 Inoreader calls/day from the 200/day budget — well within the share already documented in [RADAR.md](../hub/RADAR.md). The website's existing ISR (~28/day) plus this Cron (~24/day) plus per-key rate-limited radar Tool calls (capped at 50/key/day) still sit within the 200/day envelope.
+
+3. **Scope catalog** (forward-compatible with BL-033's OAuth scope semantics):
+
+| Scope                       | Grants                                                                                          |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `tool:<name>`               | Call a specific Tool (e.g. `tool:generate_diligence_agenda`)                                    |
+| `tool:radar:*`              | All radar Tools (`search_radar`, `get_latest_insights`)                                         |
+| `resource:library:read`     | Read all `gst://library/*` Resources                                                            |
+| `resource:regulations:read` | Read all `gst://regulations/*` Resources                                                        |
+| `resource:radar:read`       | Read all `gst://radar/*` Resources                                                              |
+| `prompt:*`                  | Invoke any prompt (the prompt itself enforces its underlying Tool/Resource scopes at call time) |
+
+For BL-032.5 (still internal, single shared bearer key per team member), the wrangler-secret-issued keys are configured with the full scope set by default. The infrastructure exists; the per-key scope variation is a BL-033 concern.
+
+4. **URI stability test**: extend [`tests/resource-uri-stability.test.ts`](https://example.invalid/) (introduced in BL-031.5) so it runs against both the stdio in-process server AND the worker via `unstable_dev` from `wrangler`, asserting both transports return identical URI manifests.
+
+### Verification
+
+1. `cd mcp-server && npm run build && npm test` — green; HTTP-specific tests pass under `unstable_dev`.
+2. From repo root: `npx astro check && npm run lint && npm run lint:css && npm run test:run` — still green.
+3. `wrangler deploy --env staging` — Worker deploys; `wrangler tail` shows Cron registration for radar-refresh.
+4. `curl -H "Authorization: Bearer <key>" https://mcp-staging.globalstrategic.tech/resources/list` returns the full URI manifest (Library × 2, Regulations × 120+, Radar × N).
+5. `curl -H "Authorization: Bearer <key>" -H "If-None-Match: <etag>" .../resources/read?uri=gst://library/vdr-structure` returns `304 Not Modified` on the second call within the cache window.
+6. Issue a key with a scope set missing `resource:radar:read`, attempt to read `gst://radar/fyi/latest` — expect `403 Forbidden` with structured error.
+7. Invoke `prompts/get` for `gst_target_quick_look` from Claude Desktop pointed at staging; confirm the four downstream Tool calls land within the per-key rate-limit budget and the model produces a single coherent brief.
+8. Delete the staging Upstash radar-snapshot key, wait for the next Cron run, confirm it repopulates without manual intervention.
+9. `wrangler deploy --env production` only after all eight steps pass on staging; then `BREAKING_CHANGES.md` reviewed for any URI/prompt-name churn.
+
+### Risks & mitigations
+
+| Risk                                                                                       | Mitigation                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Resource cache stampede on first deploy (cold cache, simultaneous reads from many clients) | Use Cloudflare's request coalescing (`cf.cache`) on Resource fetches; per-Resource lock in Upstash for cache fill                                                             |
+| Prompt fan-out exhausts a user's per-minute rate limit on first invocation of the day      | Per-key burst allowance of 10 over the steady 60 req/min limit; documented in client-facing error messages so users see a clear "wait 30 seconds" instead of a generic 429    |
+| Radar Cron fails silently and snapshot goes stale                                          | Health endpoint includes `radarSnapshotAgeSeconds`; observability initiative (BL-032.75) alerts when this exceeds 2× the Cron interval                                        |
+| URI breakage during refactor                                                               | URI-manifest test in CI; `BREAKING_CHANGES.md` required; semver `version` bump enforced by a separate test that compares manifest hashes between commits                      |
+| Inoreader budget exhaustion from Cron + rate-limited Tools combined                        | Hard daily cap tracked in Upstash counter (`inoreader-day-budget:<date>`); when counter passes 180, both Cron and radar Tools serve cached-only until midnight UTC            |
+| Bearer-key scope drift between BL-032.5 and BL-033                                         | Scope catalog is the single source of truth from this initiative forward; BL-033 reuses the same scope strings, just delivered via OAuth tokens instead of static bearer keys |
+
+### Out of scope (deferred to BL-033 or later)
+
+- OAuth 2.1, dynamic client registration, token introspection — bearer keys remain through BL-032.5
+- Per-client scope variation (different keys, different scope sets) — infrastructure is in place; the variation surface is a BL-033 product decision
+- Compliance-grade audit logging (full request/response retention, R2 immutable storage, hash chains) — BL-032.5 logs metadata only, same as BL-032
+- Customer-facing prompt customization (white-labeled `gst_*` prompts per client) — explicitly deferred to BL-033 or post-pilot
+- Status-page integration for Resource freshness (radar snapshot age visible publicly) — observability initiative (BL-032.75)
+
+---
+
+_Last updated: 2026-04-25_


### PR DESCRIPTION
## Summary

- **Codifies the local-stdio + remote-HTTP MCP server roadmap** as five paired (backlog entry, architecture decision document) artifacts. Each phase can now be sized, scheduled, and reviewed independently: BL-031 (Tools), BL-031.5 (Resources), BL-031.75 (Prompts), BL-032.5 (Resources+Prompts on remote HTTP), BL-032.75 (production observability). BL-033 left intact — its critical path is legal/pilot-recruitment, not engineering.
- **Documents the operational lifecycle** end-to-end: how MCP clients (Claude Desktop, Claude Code, Cursor, ChatGPT) discover, connect to, build, deploy, and use the server. The BL-031 doc carries the canonical transport explanation; BL-031.5 and BL-031.75 each add a focused subsection on their primitive-specific UX (Resources surface as URI-pinnable context; Prompts surface as user-driven slash-commands).
- **Backlog hygiene**: closes BL-040 / BL-041 (radar + library added to Lighthouse CI); removes completed items (BL-022, BL-026, BL-040, BL-041).

## Test plan

- [ ] Read [`MCP_SERVER_ARCHITECTURE_BL-031.md`](src/docs/development/MCP_SERVER_ARCHITECTURE_BL-031.md) end-to-end; "Discovery, connection, build, and deployment" section is clear and complete
- [ ] Cross-references resolve: each doc's `Predecessors` / `Sequels` links work; `BACKLOG.md` references the renamed files (`*_BL-031.md`, `*_BL-031_5.md`, etc.)
- [ ] [`BACKLOG.md`](src/docs/development/BACKLOG.md) Infrastructure section lists BL-031, BL-031.5, BL-031.75, BL-032, BL-032.5, BL-032.75, BL-033 in dependency order
- [ ] Each architecture doc's filename carries the BL- identifier (matches user-facing convention)
- [ ] Lighthouse CI runs against `/hub/radar/` and `/hub/library/business-architectures/` URLs (BL-040/041 closure)
- [ ] No code changes — `npm run lint && npx astro check && npm run lint:css && npm run test:run` unchanged from master baseline
- [ ] No production runtime impact — pure documentation + Lighthouse CI config

🤖 Generated with [Claude Code](https://claude.com/claude-code)