### PR TITLE
feat(mcp): BL-032.77 — instrument postEnvelope failure modes + persistent Workers observability

### DIFF
--- a/mcp-server/src/observability/sentry-envelope.ts
+++ b/mcp-server/src/observability/sentry-envelope.ts
@@ -33,6 +33,7 @@
  * ingest cannot extend `ctx.waitUntil` past its budget.
  */
 
+import { safeLog } from '../auth/safe-logger';
 import type { Env } from '../worker';
 
 interface ParsedDsn {
@@ -64,10 +65,28 @@ function randomEventId(): string {
 }
 
 async function postEnvelope(dsn: ParsedDsn, body: string): Promise<void> {
+  // BL-032.77 — diagnose Sentry-side envelope failures (missing-check-in
+  // alerts that don't match Cloudflare-side success). Three failure modes
+  // get distinct `safeLog` lines so a `wrangler tail` filter can attribute
+  // each missed check-in or noise burst to its root cause:
+  //
+  //   1. `sentry.envelope.post.non-2xx` — Sentry rejected the envelope (429
+  //      project rate limit, 503 transient, etc). Until this instrumentation
+  //      shipped, these were silent — the success path returned cleanly even
+  //      though Sentry never accepted the event. Suspected dominant cause
+  //      of the "timeout check-in" false-positive alerts.
+  //   2. `sentry.envelope.post.aborted` — local 2s timeout tripped before
+  //      response arrived. Network/DNS hiccup or Sentry-side slow ingest.
+  //   3. `sentry.envelope.post.network-error` — fetch itself threw (TLS,
+  //      DNS NXDOMAIN, etc). Rarest path; included for completeness.
+  //
+  // All three paths still resolve the promise cleanly — best-effort
+  // contract preserved; the caller's `ctx.waitUntil` is unaffected.
+  const url = `https://${dsn.host}/api/${dsn.projectId}/envelope/`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), ENVELOPE_TIMEOUT_MS);
   try {
-    await fetch(`https://${dsn.host}/api/${dsn.projectId}/envelope/`, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-sentry-envelope',
@@ -76,10 +95,26 @@ async function postEnvelope(dsn: ParsedDsn, body: string): Promise<void> {
       body,
       signal: controller.signal,
     });
-  } catch {
-    // Best-effort — swallow network errors, abort timeouts, and any
-    // other fetch rejection so the caller's ctx.waitUntil resolves
-    // cleanly. There is no recovery path.
+    if (!response.ok) {
+      safeLog({
+        event: 'sentry.envelope.post.non-2xx',
+        status: response.status,
+        success: false,
+        errorCode: 'sentry-envelope-non-2xx',
+        reason: `host=${dsn.host} project=${dsn.projectId}`,
+      });
+    }
+  } catch (err) {
+    // AbortError when the controller fires; everything else is a genuine
+    // network / TLS / DNS failure. Distinguish so the operator can tell
+    // "Sentry is slow" from "we can't reach Sentry."
+    const isAbort = err instanceof DOMException && err.name === 'AbortError';
+    safeLog({
+      event: isAbort ? 'sentry.envelope.post.aborted' : 'sentry.envelope.post.network-error',
+      success: false,
+      errorCode: isAbort ? 'sentry-envelope-abort' : 'sentry-envelope-network',
+      reason: err instanceof Error ? err.message.slice(0, 200) : 'unknown',
+    });
   } finally {
     clearTimeout(timer);
   }

