### PR TITLE
fix(mcp-cron): wrap scheduled handler in Sentry.withMonitor + missing catch (silent-cron-errors RCA)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -28,6 +28,42 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.3.12 — 2026-05-25 — scheduled handler: add missing `catch` + wrap in `Sentry.withMonitor` (cron failures now visible in Sentry)
+
+**Theme**: production showed 13 cron `outcome: exception` events on the Cloudflare dashboard in 24h while Sentry's Issues view showed zero corresponding events. Root cause: the scheduled handler's payload was `try { await refreshRadarSnapshot(env); } finally { await flushSentry(); }` — **no `catch` clause**. Exceptions escaped `ctx.waitUntil`'s promise without ever being captured by Sentry; `flushSentry` ran on an empty queue. `withSentry`'s auto-capture is anchored on the fetch handler's Response — scheduled handlers in `ctx.waitUntil` aren't covered.
+
+### Changed
+
+- **`worker.ts` scheduled handler** rewritten to mirror Sentry's reference `instrumentCron` pattern:
+  1. **`Sentry.withMonitor('radar-refresh', () => refreshRadarSnapshot(env), { schedule, … })`** — sends `in_progress` / `ok` / `error` check-ins to Sentry Crons. Auto-creates the monitor on first check-in via `upsertMonitorConfig`. Enables missed-firing alerts on the Sentry Crons dashboard.
+  2. **Outer `try/catch`** — `withMonitor` re-throws on callback rejection (only marks the check-in; does NOT call `captureException` itself). The catch calls `captureException` for the stack trace, then swallows so `ctx.waitUntil` resolves cleanly.
+  3. **`finally { await flushSentry() }`** — unchanged from the prior shape; documented in the original 4680028 commit (BL-032.8 Phase B soak Day 3).
+- **`observability/sentry.ts`** — re-exports `withMonitor` from `@sentry/cloudflare` with a docstring explaining the re-throw contract and the three-layer pattern the scheduled handler relies on. Future cron handlers should follow the same shape.
+- **`worker.ts`** now also exports `handler` as a named export so the scheduled-handler error path is directly testable. The default export (`withSentry(sentryOptions, handler)`) is unchanged.
+
+### Tests
+
+New regression suite at `mcp-server/tests/unit/worker-scheduled.test.ts` (6 cases) explicitly exercises:
+
+- `captureException` is called with the rejection AND the `{ source: 'cron.scheduled', cron }` context
+- `flushSentry` is always called (success + failure paths)
+- No `captureException` on the success path (no double-reporting)
+- No `captureException` when `refreshRadarSnapshot` returns a non-error envelope (e.g. `partial-both-failed`) — that path is already captured by the inner `captureMessage` call
+- `withMonitor` is invoked with the runtime `event.cron` (not a hardcoded constant), so a `wrangler.toml` schedule edit doesn't desync from Sentry's monitor config
+- **Load-bearing assertion**: `Promise.all(ctx.waitUntil promises).resolves` — if a future regression removes the catch, this test fails loudly because the IIFE's promise rejects.
+
+**Coverage gap closed**: prior to this commit, zero tests exercised `worker.ts`'s scheduled handler. The cron-handler suite (`tests/unit/cron/radar-refresh.test.ts`) covers `refreshRadarSnapshot` in isolation; it never asked "what does the worker do if `refreshRadarSnapshot` rejects?" That gap is why the 2026-05-25 incident wasn't caught by CI.
+
+### Why patch and not minor
+
+Bug fix to a tooling code path that was silently failing. No tool / prompt / URI surface change. No new dependencies. Operationally identical for any caller that doesn't read Sentry — the only behavior change is that Sentry now sees what Cloudflare's dashboard was reporting.
+
+**Operator semantics**: patch bump per the discipline. The first cron firing after deploy will auto-create the `radar-refresh` monitor on Sentry's Crons dashboard (Sentry Crons is available on all plans including Free, with a monthly check-in quota; the 4/day cadence is well within limits).
+
+**Architecture context**: 2026-05-25 incident RCA. Impartial-agent review confirmed the diagnosis and recommended `withMonitor` as the proper structural fix (vs. the interim "just add a catch" patch I'd initially considered) since it bundles the catch + the Sentry Crons check-in + missed-firing alerts in one wrapper designed for the scheduled-handler shape. The 4680028 commit (BL-032.8 Phase B soak Day 3) explicitly flagged this approach as "strictly better long-term shape" and punted; this incident is the trigger that took it off the punt list.
+
+---
+
 ## 0.3.11 — 2026-05-25 — stdio binary `createRequire` banner shim (unblocks `xlsx-js-style` runtime startup)
 
 **Theme**: surfaced by CI on PR #162 (2026-05-25). The "Smoke test compiled binary" step (`node mcp-server/dist/index.js < /dev/null`) failed with:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/observability/sentry.ts
+++ b/mcp-server/src/observability/sentry.ts
@@ -185,3 +185,39 @@ export async function flushSentry(timeoutMs = 2000): Promise<boolean> {
 // Re-export `withSentry` so worker.ts has a single import surface for
 // observability rather than reaching into @sentry/cloudflare directly.
 export { withSentry } from '@sentry/cloudflare';
+
+/**
+ * Re-export of Sentry's `withMonitor` — the cron-monitoring wrapper that
+ * sends `in_progress` / `ok` / `error` check-ins to Sentry Crons.
+ *
+ * **Critical behavior** (from `@sentry/core` source, verified 2026-05-25):
+ * `withMonitor` finishes the check-in with the matching status on
+ * callback resolution / rejection AND **re-throws** any rejection. It
+ * does NOT call `captureException` itself. To capture the stack trace,
+ * callers must layer an outer try/catch that calls `captureException`
+ * on the re-thrown error. The reference `instrumentCron` implementation
+ * in `@sentry/node-core/src/cron/cron.ts` follows exactly this pattern.
+ *
+ * **Why this matters for the GST scheduled handler**: missing this
+ * outer catch was the load-bearing cause of the 2026-05-25 incident
+ * where Cloudflare reported `outcome: exception` on cron firings but
+ * Sentry had zero corresponding events. The scheduled handler had a
+ * `try { … } finally { … }` shape with no `catch` — exceptions escaped
+ * `ctx.waitUntil` without ever being captured by Sentry.
+ *
+ * Pattern shape (canonical, mirrors Sentry's own instrumentCron):
+ *
+ *   try {
+ *     await withMonitor('radar-refresh', () => doWork(), { schedule: … });
+ *   } catch (err) {
+ *     captureException(err, { source: 'cron.scheduled' });
+ *   } finally {
+ *     await flushSentry();
+ *   }
+ *
+ * Free-plan note: Sentry Crons is available on all plans with a monthly
+ * check-in quota. The `upsertMonitorConfig` parameter (passed by
+ * including `schedule` in the options) auto-creates the monitor on
+ * first check-in, so no manual setup is required.
+ */
+export { withMonitor } from '@sentry/cloudflare';

--- a/mcp-server/src/worker.ts
+++ b/mcp-server/src/worker.ts
@@ -37,10 +37,12 @@ import { hasScope } from './auth/scopes';
 import { createLimiter } from './ratelimit/limiter';
 import { tooManyRequestsResponse, withRateLimitHeaders } from './ratelimit/headers';
 import {
+  captureException,
   captureMessage,
   flushSentry,
   sentryOptions,
   tagRequest,
+  withMonitor,
   withSentry,
 } from './observability/sentry';
 import { buildHealthPayload } from './observability/health';
@@ -151,32 +153,76 @@ function isRoutedPath(pathname: string): boolean {
   return false;
 }
 
-const handler: ExportedHandler<Env> = {
+// Exported for direct unit-testing of the scheduled handler's error-capture
+// path (see `tests/unit/worker-scheduled.test.ts`). The default export
+// remains the canonical wrangler entrypoint (withSentry-wrapped, below).
+export const handler: ExportedHandler<Env> = {
   /**
-   * Hourly Cron handler (BL-032.5 Phase 4). Refreshes the Upstash radar
-   * snapshot cache so MCP Resource consumers see snapshots that are at
-   * most 60 minutes stale, independent of read traffic. Budget guards
-   * (circuit breaker + daily soft cap) live inside `refreshRadarSnapshot`;
-   * we just delegate here. The scheduled handler has no response surface
-   * — return value is ignored by Cloudflare.
+   * Cron handler — refreshes the Upstash radar snapshot cache every 6h so
+   * MCP Resource consumers see snapshots that are at most ~6h stale,
+   * independent of read traffic. Budget guards (circuit breaker + daily
+   * soft cap) live inside `refreshRadarSnapshot`; we just delegate here.
+   * The scheduled handler has no response surface — return value is
+   * ignored by Cloudflare.
    *
-   * The `try { … } finally { await flushSentry() }` shape exists because
-   * `captureMessage` events emitted from cron paths (`cron.radar-refresh.*`)
-   * race against Cloudflare reclaiming the isolate once the scheduled
-   * handler returns. `withSentry` auto-flushes for the fetch handler
-   * because it can anchor against the returned Response, but the
-   * scheduled handler has no Response — so the SDK's in-memory queue
-   * gets killed mid-POST and events are lost. Observed dropping ~75% of
-   * Sentry capture during BL-032.8 Phase B soak Day 3 even though
-   * Cloudflare's cron event log showed all 4/4 daily firings succeeding.
-   * The single `ctx.waitUntil` (vs two separate `waitUntil` calls) keeps
-   * the flush ordered AFTER the captures it's draining.
+   * **Three-layer Sentry instrumentation** (mirrors Sentry's reference
+   * `instrumentCron` pattern; verified against `@sentry/node-core/src/
+   * cron/cron.ts`):
+   *
+   *   1. `withMonitor('radar-refresh', …)` — sends `in_progress` / `ok`
+   *      / `error` check-ins to Sentry Crons. Auto-creates the monitor
+   *      on first check-in via `upsertMonitorConfig` (the `schedule`
+   *      field). Sentry surfaces missed firings + sustained-failure
+   *      alerts on its Crons dashboard.
+   *   2. **Outer `try/catch`** — `withMonitor` re-throws on callback
+   *      rejection (it only marks the check-in; it does NOT call
+   *      `captureException`). Without an outer catch, the rejection
+   *      escapes `ctx.waitUntil` and Cloudflare reports
+   *      `outcome: exception` with zero Sentry signal. The catch calls
+   *      `captureException` for the stack trace and then swallows so
+   *      `ctx.waitUntil`'s promise resolves cleanly.
+   *   3. **`finally { await flushSentry() }`** — `withSentry` auto-
+   *      flushes for the fetch handler (anchored on the Response), but
+   *      the scheduled handler has no Response. Without an explicit
+   *      flush, in-flight Sentry POSTs get killed mid-flight when
+   *      Cloudflare reclaims the isolate. Observed dropping ~75% of
+   *      cron capture during BL-032.8 Phase B soak Day 3 (commit
+   *      4680028, 2026-05-19) — that fix landed the flush; this fix
+   *      lands the catch.
+   *
+   * Bug history (resolves 2026-05-25 incident): Cloudflare dashboard
+   * showed 13 cron `outcome: exception` events in 24h. Sentry's Issues
+   * view showed zero corresponding events. Root cause: the prior shape
+   * had `try { … } finally { … }` with no `catch` clause — exceptions
+   * thrown by `refreshRadarSnapshot` propagated past the IIFE, past
+   * `ctx.waitUntil`'s promise, into Cloudflare's runtime. The `finally`
+   * ran flushSentry but the SDK queue was empty (no capture had been
+   * made), so Sentry never saw the error. See
+   * `mcp-server/BREAKING_CHANGES.md` 0.3.12 for full context.
    */
-  async scheduled(_event, env, ctx): Promise<void> {
+  async scheduled(event, env, ctx): Promise<void> {
     ctx.waitUntil(
       (async () => {
         try {
-          await refreshRadarSnapshot(env);
+          // Sentry Crons check-in + monitor auto-upsert. The cron expression
+          // here MUST match wrangler.toml's `[triggers] crons` entry — if it
+          // drifts, Sentry's missed-firing alerts use the wrong baseline.
+          // `event.cron` is the source of truth at runtime; we pass it
+          // through rather than hardcoding so a wrangler.toml schedule edit
+          // doesn't silently break the monitor.
+          await withMonitor('radar-refresh', () => refreshRadarSnapshot(env), {
+            schedule: { type: 'crontab', value: event.cron },
+            checkinMargin: 5,
+            maxRuntime: 10,
+            timezone: 'UTC',
+          });
+        } catch (err) {
+          // `withMonitor` marked the check-in as `error` and re-threw.
+          // Capture here so the stack trace reaches Sentry, then swallow
+          // so `ctx.waitUntil` sees a clean resolution (Cloudflare's
+          // outcome stays `ok` — the canonical failure signal moves to
+          // the Sentry Crons dashboard).
+          captureException(err, { source: 'cron.scheduled', cron: event.cron });
         } finally {
           await flushSentry();
         }

--- a/mcp-server/tests/unit/worker-scheduled.test.ts
+++ b/mcp-server/tests/unit/worker-scheduled.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression test for the scheduled handler's Sentry error-capture path.
+ *
+ * Background (2026-05-25 incident): Cloudflare's dashboard reported 13
+ * cron `outcome: exception` events in 24h while Sentry's Issues view
+ * showed zero corresponding events. Root cause: the prior shape of
+ * `worker.ts:scheduled` was `try { … } finally { … }` with no `catch` —
+ * exceptions thrown by `refreshRadarSnapshot` (or its dependencies)
+ * escaped `ctx.waitUntil`'s promise without ever being captured by
+ * Sentry. The current implementation wraps the cron in `withMonitor`
+ * (Sentry Crons check-in) and adds an outer `catch` that calls
+ * `captureException` for the stack trace.
+ *
+ * This test exists because:
+ *   1. No existing test exercised the scheduled handler at all — the
+ *      cron-handler suite (`tests/unit/cron/radar-refresh.test.ts`)
+ *      covers `refreshRadarSnapshot` in isolation; it never asked
+ *      "what does the worker do if refreshRadarSnapshot rejects?"
+ *   2. Two future regressions are possible: someone removes the catch
+ *      (returns to the silent-Sentry state) OR someone changes the
+ *      withMonitor invocation in a way that breaks the re-throw
+ *      contract this code relies on. Both must fail this test loudly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `@sentry/cloudflare` + `agents/mcp` use the `cloudflare:workers` URL
+// scheme internally — Node's default ESM loader rejects it. Mock both at
+// the package boundary so importing worker.ts doesn't crash. (Same
+// pattern as `tests/integration/radar-snapshot-endpoint.test.ts`.)
+vi.mock('@sentry/cloudflare', () => ({
+  init: vi.fn(),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  setTag: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
+  withMonitor: vi.fn(),
+  withSentry: <T>(_opts: unknown, handler: T) => handler,
+}));
+vi.mock('agents/mcp', () => ({
+  createMcpHandler: () => async () =>
+    new Response('{"error":"mcp-mocked-in-this-test"}', { status: 501 }),
+}));
+
+// Stub the observability + cron modules so the handler picks up mockable
+// versions of our own wrappers (the @sentry/cloudflare mock above
+// satisfies sentry.ts's own imports during module load).
+vi.mock('../../src/cron/radar-refresh');
+vi.mock('../../src/observability/sentry', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  flushSentry: vi.fn().mockResolvedValue(true),
+  sentryOptions: vi.fn().mockReturnValue(undefined),
+  tagRequest: vi.fn(),
+  withMonitor: vi.fn(),
+  withSentry: <T>(_opts: unknown, h: T) => h, // pass-through wrap for the default export
+}));
+
+// Imports MUST come after vi.mock so the mocked modules are wired in.
+import { handler } from '../../src/worker';
+import * as sentry from '../../src/observability/sentry';
+import * as cron from '../../src/cron/radar-refresh';
+import type { Env } from '../../src/worker';
+
+const FAKE_ENV = {} as Env;
+const FAKE_CRON = '0 */6 * * *';
+
+function makeScheduledEvent(): ScheduledController {
+  return {
+    cron: FAKE_CRON,
+    scheduledTime: Date.now(),
+    type: 'scheduled',
+    noRetry: () => {},
+  } as unknown as ScheduledController;
+}
+
+function makeCtx(): { ctx: ExecutionContext; waitUntilPromises: Promise<unknown>[] } {
+  const waitUntilPromises: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => {
+      waitUntilPromises.push(p);
+    },
+    passThroughOnException: () => {},
+    props: {},
+  } as unknown as ExecutionContext;
+  return { ctx, waitUntilPromises };
+}
+
+describe('worker.ts scheduled handler — Sentry error capture (2026-05-25 regression)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default: withMonitor is a pass-through that runs its callback verbatim.
+    // Individual tests override this to simulate Sentry's re-throw behavior.
+    vi.mocked(sentry.withMonitor).mockImplementation(async (_slug: string, cb: () => unknown) =>
+      cb()
+    );
+    vi.mocked(sentry.flushSentry).mockResolvedValue(true);
+  });
+
+  it('captures the exception via captureException when refreshRadarSnapshot rejects', async () => {
+    const inoreaderError = new Error('Inoreader 503 Service Unavailable');
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(inoreaderError);
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(sentry.captureException).toHaveBeenCalledWith(inoreaderError, {
+      source: 'cron.scheduled',
+      cron: FAKE_CRON,
+    });
+  });
+
+  it('always calls flushSentry, even on failure', async () => {
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('upstream failure'));
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(sentry.flushSentry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT capture exception on the success path', async () => {
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 5,
+      fyiItems: 3,
+      callsConsumed: 6,
+    });
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.flushSentry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT capture exception when refreshRadarSnapshot returns a non-error envelope', async () => {
+    // The `partial-both-failed` outcome means both tiers failed but
+    // refreshRadarSnapshot caught them internally and returned a result
+    // envelope — the scheduled handler should NOT double-report.
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'partial-both-failed',
+      wireReason: 'inoreader-rate-limit',
+      fyiReason: 'inoreader-rate-limit',
+    });
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('invokes withMonitor with the runtime cron expression from the ScheduledController', async () => {
+    // The cron schedule passed to Sentry must match the schedule that
+    // actually fired. We pull it from `event.cron` (Cloudflare's runtime
+    // truth) rather than hardcoding so a `wrangler.toml` schedule edit
+    // doesn't silently desync from Sentry's monitor config.
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 0,
+      fyiItems: 0,
+      callsConsumed: 0,
+    });
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(sentry.withMonitor).toHaveBeenCalledTimes(1);
+    const [slug, _callback, config] = vi.mocked(sentry.withMonitor).mock.calls[0];
+    expect(slug).toBe('radar-refresh');
+    expect(config).toMatchObject({
+      schedule: { type: 'crontab', value: FAKE_CRON },
+      timezone: 'UTC',
+    });
+  });
+
+  it('swallows the re-thrown exception so ctx.waitUntil resolves cleanly (no unhandled rejection escapes Cloudflare runtime)', async () => {
+    // This is the load-bearing assertion against the 2026-05-25 incident
+    // shape. If the catch is removed, the promise rejects → Cloudflare
+    // reports outcome:exception → Sentry has no event. The test would
+    // fail because `await Promise.all` would itself throw.
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('any throw'));
+
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+
+    // The IIFE inside ctx.waitUntil must resolve, NOT reject. If the
+    // handler regresses to a no-catch shape, this awaits a rejected
+    // promise and the test fails loudly with the original error.
+    await expect(Promise.all(waitUntilPromises)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

2026-05-25 production incident: Cloudflare dashboard showed 13 cron `outcome: exception` events in 24h; Sentry's Issues view showed zero. Impartial-agent review (transcript in commit body) confirmed the root cause is a missing `catch` clause in the scheduled handler — `withSentry`'s auto-capture is anchored on the fetch handler's Response and doesn't cover scheduled-handler exceptions in `ctx.waitUntil`.

Fix mirrors Sentry's reference `instrumentCron` pattern (`@sentry/node-core/src/cron/cron.ts`):

1. **`Sentry.withMonitor('radar-refresh', …, { schedule, … })`** — sends `in_progress` / `ok` / `error` check-ins to Sentry Crons. Auto-creates the monitor on first check-in. Enables missed-firing alerts on the Crons dashboard.
2. **Outer `try/catch`** around `withMonitor` — `withMonitor` only marks the check-in status and re-throws; it does NOT call `captureException` itself (verified against `@sentry/core` source). The catch captures the rejection for the stack trace, then swallows so `ctx.waitUntil` resolves cleanly.
3. **`finally { await flushSentry() }`** — unchanged (kept from 4680028, BL-032.8 Phase B Day 3).

Schedule value reads from `event.cron` (Cloudflare's runtime truth) — a `wrangler.toml` schedule edit can't silently desync from Sentry's monitor config.

## Coverage gap closed

Zero existing tests exercised `worker.ts`'s scheduled handler. The cron-handler suite (`tests/unit/cron/radar-refresh.test.ts`) covers `refreshRadarSnapshot` in isolation but never asked "what does the worker do if `refreshRadarSnapshot` rejects?" New regression suite at `tests/unit/worker-scheduled.test.ts` (6 cases) closes this — including a load-bearing assertion that `ctx.waitUntil` promises resolve cleanly (if a future regression removes the catch, the test fails loudly).

## Test plan

- [x] `npm -w @gst/mcp-server run test` — **752/752 passing** (+6 new worker-scheduled cases)
- [x] `npx astro check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] Manual impartial-agent review confirmed diagnosis + recommended `withMonitor` over the interim "just add a catch" patch
- [ ] After deploy: confirm the next cron firing creates the `radar-refresh` monitor on Sentry Crons dashboard with the right schedule
- [ ] After deploy: confirm Cloudflare exception count drops AND Sentry Issues view starts receiving cron-error events (or, if the upstream Inoreader issue has resolved, both stay at zero)

## Out of scope

- The actual upstream cause of the 13 errors (likely Inoreader 5xx or similar) — that's a separate diagnostic step once Sentry starts surfacing stack traces.
- `feature/bl-032.8-phase-b-retirement` (PR #140) — its branch was just rebased onto master in the same session; this fix lands on master so it'll merge into that PR's next master-merge without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)