### PR TITLE
docs(deploy): correct AE setup — one-time dashboard enable required

### DIFF
--- a/mcp-server/src/docs/operations/DEPLOY.md
+++ b/mcp-server/src/docs/operations/DEPLOY.md
@@ -247,24 +247,39 @@ The Worker reads OAuth tokens from Upstash first ([Q4](../../../../src/docs/deve
 
 ### Steps
 
-**Nothing to do.** Analytics Engine datasets auto-materialize on first `writeDataPoint` after `wrangler deploy` — no manual provisioning in the dashboard is required (per [Cloudflare's get-started page](https://developers.cloudflare.com/analytics/analytics-engine/get-started/): "Workers Analytics Engine datasets are created automatically the first time you write to them after defining the binding in your Wrangler configuration").
+**One-time account-level enable.** Cloudflare's [get-started page](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) claims datasets auto-materialize on first `writeDataPoint` after the binding is declared, but **first-deploy reality (2026-05-28)** is that Analytics Engine has to be enabled on the account first. The "enable" surface is the **Create Blank Dataset** dialog in the dashboard — creating ANY dataset there flips the account-level switch.
 
-The binding is already declared in [`mcp-server/wrangler.toml`](../../../wrangler.toml) per environment:
+The fastest way to do this:
 
-- `wrangler dev` (no `--env`): dataset `mcp_events_dev`
-- `--env staging`: dataset `mcp_events_staging`
-- `--env production`: dataset `mcp_events`
+1. **Cloudflare dashboard** → Workers & Pages → **Analytics Engine** in the left nav (or direct link from the deploy error message)
+2. Click **Create Blank Dataset**
+3. **Dataset Name**: `mcp_events_staging` (match the staging dataset name pinned in `wrangler.toml`)
+4. **Dataset Binding**: `METRICS` (match the binding name)
+5. Click **Create Dataset**
+6. Close the "binding info" modal that follows — our `wrangler.toml` already declares the binding it shows
+
+After this one-time enable, the deploy succeeds AND every subsequent dataset (`mcp_events`, `mcp_events_dev`) auto-materializes on first write. The dashboard text confirms this — "the dataset will not appear until after you bind it to a worker and write data to it."
+
+### Per-env dataset map (already pinned in `wrangler.toml`)
+
+| Env                         | Dataset              | Binding   | Created via                                      |
+| --------------------------- | -------------------- | --------- | ------------------------------------------------ |
+| `wrangler dev` (no `--env`) | `mcp_events_dev`     | `METRICS` | Auto on first write                              |
+| `--env staging`             | `mcp_events_staging` | `METRICS` | **Manual dashboard step (account-level enable)** |
+| `--env production`          | `mcp_events`         | `METRICS` | Auto on first write (after staging step above)   |
 
 ### Verification (after first deploy)
 
-1. `npx wrangler deploy --env staging`.
-2. Send any authenticated request to `https://mcp-staging.globalstrategic.tech/mcp` (the metrics-emission integration test or a manual `curl` with a real bearer works).
-3. `npx wrangler tail --env staging` and confirm **no** `metrics.sink.write_failed` line appears. If one does, the binding is misconfigured — re-check `wrangler.toml`.
-4. (Optional, requires Phase 3 token — see [C.X below](#cx--analytics-engine-sql-query-bl-03275-phase-3)): query AE via the SQL API and confirm rows are appearing in `mcp_events_staging`.
+1. `npx wrangler deploy --env staging` — should succeed cleanly post-enable
+2. `npx wrangler deploy --env production` — auto-binds without dashboard prompts (the account-level enable carries over)
+3. Look at the deploy output's bindings table — confirms `env.METRICS (mcp_events_staging)` for staging and `env.METRICS (mcp_events)` for production. Different dataset names = different AE datasets = no staging/prod contamination.
+4. After the next cron firing (or any authenticated MCP request that exercises a tool/resource/prompt), `npx wrangler tail --env <env>` should show no `metrics.sink.write_failed` lines. If one appears, the binding-vs-dataset shape is wrong — re-check `wrangler.toml`.
+5. Within ~5-10 min of first writes, the Cloudflare dashboard → Workers & Pages → Analytics Engine should show both datasets populated.
+6. (Optional, requires Phase 3 token — see [C.X below](#cx--analytics-engine-sql-query-bl-03275-phase-3)): query AE via the SQL API and confirm rows.
 
 ### What you've completed
 
-✅ AE is bound; instrumented Tool / Resource / Prompt invocations write events to the per-env dataset.
+✅ AE is enabled at account level. Both per-env datasets exist (or will auto-materialize on first write). Instrumented Tool / Resource / Prompt invocations write events to the per-env dataset.
 
 ---
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -2327,6 +2327,14 @@ Option (a) is cheapest; option (b) is most correct. Pick after instrumentation d
 - Adding OpenTelemetry tracing for cron firings — BL-032.75 Phase 3 deferred-tracing decision still holds.
 - Changing the cron cadence — `0 */6 * * *` is correct per BL-032.7 budget math.
 
+#### Deploy-time lessons learned (2026-05-28 production deploy)
+
+**Cloudflare Analytics Engine requires a one-time dashboard step before first deploy.** Cloudflare's [get-started docs](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) claim datasets auto-materialize on first write after the binding is declared — and that's TRUE for second-and-later datasets, but the **first** dataset has to be created via the dashboard's "Create Blank Dataset" dialog (with binding name `METRICS` matching wrangler.toml). This flips the account-level enable. Subsequent datasets across other envs (e.g. `mcp_events` after `mcp_events_staging` was created manually) auto-materialize as advertised.
+
+The BL-032.75 Phase 1 closeout audit (PR #179) explicitly claimed "NO manual provisioning required for Phase 1 emission" — that was wrong. DEPLOY.md § A.4.5 has been corrected in this commit to walk operators through the one-time account-level enable. Future operators (or future-you across an Account-level fresh start) won't be surprised.
+
+**This is the kind of doc claim that needs adversarial-audit verification against production reality, not just doc-vs-doc reading.** Cloudflare's own docs were the source of the wrong claim — the audit verified the claim against docs but didn't verify the docs against a real deploy. Lesson for future plan-audit cycles: when a doc-cited fact gates a deploy step, prove it with a dry-run against a real account before declaring the audit clean.
+
 ---
 
 ### BL-033: MCP Server — External Pilot (Phase 3)


### PR DESCRIPTION
## Summary

The BL-032.75 Phase 1 closeout audit cited Cloudflare's docs claiming AE datasets auto-materialize on first write, and declared "NO manual provisioning required." Production deploy 2026-05-28 hit the "Create Blank Dataset" dashboard prompt the audit had said was impossible.

This PR corrects the doc + captures the lesson. (origin/dev was auto-deleted after PR #180 merged, so targeting master directly.)

## What changed

**`DEPLOY.md § A.4.5`**: rewrote the "Nothing to do" claim with the actual one-time-dashboard-enable walkthrough. The first dataset on a new account requires manual creation via Create Blank Dataset (dataset name `mcp_events_staging`, binding `METRICS`). Subsequent envs (production `mcp_events`, local `mcp_events_dev`) auto-materialize on first write as the Cloudflare docs claim.

**`BACKLOG.md § BL-032.77`**: new "Deploy-time lessons learned" subsection captures this and the broader lesson — when adversarial audits cite vendor docs as definitive evidence, verify against a real account, not against another doc page citing the same source.

**User memory** (out of repo, separate from this PR): filed `feedback_verify_against_reality_not_docs` so future Claude sessions don't repeat the doc-vs-doc verification anti-pattern.

## Verification

- Production already deployed cleanly with the binding `env.METRICS (mcp_events)` — confirms the corrected workflow worked end-to-end
- No code changes; doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)