--- a/mcp-server/tests/unit/observability/sentry-envelope.test.ts
+++ b/mcp-server/tests/unit/observability/sentry-envelope.test.ts
@@ -257,3 +257,103 @@ describe('captureMessageEnvelope (shim for shared-module callers)', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+describe('postEnvelope failure-mode instrumentation (BL-032.77)', () => {
+  // These cover the three new safeLog paths added 2026-05-28 to diagnose
+  // false-positive "timeout check-in" alerts on Sentry's Crons UI while
+  // Cloudflare's cron dashboard reports 100% success. The helpers stay
+  // best-effort (no throws); the new lines just add visibility so the
+  // operator can attribute each silent envelope drop to its root cause.
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // safeLog emits via console.log; capture so we can assert on it.
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  function findLogLine(eventName: string): Record<string, unknown> | undefined {
+    for (const call of consoleSpy.mock.calls) {
+      const arg = call[0];
+      if (typeof arg !== 'string') continue;
+      try {
+        const parsed = JSON.parse(arg) as Record<string, unknown>;
+        if (parsed.event === eventName) return parsed;
+      } catch {
+        // not JSON; skip
+      }
+    }
+    return undefined;
+  }
+
+  it('logs sentry.envelope.post.non-2xx with status when Sentry rejects', async () => {
+    // 429 (project rate-limit) is the suspected dominant failure mode.
+    fetchSpy.mockResolvedValueOnce(new Response('rate limited', { status: 429 }));
+    await postSentryEvent(env, { level: 'info', message: 'rate-limited heartbeat' });
+
+    const log = findLogLine('sentry.envelope.post.non-2xx');
+    expect(log).toBeDefined();
+    expect(log?.status).toBe(429);
+    expect(log?.success).toBe(false);
+    expect(log?.errorCode).toBe('sentry-envelope-non-2xx');
+    expect(typeof log?.reason).toBe('string');
+    expect((log?.reason as string).includes('host=')).toBe(true);
+    expect((log?.reason as string).includes('project=')).toBe(true);
+  });
+
+  it('logs sentry.envelope.post.non-2xx for 5xx (transient) the same way', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('upstream', { status: 503 }));
+    await postSentryEvent(env, { level: 'error', message: 'transient sentry' });
+    const log = findLogLine('sentry.envelope.post.non-2xx');
+    expect(log?.status).toBe(503);
+  });
+
+  it('does NOT log non-2xx for 2xx responses (happy path stays silent)', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('', { status: 200 }));
+    await postSentryEvent(env, { level: 'info', message: 'ok' });
+    expect(findLogLine('sentry.envelope.post.non-2xx')).toBeUndefined();
+    expect(findLogLine('sentry.envelope.post.aborted')).toBeUndefined();
+    expect(findLogLine('sentry.envelope.post.network-error')).toBeUndefined();
+  });
+
+  it('logs sentry.envelope.post.aborted when AbortController fires (2s timeout)', async () => {
+    fetchSpy.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal!.addEventListener('abort', () => {
+            const err = new DOMException('The operation was aborted', 'AbortError');
+            reject(err);
+          });
+        })
+    );
+    vi.useFakeTimers();
+    const pending = postSentryEvent(env, { level: 'error', message: 'slow' });
+    await vi.advanceTimersByTimeAsync(2000);
+    await pending;
+
+    const log = findLogLine('sentry.envelope.post.aborted');
+    expect(log).toBeDefined();
+    expect(log?.errorCode).toBe('sentry-envelope-abort');
+  });
+
+  it('logs sentry.envelope.post.network-error for non-abort fetch rejection', async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await postSentryEvent(env, { level: 'error', message: 'no network' });
+
+    const log = findLogLine('sentry.envelope.post.network-error');
+    expect(log).toBeDefined();
+    expect(log?.errorCode).toBe('sentry-envelope-network');
+    expect((log?.reason as string).includes('Failed to fetch')).toBe(true);
+  });
+
+  it('still resolves cleanly on every failure path (best-effort contract)', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('', { status: 429 }));
+    await expect(postSentryEvent(env, { level: 'info', message: 'x' })).resolves.toBeUndefined();
+
+    fetchSpy.mockRejectedValueOnce(new TypeError('network'));
+    await expect(postSentryEvent(env, { level: 'info', message: 'y' })).resolves.toBeUndefined();
+  });
+});

--- a/mcp-server/wrangler.toml
+++ b/mcp-server/wrangler.toml
@@ -52,6 +52,36 @@ upload_source_maps = true
 binding = "METRICS"
 dataset = "mcp_events_dev"
 
