### PR TITLE
feat(mcp-health): stale-while-OK semantics for inoreader observation

### DIFF
--- a/mcp-server/src/content/radar-live-store.ts
+++ b/mcp-server/src/content/radar-live-store.ts
@@ -28,7 +28,10 @@ import {
   type RateLimitInfo,
 } from '../lib/inoreader-client';
 import { createCacheStore } from '../lib/upstash-cache-store';
-import { recordInoreaderStatus } from '../observability/inoreader-status';
+import {
+  recordInoreaderStatus,
+  type InoreaderObservedSource,
+} from '../observability/inoreader-status';
 import { toSnapshotItem, type SnapshotItem } from './radar-transform';
 import type { Env } from '../worker';
 
@@ -85,11 +88,19 @@ interface CachedTier {
  * `opts.forceRefresh`: skip the cache lookup and always fetch from Inoreader.
  * Used by the BL-032.5 Phase 4 Worker Cron to refresh the snapshot on a
  * schedule independent of read traffic.
+ *
+ * `opts.source`: which path the call originated from. Recorded on the
+ * `mcp:inoreader:last-status` entry so `/health` can surface
+ * `inoreaderObservedSource`. Defaults to `'live-tool'` because that's
+ * what most callers are (MCP tool handlers, the `/radar/snapshot` HTTP
+ * route, the snapshot-reader adapter); the cron explicitly passes
+ * `'cron'`.
  */
 export async function readWireLive(
   env: Env,
-  opts: { forceRefresh?: boolean } = {}
+  opts: { forceRefresh?: boolean; source?: InoreaderObservedSource } = {}
 ): Promise<LiveTierResult> {
+  const source: InoreaderObservedSource = opts.source ?? 'live-tool';
   const cache = createCacheStore(env);
   if (cache && !opts.forceRefresh) {
     const cached = await cache.get<CachedTier>(CACHE_KEY_WIRE);
@@ -108,12 +119,12 @@ export async function readWireLive(
   if (!result.ok) {
     // BL-032 Phase 5: record observed Inoreader status for /health
     // surfacing. Best-effort; doesn't affect the failure response shape.
-    await recordInoreaderStatus(env, 'degraded', `wire:${result.reason}`);
+    await recordInoreaderStatus(env, 'degraded', source, `wire:${result.reason}`);
     return mapFailure(result);
   }
 
   // BL-032 Phase 5: record OK status so /health reflects fresh signal.
-  await recordInoreaderStatus(env, 'ok', 'wire');
+  await recordInoreaderStatus(env, 'ok', source, 'wire');
 
   const items: SnapshotItem[] = [];
   for (const item of result.data.items) {
@@ -138,12 +149,15 @@ export async function readWireLive(
  *
  * `opts.forceRefresh`: skip the cache lookup and always fetch from Inoreader.
  * Used by the BL-032.5 Phase 4 Worker Cron.
+ *
+ * `opts.source`: see `readWireLive` docstring.
  */
 export async function readFyiLive(
   env: Env,
   count: number = 30,
-  opts: { forceRefresh?: boolean } = {}
+  opts: { forceRefresh?: boolean; source?: InoreaderObservedSource } = {}
 ): Promise<LiveTierResult> {
+  const source: InoreaderObservedSource = opts.source ?? 'live-tool';
   const cache = createCacheStore(env);
   if (cache && !opts.forceRefresh) {
     const cached = await cache.get<CachedTier>(CACHE_KEY_FYI);
@@ -157,11 +171,11 @@ export async function readFyiLive(
 
   const result = await fetchAnnotatedItems(env, count);
   if (!result.ok) {
-    await recordInoreaderStatus(env, 'degraded', `fyi:${result.reason}`);
+    await recordInoreaderStatus(env, 'degraded', source, `fyi:${result.reason}`);
     return mapFailure(result);
   }
 
-  await recordInoreaderStatus(env, 'ok', 'fyi');
+  await recordInoreaderStatus(env, 'ok', source, 'fyi');
 
   const items: SnapshotItem[] = [];
   for (const item of result.data.items) {

--- a/mcp-server/src/cron/radar-refresh.ts
+++ b/mcp-server/src/cron/radar-refresh.ts
@@ -216,8 +216,8 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
 
   try {
     const [wire, fyi] = await Promise.all([
-      readWireLive(env, { forceRefresh: true }),
-      readFyiLive(env, 30, { forceRefresh: true }),
+      readWireLive(env, { forceRefresh: true, source: 'cron' }),
+      readFyiLive(env, 30, { forceRefresh: true, source: 'cron' }),
     ]);
 
     // T.Z.1 (BL-032.7) — only count Inoreader calls that actually

--- a/mcp-server/src/observability/health.ts
+++ b/mcp-server/src/observability/health.ts
@@ -4,15 +4,28 @@
  * Response shape:
  *
  *   {
- *     ok:                 boolean,
- *     version:            string,            // mcp-server package version
- *     gitSha:             string,            // deploy-time injected; 'unknown' locally
- *     phase:              string,
- *     upstashMcp:         'ok' | 'degraded', // can we reach the MCP DB?
- *     upstashInoreader:   'ok' | 'degraded', // can we reach the Inoreader DB?
- *     inoreader:          'ok' | 'degraded' | 'unknown',  // last observed Inoreader API response
- *     inoreaderObservedAt:string | null,
+ *     ok:                          boolean,
+ *     version:                     string,            // mcp-server package version
+ *     gitSha:                      string,            // deploy-time injected; 'unknown' locally
+ *     phase:                       string,
+ *     upstashMcp:                  'ok' | 'degraded', // can we reach the MCP DB?
+ *     upstashInoreader:            'ok' | 'degraded', // can we reach the Inoreader DB?
+ *     inoreader:                   'ok' | 'degraded' | 'unknown',  // last observed Inoreader API response
+ *     inoreaderObservedAt:         string | null,
+ *     inoreaderObservedSecondsAgo: number | null,     // age of the observation; null when none
+ *     inoreaderObservedSource:     'cron' | 'live-tool' | null,
+ *     radarSnapshotAgeSeconds:     number | null,
  *   }
+ *
+ * **Stale-while-OK semantics for `inoreader`** (2026-05-19): the
+ * `mcp:inoreader:last-status` key persists indefinitely — the most
+ * recent observation is always returned. `inoreaderObservedSecondsAgo`
+ * surfaces freshness so readers (this endpoint's consumers, dashboards,
+ * operators) compute their own staleness threshold. Previous version
+ * had a 5-minute TTL on the key, which meant `inoreader: 'unknown'`
+ * ~98% of the time because the 6h cron cadence was the dominant
+ * Inoreader-call source and 5 minutes ≪ 6 hours. See inoreader-status.ts
+ * docstring for the full rationale.
  *
  * **Two Upstash subsystems** (Q13 / Path 2): the Worker accesses two
  * separate databases — the website-shared Inoreader DB (Read-Only token,
@@ -34,7 +47,11 @@
  * actual 5xx from /health pages oncall.
  */
 
-import { readInoreaderStatus, type InoreaderStatus } from './inoreader-status';
+import {
+  readInoreaderStatus,
+  type InoreaderStatus,
+  type InoreaderObservedSource,
+} from './inoreader-status';
 import { createInoreaderClient, createMcpClient } from '../lib/upstash-clients';
 import type { Env } from '../worker';
 
@@ -52,6 +69,22 @@ interface HealthResponse {
   upstashInoreader: 'ok' | 'degraded';
   inoreader: InoreaderStatus;
   inoreaderObservedAt: string | null;
+  /**
+   * Age of the last Inoreader observation in seconds. `null` when no
+   * observation has been recorded (cold start, pre-first-cron). Readers
+   * use this to decide whether the `inoreader` status is fresh enough
+   * to act on: an `'ok'` from 12h ago means the cron has missed at
+   * least one firing, regardless of what the static field says.
+   */
+  inoreaderObservedSecondsAgo: number | null;
+  /**
+   * Source of the last observation — `'cron'` for cron-triggered
+   * refreshes, `'live-tool'` for MCP tool / `/radar/snapshot` calls.
+   * Diagnostically useful: if every recent observation is `'cron'`,
+   * no human is actively using the MCP surface. `null` for entries
+   * written by pre-2026-05-19 code (the field is back-compat optional).
+   */
+  inoreaderObservedSource: InoreaderObservedSource | null;
   /**
    * Age of the FYI radar snapshot in seconds (BL-032.5 Phase 4). `null` when
    * the snapshot has never been populated or when MCP DB is unreachable.
@@ -172,6 +205,8 @@ export async function buildHealthPayload(env: Env): Promise<HealthResponse> {
     upstashInoreader,
     inoreader: inoreader.status,
     inoreaderObservedAt: inoreader.observedAt,
+    inoreaderObservedSecondsAgo: inoreader.observedSecondsAgo,
+    inoreaderObservedSource: inoreader.source,
     radarSnapshotAgeSeconds,
   };
 }

--- a/mcp-server/src/observability/inoreader-status.ts
+++ b/mcp-server/src/observability/inoreader-status.ts
@@ -5,22 +5,28 @@
  * on every probe to confirm liveness. Health endpoints get hammered by
  * uptime monitors — the BACKLOG calls out this exact failure mode. So
  * we instead **cache the last observed Inoreader response status** in
- * Upstash with a short TTL. The radar-live tools' real Inoreader calls
- * write to this key; the health endpoint just reads it.
+ * Upstash. The radar-live tools' real Inoreader calls write to this key;
+ * the health endpoint just reads it.
  *
  * Status semantics:
- *   - `'ok'`        — last Inoreader call within the TTL window was 2xx
+ *   - `'ok'`        — last Inoreader call was 2xx
  *   - `'degraded'`  — last Inoreader call returned 429 / 5xx / timed out
- *   - `'unknown'`   — no recent radar-live call (TTL expired, or Worker
- *                     hasn't served any radar request since cold start)
+ *   - `'unknown'`   — no Inoreader call has been observed yet (cold start,
+ *                     pre-first-cron) or the entry is unreadable
  *
- * `'unknown'` is **not a failure** — it's a literal "we don't know yet."
- * The health endpoint reports it as such so dashboards can distinguish
- * "Inoreader is broken" from "no traffic yet to test against."
+ * **Stale-while-OK semantics** (2026-05-19): the key has no TTL — the
+ * most recent observation persists indefinitely. The `observedAt`
+ * timestamp is the truth; readers (health endpoint, operator, dashboards)
+ * compute their own staleness threshold. This replaced the original
+ * 5-minute TTL because the 6h cron cadence + cache-only website traffic
+ * meant the key was expired ~98% of the time — `/health` reported
+ * `'unknown'` continuously between cron firings, regardless of whether
+ * Inoreader was actually healthy.
  *
- * **TTL**: 5 minutes. Long enough that radar-tool traffic keeps the flag
- * fresh under normal load; short enough that a stale flag doesn't mask a
- * sudden Inoreader degradation for too long.
+ * **Source field**: each entry records whether the observation came from
+ * the cron path or from a live MCP tool call. Diagnostically useful for
+ * "is anyone actively using this server?" — if every observation for
+ * weeks is `source: 'cron'`, no human has triggered an MCP tool call.
  *
  * **Storage location**: despite the `inoreader` in the file name, the
  * `mcp:inoreader:last-status` key is Worker-observed state about Inoreader's
@@ -32,13 +38,14 @@ import { createMcpClient } from '../lib/upstash-clients';
 import type { Env } from '../worker';
 
 const STATUS_KEY = 'mcp:inoreader:last-status';
-const STATUS_TTL_SECONDS = 5 * 60;
 
 export type InoreaderStatus = 'ok' | 'degraded' | 'unknown';
+export type InoreaderObservedSource = 'cron' | 'live-tool';
 
 interface StatusEntry {
   readonly status: 'ok' | 'degraded';
   readonly observedAt: string;
+  readonly source: InoreaderObservedSource;
   /** Optional context — error code on degraded; method name on ok. */
   readonly note?: string;
 }
@@ -47,8 +54,12 @@ interface StatusEntry {
  * Record the last observed Inoreader status. Called from the radar-live
  * tools after each Inoreader call:
  *
- *   - on `ok` (2xx response with parsed body): `recordInoreaderStatus(env, 'ok')`
- *   - on `degraded` (429 / 5xx / timeout / token-stale): `recordInoreaderStatus(env, 'degraded', reason)`
+ *   - on `ok` (2xx response with parsed body): `recordInoreaderStatus(env, 'ok', source)`
+ *   - on `degraded` (429 / 5xx / timeout / token-stale): `recordInoreaderStatus(env, 'degraded', source, reason)`
+ *
+ * `source` distinguishes cron-triggered observations from live-MCP-tool
+ * observations. Operators reading `/health` use this to tell "the cron
+ * is the only thing exercising Inoreader" from "active client traffic."
  *
  * Best-effort write — Upstash failures are swallowed (caller proceeds).
  * No-op when Upstash creds aren't bound.
@@ -56,6 +67,7 @@ interface StatusEntry {
 export async function recordInoreaderStatus(
   env: Env,
   status: 'ok' | 'degraded',
+  source: InoreaderObservedSource,
   note?: string
 ): Promise<void> {
   const redis = createMcpClient(env);
@@ -64,11 +76,15 @@ export async function recordInoreaderStatus(
   const entry: StatusEntry = {
     status,
     observedAt: new Date().toISOString(),
+    source,
     note,
   };
 
   try {
-    await redis.set(STATUS_KEY, JSON.stringify(entry), { ex: STATUS_TTL_SECONDS });
+    // No TTL — the most recent observation persists indefinitely. See
+    // the "Stale-while-OK semantics" section in the module-level docstring
+    // for the rationale.
+    await redis.set(STATUS_KEY, JSON.stringify(entry));
   } catch {
     // Best-effort. Status reporting is observability, not auth — degraded
     // Upstash shouldn't fail user requests.
@@ -77,30 +93,66 @@ export async function recordInoreaderStatus(
 
 /**
  * Read the cached Inoreader status. Returns `'unknown'` when no entry
- * exists (TTL expired or never written) OR when Upstash is unreachable.
- * Also returns the timestamp of the last observation so the health
- * endpoint can surface its age.
+ * exists (never written) OR when Upstash is unreachable. Includes the
+ * timestamp of the last observation (`observedAt`), its age in seconds
+ * (`observedSecondsAgo`), and the source of that observation so the
+ * health endpoint can surface them.
+ *
+ * Backwards-compatible with entries written by the pre-2026-05-19 code
+ * path (which lacked the `source` field): those reads return
+ * `source: null` and otherwise behave normally. The next refresh
+ * upgrades the entry to the new shape.
  */
 export async function readInoreaderStatus(env: Env): Promise<{
   status: InoreaderStatus;
   observedAt: string | null;
+  observedSecondsAgo: number | null;
+  source: InoreaderObservedSource | null;
   note: string | null;
 }> {
   const redis = createMcpClient(env);
-  if (!redis) return { status: 'unknown', observedAt: null, note: null };
+  if (!redis) {
+    return {
+      status: 'unknown',
+      observedAt: null,
+      observedSecondsAgo: null,
+      source: null,
+      note: null,
+    };
+  }
 
   try {
     // Upstash auto-parses JSON values stored via redis.set(JSON.stringify(...)).
     // Handle both shapes (parsed object OR raw string).
     const raw = await redis.get<StatusEntry | string | null>(STATUS_KEY);
-    if (raw == null) return { status: 'unknown', observedAt: null, note: null };
+    if (raw == null) {
+      return {
+        status: 'unknown',
+        observedAt: null,
+        observedSecondsAgo: null,
+        source: null,
+        note: null,
+      };
+    }
     const entry: StatusEntry = typeof raw === 'string' ? (JSON.parse(raw) as StatusEntry) : raw;
+    const observedAtMs = new Date(entry.observedAt).getTime();
+    const observedSecondsAgo = Number.isFinite(observedAtMs)
+      ? Math.max(0, Math.floor((Date.now() - observedAtMs) / 1000))
+      : null;
     return {
       status: entry.status,
       observedAt: entry.observedAt,
+      observedSecondsAgo,
+      source: entry.source ?? null,
       note: entry.note ?? null,
     };
   } catch {
-    return { status: 'unknown', observedAt: null, note: null };
+    return {
+      status: 'unknown',
+      observedAt: null,
+      observedSecondsAgo: null,
+      source: null,
+      note: null,
+    };
   }
 }

--- a/mcp-server/tests/unit/cron/radar-refresh.test.ts
+++ b/mcp-server/tests/unit/cron/radar-refresh.test.ts
@@ -248,8 +248,8 @@ describe('refreshRadarSnapshot — success path', () => {
     const outcome = await refreshRadarSnapshot(env);
 
     expect(outcome).toEqual({ kind: 'success', wireItems: 3, fyiItems: 1, callsConsumed: 6 });
-    expect(mockReadWireLive).toHaveBeenCalledWith(env, { forceRefresh: true });
-    expect(mockReadFyiLive).toHaveBeenCalledWith(env, 30, { forceRefresh: true });
+    expect(mockReadWireLive).toHaveBeenCalledWith(env, { forceRefresh: true, source: 'cron' });
+    expect(mockReadFyiLive).toHaveBeenCalledWith(env, 30, { forceRefresh: true, source: 'cron' });
     expect(mockCaptureMessage).toHaveBeenCalledWith(
       'cron.radar-refresh.success',
       'info',

--- a/mcp-server/tests/unit/health.test.ts
+++ b/mcp-server/tests/unit/health.test.ts
@@ -46,7 +46,12 @@ describe('buildHealthPayload', () => {
       if (key === 'mcp:health:probe') return null; // probe just needs to NOT throw
       if (key === 'inoreader:access_token') return 'redacted-token-not-leaked'; // value discarded
       if (key === 'mcp:inoreader:last-status') {
-        return { status: 'ok', observedAt: '2026-05-04T18:00:00.000Z', note: 'wire' };
+        return {
+          status: 'ok',
+          observedAt: '2026-05-04T18:00:00.000Z',
+          source: 'cron',
+          note: 'wire',
+        };
       }
       return null;
     });
@@ -58,6 +63,7 @@ describe('buildHealthPayload', () => {
     expect(payload.upstashInoreader).toBe('ok');
     expect(payload.inoreader).toBe('ok');
     expect(payload.inoreaderObservedAt).toBe('2026-05-04T18:00:00.000Z');
+    expect(payload.inoreaderObservedSource).toBe('cron');
     expect(payload.version).toMatch(/^0\.[0-9]+\.[0-9]+$/);
     expect(payload.phase).toContain('BL-032 Phase 5');
   });
@@ -117,6 +123,7 @@ describe('buildHealthPayload', () => {
         return {
           status: 'degraded',
           observedAt: '2026-05-04T18:00:00.000Z',
+          source: 'live-tool',
           note: 'fyi:inoreader-rate-limit',
         };
       }
@@ -129,6 +136,7 @@ describe('buildHealthPayload', () => {
     expect(payload.upstashMcp).toBe('ok');
     expect(payload.upstashInoreader).toBe('ok');
     expect(payload.inoreader).toBe('degraded');
+    expect(payload.inoreaderObservedSource).toBe('live-tool');
   });
 
   it('returns ok:true when inoreader API is unknown but both DBs are fine — unknown is not degraded', async () => {
@@ -235,6 +243,87 @@ describe('buildHealthPayload', () => {
     const payload = await buildHealthPayload(baseEnv);
 
     expect(payload.gitSha).toBe('unknown');
+  });
+
+  // Added 2026-05-19: the inoreader-status entry now persists without
+  // TTL, and exposes both an observedSecondsAgo and an observedSource.
+  // These tests pin the surface of the new fields.
+  describe('inoreaderObservedSecondsAgo + inoreaderObservedSource (stale-while-OK)', () => {
+    it('computes observedSecondsAgo from the entry observedAt timestamp', async () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      redisGet.mockImplementation(async (key: string) => {
+        if (key === 'mcp:health:probe') return null;
+        if (key === 'inoreader:access_token') return 'token';
+        if (key === 'mcp:inoreader:last-status') {
+          return { status: 'ok', observedAt: twoHoursAgo, source: 'cron', note: 'wire' };
+        }
+        return null;
+      });
+
+      const payload = await buildHealthPayload(baseEnv);
+
+      // ~7200 seconds; allow ±5s for wall-clock drift during the test.
+      expect(payload.inoreaderObservedSecondsAgo).toBeGreaterThanOrEqual(7195);
+      expect(payload.inoreaderObservedSecondsAgo).toBeLessThanOrEqual(7205);
+      expect(payload.inoreaderObservedSource).toBe('cron');
+    });
+
+    it('surfaces source: "live-tool" when the observation came from a live MCP call', async () => {
+      redisGet.mockImplementation(async (key: string) => {
+        if (key === 'mcp:health:probe') return null;
+        if (key === 'inoreader:access_token') return 'token';
+        if (key === 'mcp:inoreader:last-status') {
+          return {
+            status: 'ok',
+            observedAt: new Date().toISOString(),
+            source: 'live-tool',
+            note: 'wire',
+          };
+        }
+        return null;
+      });
+
+      const payload = await buildHealthPayload(baseEnv);
+      expect(payload.inoreaderObservedSource).toBe('live-tool');
+    });
+
+    it('returns observedSecondsAgo: null and observedSource: null when no entry exists', async () => {
+      redisGet.mockImplementation(async (key: string) => {
+        if (key === 'mcp:health:probe') return null;
+        if (key === 'inoreader:access_token') return 'token';
+        if (key === 'mcp:inoreader:last-status') return null;
+        return null;
+      });
+
+      const payload = await buildHealthPayload(baseEnv);
+      expect(payload.inoreader).toBe('unknown');
+      expect(payload.inoreaderObservedAt).toBeNull();
+      expect(payload.inoreaderObservedSecondsAgo).toBeNull();
+      expect(payload.inoreaderObservedSource).toBeNull();
+    });
+
+    // Back-compat: entries written by the pre-2026-05-19 code path didn't
+    // include the `source` field. Reads of those entries must not crash
+    // and must surface `source: null` to the operator (rather than
+    // pretending the source is known). The next successful refresh
+    // upgrades the entry to the new shape.
+    it('handles pre-2026-05-19 entries without a source field (source: null)', async () => {
+      redisGet.mockImplementation(async (key: string) => {
+        if (key === 'mcp:health:probe') return null;
+        if (key === 'inoreader:access_token') return 'token';
+        if (key === 'mcp:inoreader:last-status') {
+          // Old entry shape — no `source` field.
+          return { status: 'ok', observedAt: '2026-05-18T18:00:00.000Z', note: 'wire' };
+        }
+        return null;
+      });
+
+      const payload = await buildHealthPayload(baseEnv);
+      expect(payload.inoreader).toBe('ok');
+      expect(payload.inoreaderObservedAt).toBe('2026-05-18T18:00:00.000Z');
+      expect(payload.inoreaderObservedSecondsAgo).toBeGreaterThan(0);
+      expect(payload.inoreaderObservedSource).toBeNull();
+    });
   });
 
   describe('radarSnapshotAgeSeconds (BL-032.5 Phase 4)', () => {


### PR DESCRIPTION
## Summary

Fixes /health reporting `inoreader: 'unknown'` and `inoreaderObservedAt: null` ~98% of the time, even though Inoreader is healthy and the cron is firing on cadence. Surfaced at BL-032.8 Phase B soak Day 3 (2026-05-19) right after PR #150 (Sentry-flush). Same soak-window logic: the soak surfaces production issues and the soak resolves them.

## The bug

`mcp:inoreader:last-status` had a **5-minute TTL**. The original design assumed continuous MCP-tool traffic would keep the key warm. Post-BL-032.8-Phase-A the website (highest-volume consumer) only reads cached snapshots — it never refreshes the key. So:

- 06:00 UTC: cron fires → key written → TTL starts
- 06:05 UTC: key expires
- 06:05 → 12:00 UTC: 5h 55m of \"unknown\"
- 12:00 UTC: cron fires → key rewritten → 5min later expires again

Net: `inoreader: 'unknown'` for **~98% of every 6h interval**. Field provided no useful signal.

## The fix

**Stale-while-OK semantics**. The key persists indefinitely; `observedAt` is the truth, and readers compute their own staleness threshold.

### New response shape

```jsonc
{
  \"inoreader\": \"ok\",                                   // always populated post-first-cron
  \"inoreaderObservedAt\": \"2026-05-19T12:00:42.123Z\",   // always populated post-first-cron
  \"inoreaderObservedSecondsAgo\": 14624,                // NEW — explicit freshness
  \"inoreaderObservedSource\": \"cron\"                    // NEW — \"cron\" | \"live-tool\" | null
  // ... other fields unchanged
}
```

### Operator interpretation

| Combination                                                | Meaning                                    |
| ---------------------------------------------------------- | ------------------------------------------ |
| `inoreader='ok'` + `<7h` + `source='cron'`                 | Cron firing on schedule, Inoreader healthy at last firing ✓ |
| `inoreader='ok'` + `<5min` + `source='live-tool'`          | Active MCP traffic, Inoreader healthy ✓    |
| `inoreader='degraded'` + recent `observedAt`               | Live trouble signal; check Sentry           |
| `inoreader='ok'` + `>8h`                                   | Cron has missed at least one firing 🚨     |

Plus: if every observation for weeks shows `source: 'cron'`, no human has triggered an MCP tool call. That's a real product signal for BL-033 (pilot clients).

## Code changes

- [`mcp-server/src/observability/inoreader-status.ts`](mcp-server/src/observability/inoreader-status.ts): remove TTL, add `source` field to `StatusEntry`, extend `readInoreaderStatus` return shape with `observedSecondsAgo` + `source`. Backwards-compat for pre-2026-05-19 entries without `source` (returns `null`).
- [`mcp-server/src/content/radar-live-store.ts`](mcp-server/src/content/radar-live-store.ts): `readWireLive` / `readFyiLive` accept `opts.source` (default `'live-tool'`); forward to `recordInoreaderStatus`.
- [`mcp-server/src/cron/radar-refresh.ts`](mcp-server/src/cron/radar-refresh.ts): pass `source: 'cron'` to readWireLive + readFyiLive.
- [`mcp-server/src/observability/health.ts`](mcp-server/src/observability/health.ts): add `inoreaderObservedSecondsAgo` + `inoreaderObservedSource` to `HealthResponse`; surface them from `buildHealthPayload`.
- Live-tool callers (`worker.ts` /radar/snapshot, `tools/radar-live.ts`, `content/radar-snapshot-reader-worker.ts`) unchanged — default `'live-tool'` applies.

## Test plan

- [x] **613/613** MCP tests pass (4 new unit tests in `health.test.ts` covering `observedSecondsAgo` computation, live-tool source surface, null-when-no-entry, and backwards-compat for pre-2026-05-19 entries)
- [x] Existing cron unit test updated to assert the new `opts` shape (`source: 'cron'`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean at workspace root
- [ ] CI green on this PR
- [ ] **Post-deploy verification** (operator after merge): deploy staging + production Worker; hit `/health` and verify `inoreader: 'ok'` + `inoreaderObservedSource: 'cron'` + `inoreaderObservedSecondsAgo` is a small number (last cron); wait 6h+, hit `/health` again, confirm `inoreader: 'ok'` is **still** there (no longer flips to 'unknown' between cron firings)

## Backwards compatibility

The runtime read path handles entries without the `source` field (returns `source: null`). After deploy, the next cron firing writes the new shape and the field becomes populated. No DB migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)