### PR TITLE
fix(mcp-cron): disable staging cron — was doubling Inoreader budget burn

### DIFF
--- a/mcp-server/wrangler.toml
+++ b/mcp-server/wrangler.toml
@@ -79,6 +79,40 @@ routes = [
   { pattern = "mcp-staging.globalstrategic.tech", custom_domain = true }
 ]
 
+# Staging deliberately has NO cron trigger.
+#
+# Staging exists to validate code changes, not to keep caches warm.
+# Both envs share the same Inoreader OAuth app (single registered
+# application; same credentials mirrored across envs), so a staging
+# cron firing on the same `0 */6 * * *` cadence as production
+# DOUBLED the Zone-1 budget burn against the shared 100/day cap.
+# Discovered Day 2 of the BL-032.8 Phase B soak (2026-05-18) when
+# the `mcp:inoreader:day-counter:YYYY-MM-DD` reached 36 at 12:30 UTC
+# instead of the expected 18 (3 prod firings × 6 calls).
+#
+# Cron-path validation now lives in:
+#   - `mcp-server/tests/integration/cron-proactive-refresh.test.ts`
+#   - Manual `wrangler dev --env staging` runs ad-hoc
+#   - Occasional manual `wrangler tail --env staging` of the
+#     scheduled handler triggered via Cloudflare dashboard "Trigger"
+#
+# If you re-enable the staging cron in the future, FIRST confirm
+# the staging Inoreader credentials point at a different registered
+# OAuth app from production — otherwise this regression returns.
+
+# ---------------------------------------------------------------------------
+# Production
+# ---------------------------------------------------------------------------
+# Same secret matrix as staging (with `--env production` values). Path 2:
+# UPSTASH_INOREADER_REST_TOKEN = website-DB Read-Only token; UPSTASH_MCP_REST_TOKEN
+# = MCP-DB Standard token. Independent rotation cadence per DB.
+
+[env.production]
+name = "gst-mcp"
+routes = [
+  { pattern = "mcp.globalstrategic.tech", custom_domain = true }
+]
+
 # Radar snapshot refresh — cadence calibrated to cache TTL.
 #
 # The `scheduled` handler in `src/worker.ts` delegates to
@@ -97,24 +131,8 @@ routes = [
 # the 2026-05-15 BL-032.6 demo-day Zone-1 exhaustion incident — see
 # BL-032_5_TESTING_FINDINGS.md § Section Z and BACKLOG.md § BL-032.7.
 # Corrected to `0 */6 * * *` (every 6h, top of UTC hour) on
-# 2026-05-16; matches cache TTL exactly; ~24 Inoreader calls/day per
-# env, well under the per-app 100/day Zone-1 budget.
-[env.staging.triggers]
-crons = ["0 */6 * * *"]
-
-# ---------------------------------------------------------------------------
-# Production
-# ---------------------------------------------------------------------------
-# Same secret matrix as staging (with `--env production` values). Path 2:
-# UPSTASH_INOREADER_REST_TOKEN = website-DB Read-Only token; UPSTASH_MCP_REST_TOKEN
-# = MCP-DB Standard token. Independent rotation cadence per DB.
-
-[env.production]
-name = "gst-mcp"
-routes = [
-  { pattern = "mcp.globalstrategic.tech", custom_domain = true }
-]
-
-# Same 6h cadence as staging — see commentary above (cadence rule + 2026-05-15 RCA reference).
+# 2026-05-16; matches cache TTL exactly; ~24 Inoreader calls/day,
+# well under the per-app 100/day Zone-1 budget. Production-only —
+# staging deliberately runs no cron (see staging block above).
 [env.production.triggers]
 crons = ["0 */6 * * *"]


### PR DESCRIPTION
@
## Summary

Day 2 of the [BL-032.8 Phase B soak](mcp-server/src/docs/operations/BL-032_8_SOAK_GATE.md) (2026-05-18 09:30 Brazil / 12:30 UTC) surfaced an Inoreader Zone-1 budget concern:

- **Inoreader Developer Console** showed **36% of the 100/day Zone-1 budget consumed** by 12:30 UTC
- **`mcp:inoreader:day-counter:2026-05-18`** confirmed value = **36** (so the cron path itself accounted for all 36)
- **Sentry** showed **4 `cron.radar-refresh.success` events in the last 10 hours** when only **2** should have fired (06:00 UTC + 12:00 UTC, since the 00:00 UTC firing was just outside the 10-hour window)

## Root cause

Both `[env.staging.triggers]` and `[env.production.triggers]` declared the same `crons = ["0 */6 * * *"]`. Since both envs share the same Inoreader OAuth app credentials (single registered application; secrets mirrored across envs), they were independently firing cron handlers at the same UTC times and BOTH hitting the same Inoreader Zone-1 budget AND BOTH incrementing the shared `mcp:inoreader:day-counter` in the shared MCP DB.

Math:
- 3 firings/day × 2 envs × 6 calls = **36 calls/day from cron baseline at 12:30 UTC**
- Projected to 48 calls/day by end-of-UTC-day
- Plus live tool calls → ~58/day total, uncomfortably close to the 100 cap

## Fix

Remove `[env.staging.triggers]` entirely. Staging exists to validate code changes, not to keep caches warm.

- Cron-path coverage now lives in [`mcp-server/tests/integration/cron-proactive-refresh.test.ts`](mcp-server/tests/integration/cron-proactive-refresh.test.ts), manual `wrangler dev --env staging` runs, and the Cloudflare dashboard "Trigger" button against the staging Worker.
- Defensive comment in the staging block warns future maintainers: if you re-enable the staging cron, FIRST confirm staging uses a separate Inoreader OAuth app, otherwise this regression returns.
- Cadence-rule documentation (BL-032.7 + 2026-05-15 RCA reference) moved from above the deleted staging block to above the production block — it lives with the only place cron actually fires now.

## Post-merge operator step

```powershell
Set-Location c:\Code\gst-website
git checkout master
git pull origin master
Set-Location mcp-server
npm run deploy:staging
```

After deploy completes, the wrangler output should show:

```
Deployed gst-mcp-staging (Xs)
  mcp-staging.globalstrategic.tech (custom domain)
  # NO `schedule:` line — cron trigger removed
```

(Production deploy unaffected by this PR. No production `npm run deploy:production` needed.)

## Verification post-deploy

```powershell
# Should see only production-source events from this point forward
# (next firing window: 18:00 UTC = 15:00 Brazil today)
```

Tomorrows Day-3 tick on the soak gate should show:
- Cron firings/day: **4** (production only) instead of 8 (was 4×2 envs)
- Day-counter projection: **24/day** baseline + live tool calls
- Comfortable headroom under 100/day cap

## Test plan

- [x] `npm run lint` clean
- [x] `npx wrangler types` runs without error against new wrangler.toml
- [ ] Post-deploy: wrangler output for `npm run deploy:staging` does NOT contain a `schedule:` line
- [ ] Tomorrows soak Day-3 check: `mcp:inoreader:day-counter:2026-05-19` projection drops to ~24-30/day

## Why not in PR #140 (Phase B soak branch)

PR #140 is the Phase B retirement of legacy Inoreader DB / BL-039 fallback. This is a configuration-only fix to a deploy-time budget issue. Bundling would couple two independent merge timelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@