+# ---------------------------------------------------------------------------
+# Cloudflare Workers Observability — persistent logs + traces (BL-032.77)
+# ---------------------------------------------------------------------------
+# Native Workers Logs + Workers Traces. Configured here so every deploy
+# enables them automatically — no more toggling via the Cloudflare dashboard
+# on each environment after a redeploy.
+#
+# Use cases (separate from BL-032.75 Phase 1 Analytics Engine emission):
+#   - Workers Logs: searchable request/invocation logs with 3-day retention
+#     on Free plan (200k events/day) — primary surface for diagnosing the
+#     BL-032.77 Sentry-envelope failure modes without leaning on Sentry's
+#     own ingest. Our `safeLog` lines (including the new `sentry.envelope.
+#     post.{non-2xx,aborted,network-error}` instrumentation) land here.
+#   - Workers Traces: per-invocation execution timeline. Useful for
+#     correlating cron-firing duration with `ok` check-in timing —
+#     direct evidence for or against the "isolate eviction mid-firing"
+#     hypothesis in BL-032.77 Issue B.
+#
+# The top-level `enabled = false` is the deprecated all-or-nothing flag;
+# the modern per-feature `logs.enabled` / `traces.enabled` flags below are
+# the granular controls. Cloudflare's wrangler reader honors both.
+#
+# Inheritance: top-level observability applies to all envs by default.
+# No per-env override needed; staging + production both pick this up.
+[observability]
+enabled = false
+head_sampling_rate = 1
+logs = { enabled = true, head_sampling_rate = 1, persist = true, invocation_logs = true }
+traces = { enabled = true, persist = true, head_sampling_rate = 1 }
+
 # nodejs_compat is required because the `agents` SDK pulls in `mimetext`
 # (uses node:os) and `mime-types` (uses node:path) transitively through its
 # observability module. Cloudflare's nodejs_compat layer polyfills these

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -2221,6 +2221,113 @@ All three audits converged on: **bypass the SDK on the scheduled path entirely**
 
 ---
 
