### PR TITLE
fix(docs): SECRETS_INVENTORY.md prettier escape

### DIFF
--- a/src/docs/operations/SECRETS_INVENTORY.md
+++ b/src/docs/operations/SECRETS_INVENTORY.md
@@ -218,4 +218,4 @@ Per-secret rotation steps live in [`mcp-server/src/docs/operations/DEPLOY.md`](.
 
 ---
 
-_Last updated: 2026-05-19 — created during BL-032.8 Phase B soak, Day 3. Initial draft was rewritten same-day against the authoritative `vercel env ls` + `wrangler secret list` output to correct several initial-draft misattributions (Vercel-side Upstash bindings are `KV__`+`REDIS*URL`from the Vercel Upstash integration, not`UPSTASH_INOREADER_REST*_`; `INOREADER*FOLDER_PREFIX`was never bound on Vercel;`INOREADER_REFRESH_SECRET` is Production + Preview only; website-side Sentry source-map upload vars ARE already wired).*
+_Last updated: 2026-05-19 — created during BL-032.8 Phase B soak, Day 3. Initial draft was rewritten same-day against the authoritative `vercel env ls` + `wrangler secret list` output to correct several initial-draft misattributions (Vercel-side Upstash bindings are `KV__`+`REDIS*URL`from the Vercel Upstash integration, not`UPSTASH_INOREADER_REST\*_`; `INOREADER*FOLDER_PREFIX`was never bound on Vercel;`INOREADER_REFRESH_SECRET` is Production + Preview only; website-side Sentry source-map upload vars ARE already wired).*


### PR DESCRIPTION
## Summary

One-character prettier fix on the `Last updated` line in `SECRETS_INVENTORY.md` (merged via PR #149). Adds the missing markdown-emphasis escape so prettier --check passes on CI's Linux runner.

PR #150 ([fix(mcp-cron): flush Sentry queue](https://github.com/Global-Strategic-Technologies/gst-website/pull/150)) is failing CI on this exact file because GitHub runs the prettier check against the PR's merge base (master), which now includes PR #149's file with this drift.

Merging this unblocks PR #150's CI without any cross-dependency between the two PRs themselves.

## Test plan

- [x] `npx prettier --check src/docs/operations/SECRETS_INVENTORY.md` passes locally after the fix
- [ ] CI green on this PR
- [ ] After merge, PR #150's CI re-runs and clears Prettier check

🤖 Generated with [Claude Code](https://claude.com/claude-code)