### PR TITLE
fix(mcp-server): BL-032.76 — bypass @sentry/cloudflare on scheduled handler

### DIFF
--- a/mcp-server/src/cron/radar-refresh.ts
+++ b/mcp-server/src/cron/radar-refresh.ts
@@ -35,7 +35,7 @@
 import { readWireLive, readFyiLive } from '../content/radar-live-store';
 import { isCircuitOpen } from '../ratelimit/circuit-breaker';
 import { createMcpClient } from '../lib/upstash-clients';
-import { captureMessage } from '../observability/sentry';
+import { captureMessageEnvelope } from '../observability/sentry-envelope';
 import { handleInoreaderFailure } from '../lib/inoreader-failure-handler';
 import { refreshAccessToken } from '../lib/inoreader-oauth';
 import { KV_MCP_ACCESS_TOKEN_KEY } from '../lib/inoreader-token-store';
@@ -185,7 +185,8 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
   // isn't reachable; treat as "no signal, proceed."
   const circuit = await isCircuitOpen(env);
   if (circuit?.open) {
-    captureMessage(
+    await captureMessageEnvelope(
+      env,
       'cron.radar-refresh.skipped',
       'info',
       { reason: 'circuit-open', retryAfterSeconds: circuit.retryAfterSeconds },
@@ -201,7 +202,8 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
   // Guard 2 — daily soft cap. Skip if next refresh would push us over.
   const counter = await readDayCounter(env);
   if (counter + CALLS_PER_REFRESH > DAILY_SOFT_CAP) {
-    captureMessage(
+    await captureMessageEnvelope(
+      env,
       'cron.radar-refresh.skipped',
       'info',
       { reason: 'day-cap-reached', counter, cap: DAILY_SOFT_CAP },
@@ -250,7 +252,8 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
     }
 
     if (wire.ok && fyi.ok) {
-      captureMessage(
+      await captureMessageEnvelope(
+        env,
         'cron.radar-refresh.success',
         'info',
         { wireItems: wire.items.length, fyiItems: fyi.items.length, callsConsumed },
@@ -290,7 +293,8 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
       await handleInoreaderFailure(env, fyi, 'cron-fyi');
     }
     const bothFailed = !wire.ok && !fyi.ok;
-    captureMessage(
+    await captureMessageEnvelope(
+      env,
       bothFailed ? 'cron.radar-refresh.partial-both-failed' : 'cron.radar-refresh.partial',
       'warning',
       {
@@ -321,7 +325,13 @@ export async function refreshRadarSnapshot(env: Env): Promise<RefreshOutcome> {
     };
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    captureMessage('cron.radar-refresh.error', 'error', { message }, 'cron.radar-refresh');
+    await captureMessageEnvelope(
+      env,
+      'cron.radar-refresh.error',
+      'error',
+      { message },
+      'cron.radar-refresh'
+    );
     safeLog({
       event: 'cron.radar-refresh.error',
       success: false,

--- a/mcp-server/src/lib/inoreader-egress.ts
+++ b/mcp-server/src/lib/inoreader-egress.ts
@@ -64,7 +64,7 @@
 import type { Redis } from '@upstash/redis';
 import { createMcpClient } from './upstash-clients';
 import { safeLog } from '../auth/safe-logger';
-import { captureMessage } from '../observability/sentry';
+import { captureMessageEnvelope } from '../observability/sentry-envelope';
 import type { Env } from '../worker';
 
 /**
@@ -192,7 +192,7 @@ export async function recordInoreaderEgress(opts: RecordEgressOptions): Promise<
     const tNext = await redis.incr(tKey);
     await redis.expire(tKey, TTL_SECONDS);
 
-    await maybeAlertDrift(redis, opts.category, tNext, opts.zone1UsageHeader);
+    await maybeAlertDrift(opts.env, redis, opts.category, tNext, opts.zone1UsageHeader);
   } catch {
     // Counter is a guard rail, not auth — degraded Upstash shouldn't fail
     // user requests. Surface to the operator via safeLog.
@@ -221,6 +221,7 @@ export async function recordInoreaderEgress(opts: RecordEgressOptions): Promise<
  * don't emit (rather than firing 100×). Observability must never throw.
  */
 async function maybeAlertDrift(
+  env: Env,
   redis: Redis,
   category: InoreaderEgressCategory,
   counter: number,
@@ -233,7 +234,8 @@ async function maybeAlertDrift(
   const alertOk = await trySetDailyAlertFlag(redis);
   if (!alertOk) return; // already alerted today, or Upstash unreachable
 
-  captureMessage(
+  await captureMessageEnvelope(
+    env,
     'inoreader.spend.drift',
     'warning',
     {

--- a/mcp-server/src/lib/inoreader-failure-handler.ts
+++ b/mcp-server/src/lib/inoreader-failure-handler.ts
@@ -30,7 +30,7 @@
  */
 
 import { openCircuit } from '../ratelimit/circuit-breaker';
-import { captureMessage } from '../observability/sentry';
+import { captureMessageEnvelope } from '../observability/sentry-envelope';
 import type { Env } from '../worker';
 import type { InoreaderFailure, RateLimitInfo } from './inoreader-client';
 
@@ -96,7 +96,8 @@ export async function handleInoreaderFailure(
   // doesn't delay the protective side effect.
   await openCircuit(env, `inoreader-429-${source}`);
 
-  captureMessage(
+  await captureMessageEnvelope(
+    env,
     'inoreader-rate-limit',
     'error',
     {

--- a/mcp-server/src/lib/inoreader-oauth.ts
+++ b/mcp-server/src/lib/inoreader-oauth.ts
@@ -48,7 +48,7 @@ import {
   writeRefreshToken,
   KV_MCP_ACCESS_TOKEN_KEY,
 } from './inoreader-token-store';
-import { captureMessage } from '../observability/sentry';
+import { captureMessageEnvelope } from '../observability/sentry-envelope';
 import { safeLog } from '../auth/safe-logger';
 import { recordInoreaderEgress } from './inoreader-egress';
 import type { Env } from '../worker';
@@ -199,7 +199,7 @@ async function performRefresh(
       message:
         'No Inoreader refresh token available. Upstash mcp:inoreader:refresh_token + inoreader:refresh_token + INOREADER_REFRESH_TOKEN env are all empty. Manual OAuth re-link required.',
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -214,7 +214,7 @@ async function performRefresh(
       message:
         'Inoreader credentials (INOREADER_APP_ID + INOREADER_APP_KEY) not bound on the Worker env.',
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -261,7 +261,7 @@ async function performRefresh(
       reason: 'inoreader-error',
       message: `Inoreader /oauth2/token network error: ${(e as Error).message}`,
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   } finally {
     clearTimeout(timeoutId);
@@ -298,7 +298,7 @@ async function performRefresh(
           reason: 'inoreader-error',
           message: `Inoreader /oauth2/token returned ${res.status} ${res.statusText} (body excerpt: ${bodyText.slice(0, 200)})`,
         };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -311,7 +311,7 @@ async function performRefresh(
       reason: 'inoreader-error',
       message: `Inoreader /oauth2/token returned non-JSON body: ${(e as Error).message}`,
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -321,7 +321,7 @@ async function performRefresh(
       reason: 'inoreader-error',
       message: 'Inoreader /oauth2/token response had no access_token field',
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -337,7 +337,7 @@ async function performRefresh(
         message:
           'Refresh succeeded but rotated refresh_token persistence failed; token is now in an inconsistent state.',
       };
-      logAndCapture(result, source, Date.now() - startedAt);
+      await logAndCapture(env, result, source, Date.now() - startedAt);
       return result;
     }
   }
@@ -349,7 +349,7 @@ async function performRefresh(
       reason: 'upstash-write-failed',
       message: 'Refresh succeeded but access_token persistence failed; next call will re-refresh.',
     };
-    logAndCapture(result, source, Date.now() - startedAt);
+    await logAndCapture(env, result, source, Date.now() - startedAt);
     return result;
   }
 
@@ -360,7 +360,7 @@ async function performRefresh(
     expiresAt: Date.now() + expiresIn * 1000,
     refreshSource: 'fresh',
   };
-  logAndCapture(result, source, Date.now() - startedAt);
+  await logAndCapture(env, result, source, Date.now() - startedAt);
   return result;
 }
 
@@ -372,7 +372,12 @@ async function safeReadText(res: Response): Promise<string> {
   }
 }
 
-function logAndCapture(result: RefreshResult, source: RefreshSource, durationMs: number): void {
+async function logAndCapture(
+  env: Env,
+  result: RefreshResult,
+  source: RefreshSource,
+  durationMs: number
+): Promise<void> {
   if (result.ok) {
     safeLog({
       event: 'oauth.refresh.success',
@@ -401,7 +406,8 @@ function logAndCapture(result: RefreshResult, source: RefreshSource, durationMs:
 
   const level: 'error' | 'warning' = result.reason === 'inoreader-error' ? 'warning' : 'error';
 
-  captureMessage(
+  await captureMessageEnvelope(
+    env,
     `oauth-refresh-${result.reason}`,
     level,
     {

--- a/mcp-server/src/observability/sentry-envelope.ts
+++ b/mcp-server/src/observability/sentry-envelope.ts
@@ -1,0 +1,208 @@
+/**
+ * Direct Sentry envelope POSTs — bypasses `@sentry/cloudflare` for paths
+ * where the SDK's auto-instrumentation introduces unhandled-promise
+ * rejections into `ctx.waitUntil`.
+ *
+ * Why this exists (BL-032.76, 2026-05-26 incident): the SDK's
+ * `wrapScheduledHandler` queues its own `ctx.waitUntil(flushAndDispose
+ * (client))` outside any try/catch we control. Something in that queued
+ * promise rejects under Workers-runtime conditions, producing Cloudflare
+ * `Exception Thrown` on every cron firing while the underlying work
+ * succeeds. Three in-tree fix attempts (Phase B Day-3 flush, withMonitor
+ * layering, outer try/catch around the IIFE) did not resolve the
+ * symptom. Upstream check (getsentry/sentry-javascript) surfaced no
+ * documented workaround and no config flag to disable the scheduled-
+ * handler wrap.
+ *
+ * The fix is structural: stop wrapping `scheduled` with `withSentry`
+ * (`worker.ts` default export splits to `{ fetch: withSentry(...).fetch,
+ * scheduled: handler.scheduled }`), and inside the cron path use these
+ * direct envelope POSTs instead of the SDK's `captureMessage` /
+ * `withMonitor` / `flushSentry`.
+ *
+ * Modeled on the PowerShell envelope test that proved transport health
+ * on 2026-05-26 (Sentry event_id `7a22ca8212983f1d0b58a54e4f283841`
+ * landed in the mcp-server project within ~1 min of the POST).
+ *
+ * Pure `fetch()` — no SDK import, no auto-queued `ctx.waitUntil`, no
+ * isolation-scope wrapping. Used by cron paths and any future background
+ * surface where SDK lifecycle conflicts with Workers semantics.
+ *
+ * **Best-effort contract**: every export here is wrapped to never throw.
+ * A 2000ms `AbortController` timeout bounds each POST so a slow Sentry
+ * ingest cannot extend `ctx.waitUntil` past its budget.
+ */
+
+import type { Env } from '../worker';
+
+interface ParsedDsn {
+  readonly host: string;
+  readonly projectId: string;
+  readonly publicKey: string;
+}
+
+const SENTRY_CLIENT = 'mcp-server-manual/0.1.0';
+const ENVELOPE_TIMEOUT_MS = 2000;
+
+export function parseDsn(dsn: string | undefined): ParsedDsn | null {
+  if (!dsn) return null;
+  const m = dsn.match(/^https:\/\/([a-f0-9]+)@([^/]+)\/(\d+)$/);
+  return m ? { publicKey: m[1], host: m[2], projectId: m[3] } : null;
+}
+
+function envelopeAuthHeader(publicKey: string): string {
+  return `Sentry sentry_version=7,sentry_key=${publicKey},sentry_client=${SENTRY_CLIENT}`;
+}
+
+/**
+ * 32-char lowercase hex event id. Workers runtime exposes
+ * `crypto.randomUUID()` natively; strip dashes to match Sentry's
+ * documented event_id shape.
+ */
+function randomEventId(): string {
+  return crypto.randomUUID().replace(/-/g, '');
+}
+
+async function postEnvelope(dsn: ParsedDsn, body: string): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ENVELOPE_TIMEOUT_MS);
+  try {
+    await fetch(`https://${dsn.host}/api/${dsn.projectId}/envelope/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+        'X-Sentry-Auth': envelopeAuthHeader(dsn.publicKey),
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch {
+    // Best-effort — swallow network errors, abort timeouts, and any
+    // other fetch rejection so the caller's ctx.waitUntil resolves
+    // cleanly. There is no recovery path.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Send an event envelope. Best-effort — never throws.
+ */
+export async function postSentryEvent(
+  env: Env,
+  event: {
+    level: 'info' | 'warning' | 'error';
+    message: string;
+    tags?: Record<string, string | number | boolean>;
+    extra?: Record<string, unknown>;
+  }
+): Promise<void> {
+  const dsn = parseDsn(env.SENTRY_DSN);
+  if (!dsn) return;
+
+  const eventId = randomEventId();
+  const sentAt = new Date().toISOString();
+  const eventBody: Record<string, unknown> = {
+    event_id: eventId,
+    timestamp: sentAt,
+    platform: 'javascript',
+    level: event.level,
+    message: event.message,
+  };
+  if (event.tags && Object.keys(event.tags).length > 0) eventBody.tags = event.tags;
+  if (event.extra && Object.keys(event.extra).length > 0) eventBody.extra = event.extra;
+  if (env.SENTRY_RELEASE) eventBody.release = env.SENTRY_RELEASE;
+
+  const envelope = [
+    JSON.stringify({ event_id: eventId, sent_at: sentAt }),
+    JSON.stringify({ type: 'event' }),
+    JSON.stringify(eventBody),
+  ].join('\n');
+
+  await postEnvelope(dsn, envelope);
+}
+
+/**
+ * Compatibility shim mirroring `observability/sentry.ts`'s `captureMessage`
+ * signature, so cron-reachable shared modules (inoreader-oauth.ts,
+ * inoreader-failure-handler.ts) can swap imports with a minimal diff and
+ * preserve their existing tag / extra construction.
+ *
+ * Differences vs the SDK version:
+ *   - Requires `env` (envelope POST needs `SENTRY_DSN`)
+ *   - Async (caller should await so `ctx.waitUntil` keeps the isolate
+ *     alive until the POST completes — same reason the scheduled
+ *     handler awaits its check-ins)
+ */
+export async function captureMessageEnvelope(
+  env: Env,
+  message: string,
+  level: 'info' | 'warning' | 'error' = 'warning',
+  context?: Record<string, unknown>,
+  eventTag?: string,
+  extraTags?: Record<string, string | number | boolean | undefined>
+): Promise<void> {
+  const tags: Record<string, string | number | boolean> = {};
+  if (extraTags) {
+    for (const [k, v] of Object.entries(extraTags)) {
+      if (v !== undefined) tags[k] = v;
+    }
+  }
+  if (eventTag) tags.event = eventTag;
+
+  await postSentryEvent(env, {
+    level,
+    message,
+    ...(context ? { extra: context } : {}),
+    ...(Object.keys(tags).length > 0 ? { tags } : {}),
+  });
+}
+
+/**
+ * Send a Sentry Crons check-in. Status: 'in_progress' | 'ok' | 'error'.
+ *
+ * Pair an `in_progress` with a matching `ok`/`error` using the returned
+ * `check_in_id` so Sentry's Crons UI shows the duration + outcome.
+ *
+ * `monitor_config` (schedule + timezone) is included ONLY on
+ * `in_progress` per Sentry Crons spec — closing check-ins are matched
+ * by `check_in_id` and including a config on them is wasted bytes and
+ * has been observed to confuse the monitor-upsert path.
+ *
+ * Returns the `check_in_id` (generated UUID without dashes) for the
+ * caller to thread through to the closing check-in. Returns `undefined`
+ * when `SENTRY_DSN` is unbound.
+ */
+export async function postSentryCheckIn(
+  env: Env,
+  monitorSlug: string,
+  status: 'in_progress' | 'ok' | 'error',
+  schedule: string,
+  checkInId?: string
+): Promise<string | undefined> {
+  const dsn = parseDsn(env.SENTRY_DSN);
+  if (!dsn) return undefined;
+
+  const id = checkInId ?? randomEventId();
+  const sentAt = new Date().toISOString();
+  const checkInBody: Record<string, unknown> = {
+    check_in_id: id,
+    monitor_slug: monitorSlug,
+    status,
+  };
+  if (status === 'in_progress') {
+    checkInBody.monitor_config = {
+      schedule: { type: 'crontab', value: schedule },
+      timezone: 'UTC',
+    };
+  }
+
+  const envelope = [
+    JSON.stringify({ event_id: id, sent_at: sentAt }),
+    JSON.stringify({ type: 'check_in' }),
+    JSON.stringify(checkInBody),
+  ].join('\n');
+
+  await postEnvelope(dsn, envelope);
+  return id;
+}

--- a/mcp-server/src/worker.ts
+++ b/mcp-server/src/worker.ts
@@ -36,15 +36,8 @@ import { safeLog } from './auth/safe-logger';
 import { hasScope } from './auth/scopes';
 import { createLimiter } from './ratelimit/limiter';
 import { tooManyRequestsResponse, withRateLimitHeaders } from './ratelimit/headers';
-import {
-  captureException,
-  captureMessage,
-  flushSentry,
-  sentryOptions,
-  tagRequest,
-  withMonitor,
-  withSentry,
-} from './observability/sentry';
+import { captureMessage, sentryOptions, tagRequest, withSentry } from './observability/sentry';
+import { postSentryCheckIn, postSentryEvent } from './observability/sentry-envelope';
 import { buildHealthPayload } from './observability/health';
 import { refreshRadarSnapshot } from './cron/radar-refresh';
 import { readWireLive, readFyiLive } from './content/radar-live-store';
@@ -165,84 +158,79 @@ export const handler: ExportedHandler<Env> = {
    * The scheduled handler has no response surface — return value is
    * ignored by Cloudflare.
    *
-   * **Three-layer Sentry instrumentation** (mirrors Sentry's reference
-   * `instrumentCron` pattern; verified against `@sentry/node-core/src/
-   * cron/cron.ts`):
+   * **Envelope-direct observability** (BL-032.76 — replaces the prior
+   * `withMonitor` + `captureException` + `flushSentry` stack as of
+   * 2026-05-26):
    *
-   *   1. `withMonitor('radar-refresh', …)` — sends `in_progress` / `ok`
-   *      / `error` check-ins to Sentry Crons. Auto-creates the monitor
-   *      on first check-in via `upsertMonitorConfig` (the `schedule`
-   *      field). Sentry surfaces missed firings + sustained-failure
-   *      alerts on its Crons dashboard.
-   *   2. **Outer `try/catch`** — `withMonitor` re-throws on callback
-   *      rejection (it only marks the check-in; it does NOT call
-   *      `captureException`). Without an outer catch, the rejection
-   *      escapes `ctx.waitUntil` and Cloudflare reports
-   *      `outcome: exception` with zero Sentry signal. The catch calls
-   *      `captureException` for the stack trace and then swallows so
-   *      `ctx.waitUntil`'s promise resolves cleanly.
-   *   3. **`finally { await flushSentry() }`** — `withSentry` auto-
-   *      flushes for the fetch handler (anchored on the Response), but
-   *      the scheduled handler has no Response. Without an explicit
-   *      flush, in-flight Sentry POSTs get killed mid-flight when
-   *      Cloudflare reclaims the isolate. Observed dropping ~75% of
-   *      cron capture during BL-032.8 Phase B soak Day 3 (commit
-   *      4680028, 2026-05-19) — that fix landed the flush; this fix
-   *      lands the catch.
+   *   - Sentry Crons check-ins are sent via direct envelope POST
+   *     (`postSentryCheckIn`) — `in_progress` at start, then `ok` /
+   *     `error` paired by `check_in_id`.
+   *   - Failures emit a Sentry event via direct envelope POST
+   *     (`postSentryEvent`) for the stack trace.
+   *   - NO `@sentry/cloudflare` SDK calls on this code path. The SDK
+   *     remains in use for the fetch handler only (see default export
+   *     at the bottom of this file — `withSentry({ fetch })` splits
+   *     the surface so the scheduled handler stays SDK-free).
    *
-   * Bug history (resolves 2026-05-25 incident): Cloudflare dashboard
-   * showed 13 cron `outcome: exception` events in 24h. Sentry's Issues
-   * view showed zero corresponding events. Root cause: the prior shape
-   * had `try { … } finally { … }` with no `catch` clause — exceptions
-   * thrown by `refreshRadarSnapshot` propagated past the IIFE, past
-   * `ctx.waitUntil`'s promise, into Cloudflare's runtime. The `finally`
-   * ran flushSentry but the SDK queue was empty (no capture had been
-   * made), so Sentry never saw the error. See
-   * `mcp-server/BREAKING_CHANGES.md` 0.3.12 for full context.
+   * **Why the SDK is bypassed here**: from 2026-05-19 through 2026-05-26,
+   * every cron firing reported `Exception Thrown` on Cloudflare's cron
+   * dashboard while the underlying radar work succeeded. The SDK's
+   * `wrapScheduledHandler` queues its own `ctx.waitUntil(flushAndDispose
+   * (client))` outside any try/catch we control; something in that
+   * queued promise rejects under Workers-runtime conditions. Three
+   * in-tree fix attempts (Day-3 flush, withMonitor layering, outer
+   * try/catch around the IIFE) did not resolve the symptom; upstream
+   * check found no documented workaround or config flag. The structural
+   * fix is to stop wrapping `scheduled` with `withSentry`. See
+   * `src/observability/sentry-envelope.ts` for the helper rationale.
    */
   async scheduled(event, env, ctx): Promise<void> {
     ctx.waitUntil(
       (async () => {
-        // Outer safety net: every observability call (captureException,
-        // flushSentry, even withMonitor's internal Sentry HTTP traffic)
-        // can throw under SDK-internal errors, network blips reaching
-        // Sentry ingest, or quota rejections. The original v0.3.12 fix
-        // caught `refreshRadarSnapshot` rejections but left these Sentry-
-        // plumbing throws unguarded — Cloudflare's cron dashboard
-        // continued to report `exception` even on firings where the
-        // radar work succeeded (verified 2026-05-25 18:00 UTC: /health
-        // confirmed inoreaderObservedAt updated, Cloudflare still
-        // reported Error). Wrapping the whole IIFE body guarantees
-        // ctx.waitUntil sees a clean resolution regardless of which
-        // sub-system fails. The inner try/catch/finally still does the
-        // useful capture-and-flush work on the happy path.
+        const startedAt = Date.now();
+        // Outer safety net (defense-in-depth). The envelope helpers in
+        // `sentry-envelope.ts` carry a "never throws" contract, but a
+        // future refactor that breaks that contract would re-introduce
+        // the 2026-05-19 incident shape (rejection escapes ctx.waitUntil
+        // → Cloudflare reports `Exception Thrown`). Wrapping the whole
+        // body guarantees ctx.waitUntil resolves regardless of helper
+        // regressions. Anything that lands here is intentionally dropped
+        // — the safeLog inside the inner catch is the operator-visible
+        // signal on the failure path.
         try {
+          // The cron expression in the Crons check-in MUST match
+          // wrangler.toml's `[triggers] crons` entry — `event.cron` is
+          // the runtime source of truth so a wrangler.toml edit doesn't
+          // silently desync the Sentry-side monitor config.
+          const checkInId = await postSentryCheckIn(
+            env,
+            'radar-refresh',
+            'in_progress',
+            event.cron
+          );
           try {
-            // Sentry Crons check-in + monitor auto-upsert. The cron
-            // expression here MUST match wrangler.toml's `[triggers]
-            // crons` entry — `event.cron` is the runtime source of
-            // truth so a wrangler.toml edit doesn't silently desync.
-            await withMonitor('radar-refresh', () => refreshRadarSnapshot(env), {
-              schedule: { type: 'crontab', value: event.cron },
-              checkinMargin: 5,
-              maxRuntime: 10,
-              timezone: 'UTC',
-            });
+            await refreshRadarSnapshot(env);
+            await postSentryCheckIn(env, 'radar-refresh', 'ok', event.cron, checkInId);
           } catch (err) {
-            // `withMonitor` marked the check-in `error` and re-threw.
-            // Capture so the stack trace reaches Sentry; swallow so
-            // ctx.waitUntil resolves cleanly.
-            captureException(err, { source: 'cron.scheduled', cron: event.cron });
-          } finally {
-            await flushSentry();
+            const msg = err instanceof Error ? err.message : String(err);
+            safeLog({
+              event: 'cron.scheduled.error',
+              success: false,
+              reason: msg.slice(0, 200),
+              durationMs: Date.now() - startedAt,
+            });
+            await postSentryEvent(env, {
+              level: 'error',
+              message: `cron.radar-refresh.error: ${msg}`,
+              tags: { event: 'cron.scheduled', cron: event.cron },
+              extra: { source: 'cron.scheduled', cron: event.cron },
+            });
+            await postSentryCheckIn(env, 'radar-refresh', 'error', event.cron, checkInId);
           }
         } catch {
-          // Belt-and-suspenders. Anything escaping the inner structured
-          // cleanup (Sentry SDK internal throw, ingest rejection, flush
-          // timeout that rejects rather than resolves false) lands here
-          // and is intentionally dropped — there is no further recovery
-          // and the radar work either succeeded (visible via /health)
-          // or was already captured by the inner catch.
+          // Helper-contract regression. No further recovery — the work
+          // either succeeded (visible via /health) or its failure was
+          // captured by the inner catch before this outer one fired.
         }
       })()
     );
@@ -450,7 +438,24 @@ export const handler: ExportedHandler<Env> = {
   },
 };
 
-// Wrap the handler with Sentry. Returns the same ExportedHandler shape;
-// when SENTRY_DSN isn't bound, sentryOptions returns undefined and
-// withSentry passes through to the underlying handler unchanged.
-export default withSentry(sentryOptions, handler);
+// Default export — wraps `fetch` with Sentry, leaves `scheduled` bare.
+//
+// BL-032.76 (2026-05-26): the SDK's `wrapScheduledHandler` queues its
+// own `ctx.waitUntil(flushAndDispose(client))` outside any try/catch we
+// control, producing Cloudflare `Exception Thrown` on every cron firing
+// regardless of whether our work succeeded. The fix is structural:
+// `withSentry` mutates the passed handler object in place and only
+// touches keys present on it, so passing `{ fetch }` avoids the
+// scheduled-handler wrap entirely. The bare `handler.scheduled`
+// reference becomes the default-export's `scheduled`, owning its own
+// envelope-based Sentry lifecycle (see the `scheduled` method
+// docstring + `src/observability/sentry-envelope.ts`).
+//
+// When `SENTRY_DSN` isn't bound, `sentryOptions` returns undefined and
+// `withSentry` passes the fetch handler through unchanged.
+const wrappedFetch = withSentry(sentryOptions, { fetch: handler.fetch! }).fetch;
+
+export default {
+  fetch: wrappedFetch,
+  scheduled: handler.scheduled,
+} satisfies ExportedHandler<Env>;

--- a/mcp-server/tests/unit/cron/radar-refresh.test.ts
+++ b/mcp-server/tests/unit/cron/radar-refresh.test.ts
@@ -44,8 +44,8 @@ vi.mock('../../../src/lib/upstash-clients', () => ({
 }));
 
 const { mockCaptureMessage } = vi.hoisted(() => ({ mockCaptureMessage: vi.fn() }));
-vi.mock('../../../src/observability/sentry', () => ({
-  captureMessage: mockCaptureMessage,
+vi.mock('../../../src/observability/sentry-envelope', () => ({
+  captureMessageEnvelope: mockCaptureMessage,
 }));
 
 const { mockSafeLog } = vi.hoisted(() => ({ mockSafeLog: vi.fn() }));
@@ -90,6 +90,7 @@ describe('refreshRadarSnapshot — circuit breaker guard', () => {
     expect(mockReadWireLive).not.toHaveBeenCalled();
     expect(mockReadFyiLive).not.toHaveBeenCalled();
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.skipped',
       'info',
       expect.objectContaining({ reason: 'circuit-open', retryAfterSeconds: 3600 }),
@@ -137,6 +138,7 @@ describe('refreshRadarSnapshot — daily soft cap guard', () => {
     expect(outcome).toEqual({ kind: 'skipped', reason: 'day-cap-reached', counter: 175 });
     expect(mockReadWireLive).not.toHaveBeenCalled();
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.skipped',
       'info',
       expect.objectContaining({ reason: 'day-cap-reached', counter: 175, cap: 180 }),
@@ -251,6 +253,7 @@ describe('refreshRadarSnapshot — success path', () => {
     expect(mockReadWireLive).toHaveBeenCalledWith(env, { forceRefresh: true, source: 'cron' });
     expect(mockReadFyiLive).toHaveBeenCalledWith(env, 30, { forceRefresh: true, source: 'cron' });
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.success',
       'info',
       expect.objectContaining({ wireItems: 3, fyiItems: 1 }),
@@ -342,6 +345,7 @@ describe('refreshRadarSnapshot — partial-failure path', () => {
     expect(mockCounterIncrby).toHaveBeenCalledTimes(1);
     expect(mockCounterIncrby.mock.calls[0]?.[1]).toBe(5);
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.partial',
       'warning',
       expect.objectContaining({
@@ -425,6 +429,7 @@ describe('refreshRadarSnapshot — both-tiers-failed path (T.Z.1 budget protecti
     expect(mockOpenCircuit).toHaveBeenCalledWith(env, 'inoreader-429-cron-wire');
     expect(mockOpenCircuit).toHaveBeenCalledWith(env, 'inoreader-429-cron-fyi');
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.partial-both-failed',
       'warning',
       expect.objectContaining({
@@ -458,6 +463,7 @@ describe('refreshRadarSnapshot — error path', () => {
       expect(outcome.message).toBe('boom');
     }
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'cron.radar-refresh.error',
       'error',
       expect.objectContaining({ message: 'boom' }),

--- a/mcp-server/tests/unit/lib/inoreader-egress.test.ts
+++ b/mcp-server/tests/unit/lib/inoreader-egress.test.ts
@@ -58,8 +58,8 @@ const {
 });
 
 vi.mock('@upstash/redis', () => ({ Redis: MockRedis }));
-vi.mock('../../../src/observability/sentry', () => ({
-  captureMessage: captureMessageMock,
+vi.mock('../../../src/observability/sentry-envelope', () => ({
+  captureMessageEnvelope: captureMessageMock,
 }));
 vi.mock('../../../src/auth/safe-logger', () => ({ safeLog: safeLogMock }));
 
@@ -205,11 +205,15 @@ describe('recordInoreaderEgress: drift detection', () => {
     });
 
     // Behavior contract: warning-severity capture with the diagnostic payload.
-    // Positional arg shape is NOT pinned — a future signature consolidation
-    // (e.g. options-object) should not break this test as long as the
-    // payload fields surface.
+    // The leading `env` arg is pinned positionally so a regression that
+    // drops env (and falls back to a no-DSN no-op envelope call) fails CI
+    // rather than passing silently via arrayContaining. The remaining
+    // fields use `arrayContaining` so a future signature consolidation
+    // (e.g. options-object) can land without breaking this test as long
+    // as the diagnostic surfaces.
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
     const args = captureMessageMock.mock.calls[0];
+    expect(args[0]).toBe(env);
     expect(args).toEqual(
       expect.arrayContaining([
         'inoreader.spend.drift',
@@ -233,6 +237,7 @@ describe('recordInoreaderEgress: drift detection', () => {
 
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
     const args = captureMessageMock.mock.calls[0];
+    expect(args[0]).toBe(env);
     expect(args).toEqual(expect.arrayContaining([expect.objectContaining({ drift: -7 })]));
   });
 

--- a/mcp-server/tests/unit/lib/inoreader-failure-handler.test.ts
+++ b/mcp-server/tests/unit/lib/inoreader-failure-handler.test.ts
@@ -20,8 +20,8 @@ vi.mock('../../../src/ratelimit/circuit-breaker', () => ({
   openCircuit: mockOpenCircuit,
 }));
 
-vi.mock('../../../src/observability/sentry', () => ({
-  captureMessage: mockCaptureMessage,
+vi.mock('../../../src/observability/sentry-envelope', () => ({
+  captureMessageEnvelope: mockCaptureMessage,
 }));
 
 import { handleInoreaderFailure } from '../../../src/lib/inoreader-failure-handler';
@@ -92,6 +92,7 @@ describe('handleInoreaderFailure — inoreader-rate-limit', () => {
 
     expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'inoreader-rate-limit',
       'error',
       expect.objectContaining({
@@ -124,7 +125,7 @@ describe('handleInoreaderFailure — inoreader-rate-limit', () => {
     await handleInoreaderFailure(env, failure, 'cron-fyi');
 
     expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
-    const tags = mockCaptureMessage.mock.calls[0]?.[4] as Record<string, unknown>;
+    const tags = mockCaptureMessage.mock.calls[0]?.[5] as Record<string, unknown>;
     expect(tags).toEqual({ 'inoreader.source': 'cron-fyi' });
   });
 
@@ -143,7 +144,7 @@ describe('handleInoreaderFailure — inoreader-rate-limit', () => {
     await handleInoreaderFailure(env, failure, 'live-search-radar');
 
     expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
-    const extra = mockCaptureMessage.mock.calls[0]?.[2] as Record<string, unknown>;
+    const extra = mockCaptureMessage.mock.calls[0]?.[3] as Record<string, unknown>;
     expect(extra).toMatchObject({
       bodyExcerpt: 'App over daily limit. Please retry later.',
     });
@@ -151,7 +152,7 @@ describe('handleInoreaderFailure — inoreader-rate-limit', () => {
     // cardinality. Pin the boundary: bodyExcerpt belongs in `extra`,
     // never on `extraTags`. A regression that moves it would silently
     // blow up Sentry tag indexes — this assertion blocks that.
-    const tags = mockCaptureMessage.mock.calls[0]?.[4] as Record<string, unknown>;
+    const tags = mockCaptureMessage.mock.calls[0]?.[5] as Record<string, unknown>;
     expect(tags).not.toHaveProperty('bodyExcerpt');
   });
 
@@ -166,7 +167,7 @@ describe('handleInoreaderFailure — inoreader-rate-limit', () => {
     await handleInoreaderFailure(env, failure, 'cron-wire');
 
     expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
-    const extra = mockCaptureMessage.mock.calls[0]?.[2] as Record<string, unknown>;
+    const extra = mockCaptureMessage.mock.calls[0]?.[3] as Record<string, unknown>;
     expect(extra).not.toHaveProperty('bodyExcerpt');
   });
 });

--- a/mcp-server/tests/unit/lib/inoreader-oauth.test.ts
+++ b/mcp-server/tests/unit/lib/inoreader-oauth.test.ts
@@ -36,8 +36,8 @@ const { redisGet, redisSet, redisDel, MockRedis, mockCaptureMessage, mockSafeLog
 );
 
 vi.mock('@upstash/redis', () => ({ Redis: MockRedis }));
-vi.mock('../../../src/observability/sentry', () => ({
-  captureMessage: mockCaptureMessage,
+vi.mock('../../../src/observability/sentry-envelope', () => ({
+  captureMessageEnvelope: mockCaptureMessage,
 }));
 vi.mock('../../../src/auth/safe-logger', () => ({ safeLog: mockSafeLog }));
 
@@ -219,6 +219,7 @@ describe('refreshAccessToken — error taxonomy', () => {
     expect(result.reason).toBe('invalid-refresh-token');
     // Sentry: paging-class (error level) — operator must re-link OAuth.
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'oauth-refresh-invalid-refresh-token',
       'error',
       expect.objectContaining({ source: 'cron' }),
@@ -253,6 +254,7 @@ describe('refreshAccessToken — error taxonomy', () => {
     expect(result.reason).toBe('inoreader-error');
     // Sentry: warning (transient; caller fallback may recover).
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      env,
       'oauth-refresh-inoreader-error',
       'warning',
       expect.anything(),
@@ -313,6 +315,7 @@ describe('refreshAccessToken — error taxonomy', () => {
     // No /oauth2/token POST attempted — no point without a refresh_token.
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(mockCaptureMessage).toHaveBeenCalledWith(
+      { ...env, INOREADER_REFRESH_TOKEN: undefined },
       'oauth-refresh-token-missing',
       'error',
       expect.anything(),

--- a/mcp-server/tests/unit/observability/sentry-envelope.test.ts
+++ b/mcp-server/tests/unit/observability/sentry-envelope.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the direct Sentry envelope POST helpers (BL-032.76).
+ *
+ * These exercise the helpers in isolation — no `@sentry/cloudflare` SDK
+ * is loaded, no Workers runtime; just `fetch` mocked at the global level
+ * to inspect the envelope shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  parseDsn,
+  postSentryEvent,
+  postSentryCheckIn,
+  captureMessageEnvelope,
+} from '../../../src/observability/sentry-envelope';
+import type { Env } from '../../../src/worker';
+
+const FAKE_DSN =
+  'https://18b0d78cb4cbff2cbee5da2ae86c3e5e@o4511195716386816.ingest.us.sentry.io/4511343962357760';
+const env = {
+  SENTRY_DSN: FAKE_DSN,
+  UPSTASH_MCP_REST_URL: 'https://mcp.upstash.io',
+  UPSTASH_MCP_REST_TOKEN: 'token',
+} as unknown as Env;
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('parseDsn', () => {
+  it('parses a valid DSN into host / projectId / publicKey', () => {
+    expect(parseDsn(FAKE_DSN)).toEqual({
+      publicKey: '18b0d78cb4cbff2cbee5da2ae86c3e5e',
+      host: 'o4511195716386816.ingest.us.sentry.io',
+      projectId: '4511343962357760',
+    });
+  });
+
+  it('returns null for undefined', () => {
+    expect(parseDsn(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    // Distinct from undefined — wrangler can bind a secret to '' and we
+    // must short-circuit identically rather than pass the empty key
+    // through to fetch.
+    expect(parseDsn('')).toBeNull();
+  });
+
+  it('returns null for malformed input (missing scheme)', () => {
+    expect(parseDsn('foo@example.com/123')).toBeNull();
+  });
+
+  it('returns null when project id is non-numeric', () => {
+    expect(parseDsn('https://abc@host/notanumber')).toBeNull();
+  });
+
+  it('returns null when a path suffix follows the project id', () => {
+    expect(parseDsn('https://abc@host/123/extra')).toBeNull();
+  });
+});
+
+describe('postSentryEvent', () => {
+  it('POSTs an envelope to /api/<projectId>/envelope/ with correct headers + body shape', async () => {
+    await postSentryEvent(env, {
+      level: 'error',
+      message: 'cron.radar-refresh.error: boom',
+      tags: { event: 'cron.scheduled', cron: '0 */6 * * *' },
+      extra: { source: 'cron.scheduled' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      'https://o4511195716386816.ingest.us.sentry.io/api/4511343962357760/envelope/'
+    );
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/x-sentry-envelope',
+      'X-Sentry-Auth': expect.stringContaining(
+        'Sentry sentry_version=7,sentry_key=18b0d78cb4cbff2cbee5da2ae86c3e5e,sentry_client='
+      ),
+    });
+
+    const parts = (init.body as string).split('\n');
+    expect(parts).toHaveLength(3);
+    const [headerRaw, itemHeaderRaw, payloadRaw] = parts;
+    const header = JSON.parse(headerRaw);
+    const itemHeader = JSON.parse(itemHeaderRaw);
+    const payload = JSON.parse(payloadRaw);
+    expect(header).toMatchObject({
+      event_id: expect.stringMatching(/^[a-f0-9]{32}$/),
+      sent_at: expect.any(String),
+    });
+    expect(itemHeader).toEqual({ type: 'event' });
+    expect(payload).toMatchObject({
+      event_id: header.event_id,
+      platform: 'javascript',
+      level: 'error',
+      message: 'cron.radar-refresh.error: boom',
+      tags: { event: 'cron.scheduled', cron: '0 */6 * * *' },
+      extra: { source: 'cron.scheduled' },
+    });
+    // Default env has no SENTRY_RELEASE — must not surface a stray
+    // `release: undefined` field that would be sent to Sentry as the
+    // literal string "undefined".
+    expect(payload).not.toHaveProperty('release');
+  });
+
+  it('includes release when SENTRY_RELEASE is bound', async () => {
+    const envWithRelease = { ...env, SENTRY_RELEASE: 'abc1234' } as unknown as Env;
+    await postSentryEvent(envWithRelease, { level: 'info', message: 'hi' });
+
+    const payload = JSON.parse((fetchSpy.mock.calls[0]![1].body as string).split('\n')[2]);
+    expect(payload.release).toBe('abc1234');
+  });
+
+  it('does NOT POST when SENTRY_DSN is unbound', async () => {
+    await postSentryEvent({} as Env, { level: 'info', message: 'hi' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetch rejections without throwing', async () => {
+    fetchSpy.mockRejectedValue(new Error('network unreachable'));
+    await expect(
+      postSentryEvent(env, { level: 'error', message: 'should not throw' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('aborts after the 2000ms timeout when Sentry hangs', async () => {
+    // Construct a fetch that never resolves naturally — it must be
+    // aborted by the helper's AbortController.
+    let abortedSignal: AbortSignal | undefined;
+    fetchSpy.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          abortedSignal = init.signal!;
+          init.signal!.addEventListener('abort', () => reject(new Error('aborted')));
+        })
+    );
+
+    vi.useFakeTimers();
+    const pending = postSentryEvent(env, { level: 'error', message: 'slow ingest' });
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(pending).resolves.toBeUndefined();
+    expect(abortedSignal!.aborted).toBe(true);
+  });
+});
+
+describe('postSentryCheckIn', () => {
+  it('in_progress check-in includes monitor_config and returns a fresh id', async () => {
+    const id = await postSentryCheckIn(env, 'radar-refresh', 'in_progress', '0 */6 * * *');
+
+    expect(id).toMatch(/^[a-f0-9]{32}$/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const parts = (fetchSpy.mock.calls[0]![1].body as string).split('\n');
+    expect(JSON.parse(parts[1])).toEqual({ type: 'check_in' });
+    const checkIn = JSON.parse(parts[2]);
+    expect(checkIn).toMatchObject({
+      check_in_id: id,
+      monitor_slug: 'radar-refresh',
+      status: 'in_progress',
+      monitor_config: {
+        schedule: { type: 'crontab', value: '0 */6 * * *' },
+        timezone: 'UTC',
+      },
+    });
+  });
+
+  it('ok check-in REUSES the passed checkInId and OMITS monitor_config', async () => {
+    const id = 'a'.repeat(32);
+    const returned = await postSentryCheckIn(env, 'radar-refresh', 'ok', '0 */6 * * *', id);
+
+    expect(returned).toBe(id);
+    const checkIn = JSON.parse((fetchSpy.mock.calls[0]![1].body as string).split('\n')[2]);
+    expect(checkIn).toMatchObject({
+      check_in_id: id,
+      monitor_slug: 'radar-refresh',
+      status: 'ok',
+    });
+    expect(checkIn).not.toHaveProperty('monitor_config');
+  });
+
+  it('error check-in REUSES the passed checkInId and OMITS monitor_config', async () => {
+    const id = 'b'.repeat(32);
+    await postSentryCheckIn(env, 'radar-refresh', 'error', '0 */6 * * *', id);
+
+    const checkIn = JSON.parse((fetchSpy.mock.calls[0]![1].body as string).split('\n')[2]);
+    expect(checkIn).toMatchObject({ check_in_id: id, status: 'error' });
+    expect(checkIn).not.toHaveProperty('monitor_config');
+  });
+
+  it('returns undefined and does NOT POST when SENTRY_DSN is unbound', async () => {
+    const returned = await postSentryCheckIn(
+      {} as Env,
+      'radar-refresh',
+      'in_progress',
+      '0 */6 * * *'
+    );
+    expect(returned).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetch rejections without throwing', async () => {
+    fetchSpy.mockRejectedValue(new Error('network'));
+    await expect(
+      postSentryCheckIn(env, 'radar-refresh', 'ok', '0 */6 * * *', 'c'.repeat(32))
+    ).resolves.toBe('c'.repeat(32));
+  });
+});
+
+describe('captureMessageEnvelope (shim for shared-module callers)', () => {
+  it('forwards tags + extras to postSentryEvent envelope shape', async () => {
+    await captureMessageEnvelope(
+      env,
+      'inoreader-rate-limit',
+      'error',
+      { status: 429, source: 'cron-wire' },
+      'inoreader-rate-limit',
+      { 'inoreader.source': 'cron-wire', 'inoreader.zone1.usage': 100 }
+    );
+
+    const payload = JSON.parse((fetchSpy.mock.calls[0]![1].body as string).split('\n')[2]);
+    expect(payload).toMatchObject({
+      level: 'error',
+      message: 'inoreader-rate-limit',
+      extra: { status: 429, source: 'cron-wire' },
+      tags: {
+        event: 'inoreader-rate-limit',
+        'inoreader.source': 'cron-wire',
+        'inoreader.zone1.usage': 100,
+      },
+    });
+  });
+
+  it('drops undefined-valued extraTags so they do not surface as the literal string "undefined"', async () => {
+    await captureMessageEnvelope(env, 'm', 'warning', undefined, 'tag', {
+      keep: 'yes',
+      drop: undefined,
+    });
+
+    const payload = JSON.parse((fetchSpy.mock.calls[0]![1].body as string).split('\n')[2]);
+    expect(payload.tags).toEqual({ event: 'tag', keep: 'yes' });
+    expect(payload.tags).not.toHaveProperty('drop');
+  });
+
+  it('does NOT POST when SENTRY_DSN is unbound', async () => {
+    await captureMessageEnvelope({} as Env, 'm', 'info');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/mcp-server/tests/unit/worker-scheduled.test.ts
+++ b/mcp-server/tests/unit/worker-scheduled.test.ts
@@ -1,33 +1,41 @@
 /**
- * Regression test for the scheduled handler's Sentry error-capture path.
+ * Tests for the scheduled handler's envelope-based Sentry lifecycle
+ * (BL-032.76 — supersedes the prior `withMonitor` + `flushSentry` shape).
  *
- * Background (2026-05-25 incident): Cloudflare's dashboard reported 13
- * cron `outcome: exception` events in 24h while Sentry's Issues view
- * showed zero corresponding events. Root cause: the prior shape of
- * `worker.ts:scheduled` was `try { … } finally { … }` with no `catch` —
- * exceptions thrown by `refreshRadarSnapshot` (or its dependencies)
- * escaped `ctx.waitUntil`'s promise without ever being captured by
- * Sentry. The current implementation wraps the cron in `withMonitor`
- * (Sentry Crons check-in) and adds an outer `catch` that calls
- * `captureException` for the stack trace.
+ * Background (2026-05-19 → 2026-05-26): every cron firing reported
+ * `Exception Thrown` on Cloudflare's cron-events dashboard while the
+ * underlying radar work succeeded. Root cause traced to the SDK's
+ * `wrapScheduledHandler` queueing its own `ctx.waitUntil(flushAndDispose
+ * (client))` outside any try/catch we control. The structural fix is to
+ * stop wrapping `scheduled` with `withSentry` (the default export now
+ * passes `{ fetch }` only) and to use direct envelope POSTs for
+ * observability inside the cron path.
  *
- * This test exists because:
- *   1. No existing test exercised the scheduled handler at all — the
- *      cron-handler suite (`tests/unit/cron/radar-refresh.test.ts`)
- *      covers `refreshRadarSnapshot` in isolation; it never asked
- *      "what does the worker do if refreshRadarSnapshot rejects?"
- *   2. Two future regressions are possible: someone removes the catch
- *      (returns to the silent-Sentry state) OR someone changes the
- *      withMonitor invocation in a way that breaks the re-throw
- *      contract this code relies on. Both must fail this test loudly.
+ * These tests pin the new contract:
+ *   - `withSentry` is called with a handler that has NO `scheduled` key
+ *     (regression guard against future re-wrapping)
+ *   - Scheduled handler invokes `refreshRadarSnapshot` exactly once
+ *   - Success path: `postSentryCheckIn('in_progress')` → `('ok')` with
+ *     matching `checkInId`
+ *   - Error path: `postSentryCheckIn('in_progress')` → `postSentryEvent`
+ *     → `postSentryCheckIn('error')` with matching `checkInId`
+ *   - DSN-missing path: handler still completes and `refreshRadarSnapshot`
+ *     still runs
+ *   - `ctx.waitUntil` always resolves cleanly (no unhandled rejection)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // `@sentry/cloudflare` + `agents/mcp` use the `cloudflare:workers` URL
-// scheme internally — Node's default ESM loader rejects it. Mock both at
-// the package boundary so importing worker.ts doesn't crash. (Same
-// pattern as `tests/integration/radar-snapshot-endpoint.test.ts`.)
+// scheme internally — Node's default ESM loader rejects it. Mock both
+// at the package boundary so importing worker.ts doesn't crash.
+const { withSentryMock, mockPostCheckIn, mockPostEvent, mockSafeLog } = vi.hoisted(() => ({
+  withSentryMock: vi.fn(<T>(_opts: unknown, handler: T) => handler),
+  mockPostCheckIn: vi.fn(),
+  mockPostEvent: vi.fn(),
+  mockSafeLog: vi.fn(),
+}));
+
 vi.mock('@sentry/cloudflare', () => ({
   init: vi.fn(),
   captureMessage: vi.fn(),
@@ -35,30 +43,33 @@ vi.mock('@sentry/cloudflare', () => ({
   setTag: vi.fn(),
   flush: vi.fn().mockResolvedValue(true),
   withMonitor: vi.fn(),
-  withSentry: <T>(_opts: unknown, handler: T) => handler,
+  withSentry: withSentryMock,
 }));
 vi.mock('agents/mcp', () => ({
   createMcpHandler: () => async () =>
     new Response('{"error":"mcp-mocked-in-this-test"}', { status: 501 }),
 }));
 
-// Stub the observability + cron modules so the handler picks up mockable
-// versions of our own wrappers (the @sentry/cloudflare mock above
-// satisfies sentry.ts's own imports during module load).
 vi.mock('../../src/cron/radar-refresh');
 vi.mock('../../src/observability/sentry', () => ({
-  captureException: vi.fn(),
   captureMessage: vi.fn(),
-  flushSentry: vi.fn().mockResolvedValue(true),
   sentryOptions: vi.fn().mockReturnValue(undefined),
   tagRequest: vi.fn(),
-  withMonitor: vi.fn(),
-  withSentry: <T>(_opts: unknown, h: T) => h, // pass-through wrap for the default export
+  withSentry: withSentryMock, // pass-through wrap for the default export
+}));
+
+vi.mock('../../src/observability/sentry-envelope', () => ({
+  postSentryCheckIn: mockPostCheckIn,
+  postSentryEvent: mockPostEvent,
+}));
+
+vi.mock('../../src/auth/safe-logger', () => ({
+  safeLog: mockSafeLog,
 }));
 
 // Imports MUST come after vi.mock so the mocked modules are wired in.
 import { handler } from '../../src/worker';
-import * as sentry from '../../src/observability/sentry';
+import workerDefault from '../../src/worker';
 import * as cron from '../../src/cron/radar-refresh';
 import type { Env } from '../../src/worker';
 
@@ -86,43 +97,40 @@ function makeCtx(): { ctx: ExecutionContext; waitUntilPromises: Promise<unknown>
   return { ctx, waitUntilPromises };
 }
 
-describe('worker.ts scheduled handler — Sentry error capture (2026-05-25 regression)', () => {
+describe('worker default export — withSentry wraps fetch only (BL-032.76 regression guard)', () => {
+  it('withSentry is called with a handler literal that has NO scheduled key', () => {
+    // Load-bearing assertion against the 2026-05-19 incident shape. The
+    // SDK's `wrapScheduledHandler` queues its own ctx.waitUntil flush
+    // outside our control; passing a handler literal with `scheduled`
+    // attached re-introduces the broken cron status reporting. The
+    // default export MUST pass `{ fetch }` only.
+    expect(withSentryMock).toHaveBeenCalled();
+    const [, passedHandler] = withSentryMock.mock.calls[0]!;
+    expect(passedHandler).toHaveProperty('fetch');
+    expect(passedHandler).not.toHaveProperty('scheduled');
+  });
+
+  it('the default export still has both fetch and scheduled (composed after withSentry)', () => {
+    expect(workerDefault).toHaveProperty('fetch');
+    expect(workerDefault).toHaveProperty('scheduled');
+    expect(typeof workerDefault.scheduled).toBe('function');
+  });
+});
+
+describe('worker.ts scheduled handler — envelope check-in lifecycle (BL-032.76)', () => {
   beforeEach(() => {
-    vi.resetAllMocks();
-    // Default: withMonitor is a pass-through that runs its callback verbatim.
-    // Individual tests override this to simulate Sentry's re-throw behavior.
-    vi.mocked(sentry.withMonitor).mockImplementation(async (_slug: string, cb: () => unknown) =>
-      cb()
+    mockPostCheckIn.mockReset();
+    mockPostEvent.mockReset();
+    mockSafeLog.mockReset();
+    // Default: postSentryCheckIn returns a fresh id on in_progress,
+    // returns same id on closing check-ins.
+    mockPostCheckIn.mockImplementation(
+      async (_env, _slug, _status, _schedule, checkInId) => checkInId ?? 'fake-id-abc'
     );
-    vi.mocked(sentry.flushSentry).mockResolvedValue(true);
+    vi.mocked(cron.refreshRadarSnapshot).mockReset();
   });
 
-  it('captures the exception via captureException when refreshRadarSnapshot rejects', async () => {
-    const inoreaderError = new Error('Inoreader 503 Service Unavailable');
-    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(inoreaderError);
-
-    const { ctx, waitUntilPromises } = makeCtx();
-    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
-    await Promise.all(waitUntilPromises);
-
-    expect(sentry.captureException).toHaveBeenCalledTimes(1);
-    expect(sentry.captureException).toHaveBeenCalledWith(inoreaderError, {
-      source: 'cron.scheduled',
-      cron: FAKE_CRON,
-    });
-  });
-
-  it('always calls flushSentry, even on failure', async () => {
-    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('upstream failure'));
-
-    const { ctx, waitUntilPromises } = makeCtx();
-    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
-    await Promise.all(waitUntilPromises);
-
-    expect(sentry.flushSentry).toHaveBeenCalledTimes(1);
-  });
-
-  it('does NOT capture exception on the success path', async () => {
+  it('success path: in_progress → ok with matching checkInId', async () => {
     vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
       kind: 'success',
       wireItems: 5,
@@ -134,88 +142,127 @@ describe('worker.ts scheduled handler — Sentry error capture (2026-05-25 regre
     handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
     await Promise.all(waitUntilPromises);
 
-    expect(sentry.captureException).not.toHaveBeenCalled();
-    expect(sentry.flushSentry).toHaveBeenCalledTimes(1);
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      1,
+      FAKE_ENV,
+      'radar-refresh',
+      'in_progress',
+      FAKE_CRON
+    );
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      2,
+      FAKE_ENV,
+      'radar-refresh',
+      'ok',
+      FAKE_CRON,
+      'fake-id-abc'
+    );
+    expect(mockPostEvent).not.toHaveBeenCalled();
+    expect(cron.refreshRadarSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it('does NOT capture exception when refreshRadarSnapshot returns a non-error envelope', async () => {
-    // The `partial-both-failed` outcome means both tiers failed but
-    // refreshRadarSnapshot caught them internally and returned a result
-    // envelope — the scheduled handler should NOT double-report.
-    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
-      kind: 'partial-both-failed',
-      wireReason: 'inoreader-rate-limit',
-      fyiReason: 'inoreader-rate-limit',
-    });
+  it('error path: in_progress → postSentryEvent → error with matching checkInId', async () => {
+    const upstreamErr = new Error('Inoreader 503 Service Unavailable');
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(upstreamErr);
 
     const { ctx, waitUntilPromises } = makeCtx();
     handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
     await Promise.all(waitUntilPromises);
 
-    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      1,
+      FAKE_ENV,
+      'radar-refresh',
+      'in_progress',
+      FAKE_CRON
+    );
+    expect(mockPostEvent).toHaveBeenCalledTimes(1);
+    expect(mockPostEvent).toHaveBeenCalledWith(
+      FAKE_ENV,
+      expect.objectContaining({
+        level: 'error',
+        message: expect.stringContaining('Inoreader 503 Service Unavailable'),
+        tags: expect.objectContaining({ event: 'cron.scheduled', cron: FAKE_CRON }),
+      })
+    );
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      2,
+      FAKE_ENV,
+      'radar-refresh',
+      'error',
+      FAKE_CRON,
+      'fake-id-abc'
+    );
+
+    // safeLog contract — the operator-visible diagnostic line that
+    // `wrangler tail` surfaces. If a refactor drops this emit, the
+    // structured-log channel goes silent on cron errors. Reason is
+    // truncated to 200 chars so an oversized stack doesn't bloat the
+    // log line.
+    expect(mockSafeLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'cron.scheduled.error',
+        success: false,
+        reason: expect.stringContaining('Inoreader 503 Service Unavailable'),
+      })
+    );
+
+    // Ordering invariant: in_progress fires before refreshRadarSnapshot
+    // is awaited; postSentryEvent fires before the closing check-in.
+    const inProgressOrder = mockPostCheckIn.mock.invocationCallOrder[0]!;
+    const eventOrder = mockPostEvent.mock.invocationCallOrder[0]!;
+    const errorOrder = mockPostCheckIn.mock.invocationCallOrder[1]!;
+    expect(inProgressOrder).toBeLessThan(eventOrder);
+    expect(eventOrder).toBeLessThan(errorOrder);
   });
 
-  it('invokes withMonitor with the runtime cron expression from the ScheduledController', async () => {
-    // The cron schedule passed to Sentry must match the schedule that
-    // actually fired. We pull it from `event.cron` (Cloudflare's runtime
-    // truth) rather than hardcoding so a `wrangler.toml` schedule edit
-    // doesn't silently desync from Sentry's monitor config.
+  it('DSN-missing path: handler still runs refreshRadarSnapshot and propagates undefined checkInId to the closing check-in', async () => {
+    // When SENTRY_DSN is unbound, the envelope helpers short-circuit
+    // and return undefined. The handler must still invoke the underlying
+    // work — observability gracefully degrades; correctness does not.
+    mockPostCheckIn.mockResolvedValue(undefined);
     vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
       kind: 'success',
-      wireItems: 0,
+      wireItems: 1,
       fyiItems: 0,
-      callsConsumed: 0,
+      callsConsumed: 5,
     });
 
     const { ctx, waitUntilPromises } = makeCtx();
     handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
     await Promise.all(waitUntilPromises);
 
-    expect(sentry.withMonitor).toHaveBeenCalledTimes(1);
-    const [slug, _callback, config] = vi.mocked(sentry.withMonitor).mock.calls[0];
-    expect(slug).toBe('radar-refresh');
-    expect(config).toMatchObject({
-      schedule: { type: 'crontab', value: FAKE_CRON },
-      timezone: 'UTC',
-    });
+    expect(cron.refreshRadarSnapshot).toHaveBeenCalledTimes(1);
+    // Closing check-in is attempted (also a no-op without DSN) and
+    // receives the undefined checkInId we got back from the opener.
+    // Pinning the boundary here so a refactor that defaults the id
+    // (e.g. `checkInId ?? generateNew()`) doesn't silently change the
+    // contract DSN-bound callers depend on.
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      2,
+      FAKE_ENV,
+      'radar-refresh',
+      'ok',
+      FAKE_CRON,
+      undefined
+    );
   });
 
-  it('swallows the re-thrown exception so ctx.waitUntil resolves cleanly (no unhandled rejection escapes Cloudflare runtime)', async () => {
-    // This is the load-bearing assertion against the 2026-05-25 incident
-    // shape. If the catch is removed, the promise rejects → Cloudflare
-    // reports outcome:exception → Sentry has no event. The test would
-    // fail because `await Promise.all` would itself throw.
-    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('any throw'));
-
-    const { ctx, waitUntilPromises } = makeCtx();
-    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
-
-    // The IIFE inside ctx.waitUntil must resolve, NOT reject. If the
-    // handler regresses to a no-catch shape, this awaits a rejected
-    // promise and the test fails loudly with the original error.
-    await expect(Promise.all(waitUntilPromises)).resolves.toBeDefined();
-  });
-
-  it('swallows throws from flushSentry so Cloudflare sees outcome:ok even on Sentry-side failures (2026-05-25 18:00 UTC regression)', async () => {
-    // 0.3.12 introduced the catch around refreshRadarSnapshot but left
-    // `await flushSentry()` in the finally block unguarded. Cloudflare's
-    // cron dashboard continued to report `exception` on every firing
-    // because Sentry SDK flush failures (ingest network blips, quota
-    // rejections, internal SDK errors) propagated past the IIFE.
-    // Confirmed via the 2026-05-25 dashboard: cron successfully made
-    // the Inoreader call (/health.inoreaderObservedAt updated), but
-    // Cloudflare still reported Error.
+  it('postSentryEvent rejection does NOT escape ctx.waitUntil (observability never fails the cron)', async () => {
+    // Symptom-side of the BL-032.76 incident: the SDK's queued
+    // ctx.waitUntil for the auto-flush rejected and produced Cloudflare
+    // `Exception Thrown`. The envelope helpers are documented as
+    // best-effort/never-throw — but if a future refactor breaks that
+    // contract (e.g. removes the try/catch in postEnvelope), the cron
+    // status reporting would regress to the 2026-05-19 shape.
     //
-    // The 0.3.13 fix is an outer try/catch around the entire IIFE body
-    // that swallows Sentry-plumbing throws. This test forces flushSentry
-    // to reject and asserts ctx.waitUntil still resolves cleanly.
-    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
-      kind: 'success',
-      wireItems: 5,
-      fyiItems: 3,
-      callsConsumed: 6,
-    });
-    vi.mocked(sentry.flushSentry).mockRejectedValue(new Error('sentry ingest unreachable'));
+    // This test forces an envelope helper to reject and asserts the
+    // outer handler still resolves cleanly.
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('upstream'));
+    mockPostEvent.mockRejectedValue(new Error('sentry ingest 502'));
 
     const { ctx, waitUntilPromises } = makeCtx();
     handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
@@ -223,15 +270,12 @@ describe('worker.ts scheduled handler — Sentry error capture (2026-05-25 regre
     await expect(Promise.all(waitUntilPromises)).resolves.toBeDefined();
   });
 
-  it('swallows throws from captureException so flushSentry-then-resolve still happens (defense-in-depth)', async () => {
-    // Lower-probability path than the flushSentry case but covered by
-    // the same outer catch. If captureException somehow throws (Sentry
-    // SDK getting into a bad scope, fetch failure mid-capture), the
-    // finally block still runs flushSentry and ctx.waitUntil resolves.
-    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('upstream failure'));
-    vi.mocked(sentry.captureException).mockImplementation(() => {
-      throw new Error('sentry capture internal error');
-    });
+  it('ctx.waitUntil always resolves cleanly even when refreshRadarSnapshot rejects', async () => {
+    // Load-bearing — this is the symptom side of the 2026-05-19 incident.
+    // The IIFE inside ctx.waitUntil MUST resolve, NEVER reject, regardless
+    // of what `refreshRadarSnapshot` does. The catch in scheduled() is the
+    // safety net.
+    vi.mocked(cron.refreshRadarSnapshot).mockRejectedValue(new Error('any throw'));
 
     const { ctx, waitUntilPromises } = makeCtx();
     handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);


### PR DESCRIPTION
## Summary

Fixes the BL-032.76 incident where every MCP-server cron firing has reported `Exception Thrown` on Cloudflare's cron-events dashboard since 2026-05-19 while the underlying radar work succeeds, and Sentry receives zero `cron.radar-refresh.*` events.

**Root cause** (verified at SDK source): `@sentry/cloudflare`'s `withSentry` wraps the scheduled handler and queues its own `ctx.waitUntil(flushAndDispose(client))` outside any try/catch we control. Something in that queued promise rejects under Workers-runtime conditions. Three in-tree fixes (Day-3 flush, withMonitor layering, outer try/catch around the IIFE) did not resolve the symptom. Upstream check ([getsentry/sentry-javascript](https://github.com/getsentry/sentry-javascript)) surfaced no documented workaround and no SDK flag to disable the scheduled-handler wrap. Related open issue [#17476](https://github.com/getsentry/sentry-javascript/issues/17476) confirms `waitUntil` events are lost (adjacent, but a different symptom).

**Structural fix (Option B per backlog)**: stop wrapping the scheduled handler with `withSentry`; replace SDK calls in the cron path with direct `fetch()` POSTs to Sentry's envelope endpoint. Transport proven 2026-05-26 (event_id `7a22ca8212983f1d0b58a54e4f283841`).

### Changes
- **New `mcp-server/src/observability/sentry-envelope.ts`** — `parseDsn` / `postSentryEvent` / `postSentryCheckIn` / `captureMessageEnvelope`. AbortController 2000ms timeout, `crypto.randomUUID()` ids, `monitor_config` only on `in_progress` per Sentry Crons spec, best-effort (never throws).
- **`worker.ts` default export splits** to `withSentry({ fetch })` only; scheduled is exported bare. Regression-guard test pins the contract.
- **Scheduled handler** uses envelope check-ins (`in_progress` → `ok`/`error` by `check_in_id`) and posts the error event via envelope. Outer try/catch as defense-in-depth against helper-contract regression.
- **Cron-path `captureMessage` calls** in `radar-refresh.ts` (5 sites), `inoreader-oauth.ts`, `inoreader-failure-handler.ts`, and `inoreader-egress.ts` all routed through envelope so cron-fired observability from OAuth refresh + 429 handling + spend-drift actually lands.

### Tests
- **New `tests/unit/observability/sentry-envelope.test.ts`** (19 tests): parseDsn edge cases including empty-string + path-suffix; envelope wire shape (URL / headers / 3-line body / payload); DSN-missing short-circuit; fetch-reject swallow; AbortController timeout via fake timers; monitor_config presence-by-status; no-release negative.
- **Rewritten `tests/unit/worker-scheduled.test.ts`** (8 tests): regression guard that `withSentry` is called with a handler literal that has NO `scheduled` key; success/error lifecycle; DSN-missing path with `checkInId=undefined` propagation; `postSentryEvent` rejection still resolves `ctx.waitUntil` cleanly; safeLog contract on the error path.
- **Mock swaps** in `radar-refresh`, `inoreader-failure-handler`, `inoreader-oauth`, `inoreader-egress` tests for the new envelope signature (env as leading positional arg).

### Why scope includes shared inoreader modules
The audit traced cron path through `maybeProactiveRefresh` → `refreshAccessToken('cron')` → `captureMessage`, and `handleInoreaderFailure` from `radar-refresh.ts:271,274`. Without bringing these in, Option B would have regressed observability on those paths (post-fix the cron has no isolate-lifetime contract over SDK-queued events). Scope decision recorded in [the plan](https://github.com/Global-Strategic-Technologies/gst-website/blob/feature/bl-032.76-cron-sentry-bypass/.claude/plans).

### Verification
- `npm run typecheck` ✅
- `npm test` — 870/872 mcp-server tests pass (2 pre-existing portfolio-count failures on master, unrelated)
- `npx astro check` ✅
- `npm run test:run` — 1173/1173 root tests pass

## Test plan
- [ ] CI green
- [ ] Deploy to production: `cd mcp-server && npm run deploy:production`
- [ ] Confirm `/health.gitSha` matches deploy commit
- [ ] Use Cloudflare dashboard **"Trigger Scheduled Event"** button for first verification firing (avoids Inoreader budget burn of an accelerated cron schedule)
- [ ] Cloudflare cron-events dashboard reports `Success` (not `Error`)
- [ ] Sentry mcp-server → Crons shows monitor `radar-refresh` with `in_progress` → `ok` pair
- [ ] Sentry mcp-server → Issues receives `cron.radar-refresh.success` event
- [ ] `/health.inoreaderObservedAt` updates within 3s of trigger
- [ ] `wrangler tail` shows clean `safeLog` lines, no exception headers
- [ ] Wait for next scheduled `0 */6 * * *` firing and confirm same `Success` status

## Unblocks / strengthens
- **Unblocks BL-032.75 Phase 3** alerting — alerts on Cloudflare cron status become reliable once 100% of firings stop reporting Error.
- **Strengthens BL-033** pilot SLA story — cron-reliability conversation no longer carries a misleading dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)