+### BL-032.77: Sentry envelope-POST reliability + cron drift-detection refinement
+
+**Source**: 2026-05-28 post-deploy observation session — three open Sentry issues on the `gst-mcp-server` project, none of which match the underlying reality of the system (Cloudflare cron logs show 100% success; `/health` confirms radar substrate healthy; Inoreader Developer Console shows 25% daily usage well under budget). | **Effort**: ~half-day investigation (instrumentation) + ~half-day fix once root cause confirmed | **Status**: 🟡 **In progress** — instrumentation PR (TBD) lands the observability-of-observability layer; fixes follow after the next ~1-2 missed check-in events surface the root cause | **Depends on**: BL-032.76 (the envelope path this ticket investigates) | **Blocks**: BL-032.75 Phase 3 alerting credibility (alerts on `cron.radar-refresh.*` Sentry events are unreliable signal while every successful firing surfaces as a noisy Issue + occasional false-positive "timeout check-in")
+
+**As an** operator monitoring the MCP Worker, **I want** Sentry's `gst-mcp-server` Issues view to reflect actionable failures only (not "every cron success creates an Issue" and not "false-positive missed check-in alerts"), AND I want the Phase 0 `inoreader.spend.drift` detection to fire only on real drift (not on parallel-cron eventual-consistency races), **so that** I can trust the Sentry signal as the canonical operations dashboard for BL-033 SLA reporting.
+
+#### Symptoms (observed 2026-05-28 18:00 UTC-3)
+
+The Sentry project `gst-mcp-server` shows three unresolved issues across `All Envs` / 24h:
+
+| Issue                                                                                       | Age  | Events | Users | Severity            |
+| ------------------------------------------------------------------------------------------- | ---- | ------ | ----- | ------------------- |
+| `Cron failure: radar-refresh` — "Your monitor is failing: A timeout check-in was detected." | 4hr  | 2      | 0     | New / Investigating |
+| `cron.radar-refresh.success` — (No error message)                                           | 10hr | 4      | 3     | Ongoing             |
+| `inoreader.spend.drift` — (No error message)                                                | 10hr | 1      | 1     | New                 |
+
+The radar loads correctly via `/hub/radar` (Cloudflare cron dashboard reports 100% success across the same 24h window). Inoreader's quota at the time of this report: **25% of Zone-1 daily budget, 0% Zone-2**.
+
+#### Triage by issue
+
+##### Issue A — `cron.radar-refresh.success` Sentry Issue (4 events / 3 users / Ongoing)
+
+**Source**: [`cron/radar-refresh.ts:255-261`](mcp-server/src/cron/radar-refresh.ts#L255-L261) emits `captureMessageEnvelope('cron.radar-refresh.success', 'info', ...)` on **every successful firing**. Sentry treats every `captureMessage` call as an Issue regardless of `level` — so every success creates/updates one grouped Issue with re-fires.
+
+**Why it used to make sense**: pre-BL-032.76, this was the only Sentry-side signal that crons were running. Defended as a positive heartbeat.
+
+**Why it's now redundant**: BL-032.76 ships a proper Sentry Crons check-in (`postSentryCheckIn(env, 'radar-refresh', 'ok', ...)`) for the same signal. BL-032.75 Phase 1 (PR #179) will dual-write a `cron_outcome` event to AE once Step 6 wires the emitter post-soak. The captureMessage is duplicate signal AND actively misleading (green successes show up as an unresolved Issue).
+
+**Decision (2026-05-28)**: **keep the success captureMessage for now**, as a backup heartbeat until Issue B (envelope check-in reliability) is fully diagnosed and resolved. Once we have ≥7 days of clean Sentry Crons check-ins post-fix, drop the captureMessage in a one-line follow-up commit.
+
+##### Issue B — "Cron failure: timeout check-in" (2 events / 4hr ago / New)
+
+**Symptom**: Sentry Crons monitor flags a missed close-in. The `in_progress` check-in was received but no matching `ok`/`error` arrived within the auto-created monitor's window. Cloudflare cron logs confirm the firing succeeded; the radar substrate is healthy; the cron handler reached the `ok` branch (otherwise `radar-refresh.success` wouldn't have surfaced as Issue A).
+
+**Root cause hypothesis (likeliest first)**:
+
+1. **`postEnvelope` doesn't check `response.ok`.** [`sentry-envelope.ts:79`](mcp-server/src/observability/sentry-envelope.ts#L79) does `await fetch(...)` then `catch {}` on network errors only — Sentry-side 4xx (e.g. 429 project-rate-limit) or 5xx (transient) returns silently. Each cron firing currently emits **~4-5 envelope events within seconds**: `in_progress` check-in + `proactive-refresh.skipped` (info) + `radar-refresh.success` (info) + `ok` check-in + occasionally `inoreader.spend.drift` (warning) or OAuth-refresh captures. That burst can trip Sentry's project-level Spike Protection or per-DSN throttling. We have zero visibility into Sentry-side rejection today.
+
+2. **Sentry's `check_in_id` matching fails** between `in_progress` and `ok` envelopes — would require a serialization mismatch we can't see; unlikely given the code is uniform, but verifiable per-event in Sentry's UI by inspecting check-in pair IDs.
+
+3. **Worker isolate eviction mid-firing** — `ctx.waitUntil` gives 30s wall-clock on free tier (much longer on paid). The IIFE chain (~10-30s wall-clock for the full radar refresh) shouldn't approach the limit, but a cold-start + Inoreader latency spike + Upstash flap could.
+
+4. **Network blip on the `ok` POST** — possible but doesn't fit the 25% drop rate (2 misses out of ~8 firings since the BL-032.76 deploy).
+
+**Initial proposal rejected by operator (2026-05-28)**: adding retry-once + tighter `monitor_config` margins felt like patching symptoms without identifying the root cause. The operator's instinct is correct — we should diagnose before fixing.
+
+**Agreed first action**: **instrument `postEnvelope` to log on non-2xx response (with status + URL) AND log on abort/timeout separately.** Deploy, wait for the next 1-2 missed check-ins, observe which failure mode hits. Then decide between:
+
+- "Sentry envelope returned 429" → reduce per-firing envelope count (drop Issue A's captureMessage; throttle drift alerts) OR raise the Sentry project's quota / Spike Protection threshold
+- "Sentry envelope returned 5xx" → transient; retry-once IS the right fix
+- "fetch aborted (timeout)" → network blip; retry-once still appropriate
+- No new visibility → deeper investigation needed (Worker isolate lifecycle; check-in ID matching)
+
+##### Issue C — `inoreader.spend.drift` (1 event / 10hr ago / New)
+
+**Payload** (from operator's Sentry UI inspection 2026-05-28):
+
+```
+category: cron-radar
+counter:  4
+drift:    3
+observed: 1
+```
+
+**Initial interpretation (incorrect)**: counter > observed means our wrapper is over-counting Zone-1 calls — maybe `stream/contents/*` is actually Zone-2 not Zone-1.
+
+**Verified against Inoreader docs (2026-05-28)** [https://www.inoreader.com/developers/rate-limiting](https://www.inoreader.com/developers/rate-limiting): `/reader/api/0/tag/list`, `/reader/api/0/stream/contents/*`, and `/reader/api/0/stream/items/contents` are **all Zone 1**. Our wrapper's classification ([`inoreader-egress.ts:83-89`](mcp-server/src/lib/inoreader-egress.ts#L83-L89)) is correct.
+
+**Refined root-cause hypothesis**: **Inoreader's quota counter has eventual consistency under parallel cron load.** A single cron firing makes 6 Zone-1 calls in parallel via `Promise.all` (1 tag-list + 4 folder streams + 1 annotated-items). The `X-Reader-Zone1-Usage` header on each response reflects Inoreader's server-side cumulative count at the time the request was processed. Under parallel load, the first request to complete observes a low `usage` value while our local counter (incrementing on each completion) is already higher.
+
+Timeline that matches the payload:
+
+- 6 cron-radar calls fire in parallel
+- First call completes; Inoreader's counter shows 1 (just incremented for this call); our local counter increments to 1 → drift = 0
+- Three more calls complete; their response headers are undefined OR carry stale low values (because Inoreader's serialization is concurrent-write-then-read, not synchronous-batch); our local counter is now 4
+- Fourth call completes with header=1 → drift = 4 - 1 = 3 → alert fires
+
+This is **drift detection working as designed but flagging a non-actionable race condition**.
+
+**Why this matters**: a real drift signal (uncounted egress path, like the 15-25% gap that justified the Phase 0 wrapper in the first place) would show up as **persistent drift across days** — not one event from a single firing. The current per-call drift check with daily debounce is too sensitive for parallel-cron workloads.
+
+**Fix options (to evaluate after Issue B instrumentation lands)**:
+
+- **(a)** Raise `DRIFT_THRESHOLD_ABS` from 2 to ~6 (one cron firing's full Zone-1 count). Catches over-counting on a >cron-firing scale; tolerates parallel-completion races.
+- **(b)** Move drift check from per-call to end-of-firing: after `refreshRadarSnapshot` completes, compare the post-firing local counter delta vs the LAST observed `X-Reader-Zone1-Usage` value of the firing.
+- **(c)** Capture parallel-firing semantics explicitly: drift fires only when counter > observed + (expected_parallel_count_of_current_firing).
+
+Option (a) is cheapest; option (b) is most correct. Pick after instrumentation data clarifies whether single drift events represent real over-counting that the threshold-bump would silence vs the race we suspect.
+
+#### Acceptance criteria
+
+- [ ] **Instrumentation lands** — `postEnvelope` checks `response.ok`; logs non-2xx status + URL via `safeLog`; logs abort/timeout separately. No behavioral change to the success path; net +20 LOC.
+- [ ] **Cloudflare Worker observability** enabled persistently via wrangler config (`[observability]` block with `logs.enabled = true` + `traces.enabled = true`) so operators don't have to toggle via dashboard every deploy.
+- [ ] **Diagnosis deliverable** — after 1-week post-deploy window OR 3 missed check-in events (whichever comes first), file a follow-up commit documenting which failure mode dominates. Update this stanza with findings.
+- [ ] **Issue B fix lands** — choice driven by diagnosis data; could be retry-once / Sentry Spike Protection adjustment / envelope-emit throttling / something else.
+- [ ] **Issue C fix lands** — one of the three options above; choice driven by whether the post-instrumentation data shows persistent drift (real bug) or transient firing-window drift (parallel race).
+- [ ] **Issue A captureMessage retired** — only after Issue B's check-in reliability is verified over 7+ days of clean Sentry Crons signal.
+- [ ] BL-032.76 stanza updated with cross-reference to this ticket as the "verification-pass follow-up."
+
+#### Out of scope
+
+- Migrating to Sentry SDK on the cron path — explicitly chosen against in BL-032.76; the envelope path is the architectural decision.
+- Adding OpenTelemetry tracing for cron firings — BL-032.75 Phase 3 deferred-tracing decision still holds.
+- Changing the cron cadence — `0 */6 * * *` is correct per BL-032.7 budget math.
+
+---
+
 ### BL-033: MCP Server — External Pilot (Phase 3)
 
 **Source**: MCP_SERVER_INITIATIVE.md (archived) | **Effort**: 2 weeks engineering + indeterminate legal/sales lead time | **Status**: Open | **Depends on**: BL-032, BL-032.7 (substrate safety + observability — shipped 2026-05-16), **BL-032.8** (radar consumer unification — precondition; eliminates the website's direct Inoreader caller so all consumers — including pilot clients — go through the same canonical MCP path with the BL-032.7 protections)


### PR DESCRIPTION
## Summary

Diagnosis layer for three live Sentry issues on `gst-mcp-server` that don't match the underlying reality of the system (Cloudflare cron logs show 100% success; `/health` confirms healthy radar substrate; Inoreader at 25% Zone-1 quota).

This PR ships **instrumentation only** — no behavior changes to the success path. Once deployed, the next 1-2 missed check-in events will surface their root-cause attribution in `wrangler tail` / Workers Logs, then a follow-up PR ships the actual fix.

## Issues being investigated

| Issue | Severity | Status in this PR |
|---|---|---|
| `Cron failure: timeout check-in` (2 events, 4hr ago) | Active investigation | Instrumentation lands this PR; fix follows once data confirms root cause |
| `cron.radar-refresh.success` as Sentry Issue (4 events, "Ongoing") | Known noise; keep as backup heartbeat | Defer cleanup until Issue B's check-in reliability is verified |
| `inoreader.spend.drift` (1 event, payload `counter=4 observed=1 drift=3`) | Likely false positive (parallel-cron eventual-consistency race) | Inoreader docs confirm our Zone-1 classification is correct; refinement options documented in BACKLOG |

Full triage + 4 ranked root-cause hypotheses for Issue B in [BACKLOG.md § BL-032.77](src/docs/development/BACKLOG.md).

## What lands

### 1. `postEnvelope` instrumentation (`sentry-envelope.ts`)

Three distinct `safeLog` lines emit on previously-silent failure modes:

- **`sentry.envelope.post.non-2xx`** with `status` + host + project — Sentry rejected the envelope (suspected dominant cause: project-level 429 from envelope burst during cron firing)
- **`sentry.envelope.post.aborted`** — 2s `AbortController` timeout tripped (slow ingest or network)
- **`sentry.envelope.post.network-error`** — fetch threw (DNS / TLS / etc) — distinguished from abort via `DOMException` AbortError check

Behavior unchanged on the success path. Best-effort contract preserved — every failure path still resolves cleanly so `ctx.waitUntil` is unaffected.

### 2. Persistent Workers Observability (`wrangler.toml`)

Top-level `[observability]` block enabling Workers Logs (200k events/day + 3-day retention on Free plan) and Workers Traces. **No more manual dashboard toggling on each deploy.** Inheritance applies to all envs (dev / staging / production).

Workers Logs is the primary surface for the new `sentry.envelope.post.*` lines — search-queryable, persistent, doesn't depend on Sentry itself being reachable.

### 3. BL-032.77 backlog entry (`BACKLOG.md`)

Full investigation captured for future contributors:
- Symptoms verbatim from 2026-05-28 Sentry dashboard
- Per-issue triage + ranked root-cause hypotheses
- Acceptance criteria + out-of-scope
- Cross-references to BL-032.76 (sibling) and BL-032.75 Phase 3 (downstream alerting credibility dependency)

## Test plan

- [x] `npm run typecheck` clean
- [x] 6 new envelope tests cover: 429 non-2xx, 503 non-2xx, happy-path silence, abort with timer, network-error fetch rejection, best-effort resolution contract under every failure mode
- [x] All existing envelope tests still green (19 → 25)
- [x] `npx wrangler deploy --dry-run --env staging` accepts the observability config
- [ ] **After merge + deploy**: wait for the next 1-2 missed check-ins; observe which `sentry.envelope.post.*` event fires; file a follow-up PR with the matching fix (retry-once if 5xx/abort dominates; envelope throttling + per-firing event reduction if 429 dominates)

## Follow-ups

Tracked in BL-032.77 ACs:
- Issue B fix (driven by post-deploy diagnosis data)
- Issue C drift-detection refinement (raise threshold, OR move check to end-of-firing, OR explicit parallel-firing semantics)
- Issue A `cron.radar-refresh.success` captureMessage retired (only after 7+ days of clean Sentry Crons signal post-Issue-B fix)

## Branch context

Branched from `dev` at `b3afefb` (before PR #179 merged). PR #180 (`dev → master`) is currently open for review; this PR can be retargeted to master after #180 lands if you prefer, or merged into dev first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)