### PR TITLE
fix(mcp): BL-032.77 cron dedup — single-flight lock on event.scheduledTime

### DIFF
--- a/mcp-server/src/auth/safe-logger.ts
+++ b/mcp-server/src/auth/safe-logger.ts
@@ -91,6 +91,23 @@ export interface LogEvent {
    * without pre-joining the category breakdown.
    */
   egressSource?: string;
+  /**
+   * Cron expression from `ScheduledController.cron` (e.g.
+   * `0` `<asterisk-slash-6>` `<asterisk>` `<asterisk>` `<asterisk>` — escaped
+   * here because JSDoc otherwise treats the embedded `*` `/` `6` as a
+   * close-comment-then-divide-by-6). Carried on cron-path events so operator
+   * queries can filter by schedule when multiple cron entries are defined.
+   * BL-032.77 dedup added this for `cron.scheduled.deduplicated` correlation.
+   */
+  cron?: string;
+  /**
+   * `ScheduledController.scheduledTime` — epoch ms of the scheduled fire
+   * (NOT wall-clock at invocation). Identical across duplicate invocations
+   * of the same cron firing, which is what BL-032.77's dedup lock keys on.
+   * Carried on `cron.scheduled.deduplicated` so operators can correlate the
+   * dropped invocation with the winner's logs by matching scheduledTime.
+   */
+  scheduledTime?: number;
 }
 
 /**

--- a/mcp-server/src/metrics/_schema.ts
+++ b/mcp-server/src/metrics/_schema.ts
@@ -182,7 +182,14 @@ export const OUTCOME_VALUES: Readonly<Record<EventType, readonly string[]>> = {
   rate_limit_decision: ['allow', 'throttle', 'deny'],
   inoreader_call: ['success', 'error'],
   health_check: ['ok', 'degraded', 'error'],
-  cron_outcome: ['success', 'partial', 'error', 'skipped-circuit', 'skipped-budget'],
+  cron_outcome: [
+    'success',
+    'partial',
+    'error',
+    'skipped-circuit',
+    'skipped-budget',
+    'deduplicated',
+  ],
 };
 
 /**

--- a/mcp-server/src/worker.ts
+++ b/mcp-server/src/worker.ts
@@ -41,6 +41,7 @@ import { AnalyticsEngineSink, emit } from './metrics/_index';
 import type { RefreshOutcome } from './cron/radar-refresh';
 import { postSentryCheckIn, postSentryEvent } from './observability/sentry-envelope';
 import { buildHealthPayload } from './observability/health';
+import { acquire } from './lib/single-flight-lock';
 import { refreshRadarSnapshot } from './cron/radar-refresh';
 import { readWireLive, readFyiLive } from './content/radar-live-store';
 
@@ -198,6 +199,48 @@ export const handler: ExportedHandler<Env> = {
         // — the safeLog inside the inner catch is the operator-visible
         // signal on the failure path.
         try {
+          // BL-032.77 — Cloudflare's `ScheduledController` may invoke the
+          // scheduled handler multiple times for the same scheduled fire
+          // (documented platform behavior; see
+          // https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/
+          // and the "cached-by-peer" observation in production on 2026-05-29).
+          // Both invocations share `event.scheduledTime` (epoch ms of the
+          // scheduled fire, NOT wall-clock at invocation), so we use it as the
+          // dedup key. `event.cron` is included so a future second cron entry
+          // in `wrangler.toml` doesn't collide on the same scheduledTime.
+          //
+          // Lock TTL of 5 min outlasts any plausible firing duration (typical:
+          // 2-10 seconds; worst case bounded by Inoreader's per-request caps).
+          // Fail-open semantics in `acquire`: if Upstash is unreachable, both
+          // invocations run — better to occasionally double-fetch Inoreader
+          // than to silently skip a firing during an Upstash outage.
+          //
+          // Loser path emits one `cron_outcome` AE event with outcome
+          // `'deduplicated'` so the dataset reflects how often Cloudflare
+          // double-fires; without it, dedup'd invocations would be invisible
+          // and we'd lose the ability to detect a regression in CF's behavior.
+          const lockKey = `mcp:lock:cron-radar-refresh:${event.cron}:${event.scheduledTime}`;
+          const acquired = await acquire(env, lockKey, 300);
+          if (!acquired) {
+            safeLog({
+              event: 'cron.scheduled.deduplicated',
+              reason: 'peer-holds-lock',
+              success: true,
+              durationMs: Date.now() - startedAt,
+              cron: event.cron,
+              scheduledTime: event.scheduledTime,
+            });
+            if (env.METRICS) {
+              emit(new AnalyticsEngineSink(env.METRICS), {
+                event_type: 'cron_outcome',
+                name: 'radar-refresh',
+                outcome: 'deduplicated',
+                duration_ms: Date.now() - startedAt,
+              });
+            }
+            return;
+          }
+
           // The cron expression in the Crons check-in MUST match
           // wrangler.toml's `[triggers] crons` entry — `event.cron` is
           // the runtime source of truth so a wrangler.toml edit doesn't

--- a/mcp-server/tests/unit/metrics/schema.test.ts
+++ b/mcp-server/tests/unit/metrics/schema.test.ts
@@ -117,6 +117,7 @@ describe('AE column-map schema (BL-032.75 Phase 1 source of truth)', () => {
           "error",
           "skipped-circuit",
           "skipped-budget",
+          "deduplicated",
         ],
         "health_check": [
           "ok",

--- a/mcp-server/tests/unit/worker-scheduled.test.ts
+++ b/mcp-server/tests/unit/worker-scheduled.test.ts
@@ -29,12 +29,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // `@sentry/cloudflare` + `agents/mcp` use the `cloudflare:workers` URL
 // scheme internally — Node's default ESM loader rejects it. Mock both
 // at the package boundary so importing worker.ts doesn't crash.
-const { withSentryMock, mockPostCheckIn, mockPostEvent, mockSafeLog } = vi.hoisted(() => ({
-  withSentryMock: vi.fn(<T>(_opts: unknown, handler: T) => handler),
-  mockPostCheckIn: vi.fn(),
-  mockPostEvent: vi.fn(),
-  mockSafeLog: vi.fn(),
-}));
+const { withSentryMock, mockPostCheckIn, mockPostEvent, mockSafeLog, mockAcquire } = vi.hoisted(
+  () => ({
+    withSentryMock: vi.fn(<T>(_opts: unknown, handler: T) => handler),
+    mockPostCheckIn: vi.fn(),
+    mockPostEvent: vi.fn(),
+    mockSafeLog: vi.fn(),
+    // BL-032.77 dedup mock — default to `true` (lock acquired) so existing
+    // happy-path tests run the full handler. Tests that need to exercise
+    // the loser path override via `mockAcquire.mockResolvedValueOnce(false)`.
+    mockAcquire: vi.fn().mockResolvedValue(true),
+  })
+);
 
 vi.mock('@sentry/cloudflare', () => ({
   init: vi.fn(),
@@ -67,6 +73,12 @@ vi.mock('../../src/auth/safe-logger', () => ({
   safeLog: mockSafeLog,
 }));
 
+vi.mock('../../src/lib/single-flight-lock', () => ({
+  acquire: mockAcquire,
+  pollForChange: vi.fn(),
+  release: vi.fn(),
+}));
+
 // Imports MUST come after vi.mock so the mocked modules are wired in.
 import { handler } from '../../src/worker';
 import workerDefault from '../../src/worker';
@@ -75,11 +87,18 @@ import type { Env } from '../../src/worker';
 
 const FAKE_ENV = {} as Env;
 const FAKE_CRON = '0 */6 * * *';
+// BL-032.77 dedup tests need a STABLE scheduledTime so the lock key is
+// deterministic across the two concurrent invocations of the concurrency
+// test. Using a fixed epoch-ms value (2026-05-29T12:00:00Z) means both
+// invocations produce the same lock key — which is precisely the property
+// the dedup lock relies on (Cloudflare's `ScheduledController.scheduledTime`
+// is identical across duplicate invocations of the same fire).
+const FAKE_SCHEDULED_TIME = 1_780_056_000_000;
 
-function makeScheduledEvent(): ScheduledController {
+function makeScheduledEvent(scheduledTime: number = FAKE_SCHEDULED_TIME): ScheduledController {
   return {
     cron: FAKE_CRON,
-    scheduledTime: Date.now(),
+    scheduledTime,
     type: 'scheduled',
     noRetry: () => {},
   } as unknown as ScheduledController;
@@ -128,6 +147,10 @@ describe('worker.ts scheduled handler — envelope check-in lifecycle (BL-032.76
       async (_env, _slug, _status, _schedule, checkInId) => checkInId ?? 'fake-id-abc'
     );
     vi.mocked(cron.refreshRadarSnapshot).mockReset();
+    // BL-032.77 — default to lock acquired so existing tests below run the
+    // full handler. Dedup-specific tests reset and override.
+    mockAcquire.mockReset();
+    mockAcquire.mockResolvedValue(true);
   });
 
   it('success path: in_progress → ok with matching checkInId', async () => {
@@ -361,5 +384,178 @@ describe('refreshOutcomeToAe — RefreshOutcome.kind → cron_outcome enum mappi
       const ae = refreshOutcomeToAe(outcome);
       expect(OUTCOME_VALUES.cron_outcome).toContain(ae);
     }
+  });
+});
+
+describe('worker.ts scheduled handler — single-flight dedup (BL-032.77 cron-firing dedup)', () => {
+  // BL-032.77 production discovery (2026-05-29): Cloudflare invokes the
+  // scheduled handler multiple times for the same scheduledTime, doubling
+  // Zone-1 spend (observed 36/day vs expected 18/day after 3 firings).
+  // The dedup lock at the top of the scheduled handler exits losers
+  // cleanly before any work. These tests pin the dedup contract.
+  beforeEach(() => {
+    mockPostCheckIn.mockReset();
+    mockPostEvent.mockReset();
+    mockSafeLog.mockReset();
+    mockPostCheckIn.mockImplementation(
+      async (_env, _slug, _status, _schedule, checkInId) => checkInId ?? 'fake-id-abc'
+    );
+    vi.mocked(cron.refreshRadarSnapshot).mockReset();
+    mockAcquire.mockReset();
+    mockAcquire.mockResolvedValue(true);
+  });
+
+  it('lock acquired → full work runs (regression guard for happy path)', async () => {
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 5,
+      fyiItems: 3,
+      callsConsumed: 6,
+    });
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(mockAcquire).toHaveBeenCalledTimes(1);
+    expect(mockAcquire).toHaveBeenCalledWith(
+      FAKE_ENV,
+      `mcp:lock:cron-radar-refresh:${FAKE_CRON}:${FAKE_SCHEDULED_TIME}`,
+      300
+    );
+    expect(cron.refreshRadarSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
+  });
+
+  it('lock NOT acquired → loser path: NO check-ins, NO refresh, NO Sentry event; safeLog emitted with correlation fields', async () => {
+    mockAcquire.mockResolvedValueOnce(false);
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    // Critical: zero side-effects to Sentry, zero work, zero Inoreader.
+    expect(cron.refreshRadarSnapshot).not.toHaveBeenCalled();
+    expect(mockPostCheckIn).not.toHaveBeenCalled();
+    expect(mockPostEvent).not.toHaveBeenCalled();
+
+    // Loser path emits exactly one structured-log line with correlation
+    // fields so operators can match a dropped invocation against the
+    // winner's logs by scheduledTime.
+    expect(mockSafeLog).toHaveBeenCalledTimes(1);
+    expect(mockSafeLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'cron.scheduled.deduplicated',
+        reason: 'peer-holds-lock',
+        success: true,
+        cron: FAKE_CRON,
+        scheduledTime: FAKE_SCHEDULED_TIME,
+        durationMs: expect.any(Number),
+      })
+    );
+  });
+
+  it('lock key format pinned: mcp:lock:cron-radar-refresh:<cron>:<scheduledTime>', async () => {
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 0,
+      fyiItems: 0,
+      callsConsumed: 6,
+    });
+    // Two different scheduledTimes (different firings) — assert distinct
+    // lock keys, NOT a single shared key. Regression guard against a
+    // future refactor that drops scheduledTime from the key (would
+    // re-introduce the double-firing bug).
+    const { ctx: ctxA, waitUntilPromises: waA } = makeCtx();
+    const { ctx: ctxB, waitUntilPromises: waB } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(1_780_056_000_000), FAKE_ENV, ctxA);
+    handler.scheduled!(makeScheduledEvent(1_780_077_600_000), FAKE_ENV, ctxB);
+    await Promise.all([...waA, ...waB]);
+
+    expect(mockAcquire).toHaveBeenCalledTimes(2);
+    expect(mockAcquire.mock.calls[0][1]).toBe(
+      `mcp:lock:cron-radar-refresh:${FAKE_CRON}:1780056000000`
+    );
+    expect(mockAcquire.mock.calls[1][1]).toBe(
+      `mcp:lock:cron-radar-refresh:${FAKE_CRON}:1780077600000`
+    );
+    // TTL pinned at 300s — regression guard against TTL shortening
+    // mid-firing or lengthening past the 6h cron cadence.
+    expect(mockAcquire.mock.calls[0][2]).toBe(300);
+    expect(mockAcquire.mock.calls[1][2]).toBe(300);
+  });
+
+  it('concurrency: two parallel invocations of the same scheduledTime → exactly one runs the work', async () => {
+    // The core property the dedup lock introduces. Mock SETNX atomicity by
+    // returning `true` for the FIRST acquire() call and `false` for the
+    // SECOND — modeling Upstash's atomic SET NX where exactly one wins.
+    mockAcquire.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 5,
+      fyiItems: 3,
+      callsConsumed: 6,
+    });
+
+    const event = makeScheduledEvent();
+    const { ctx: ctxA, waitUntilPromises: waA } = makeCtx();
+    const { ctx: ctxB, waitUntilPromises: waB } = makeCtx();
+    // Fire BOTH invocations in parallel — same `event` (= same
+    // scheduledTime, same cron). This mirrors Cloudflare's actual
+    // double-firing behavior observed in production 2026-05-29.
+    handler.scheduled!(event, FAKE_ENV, ctxA);
+    handler.scheduled!(event, FAKE_ENV, ctxB);
+    await Promise.all([...waA, ...waB]);
+
+    // Both invocations attempted to acquire — Upstash SETNX is the arbiter.
+    expect(mockAcquire).toHaveBeenCalledTimes(2);
+
+    // Only ONE invocation ran the work — the lock-winner.
+    expect(cron.refreshRadarSnapshot).toHaveBeenCalledTimes(1);
+
+    // Only ONE invocation sent Sentry check-ins (the winner's in_progress
+    // + ok pair, both with the same checkInId).
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      1,
+      FAKE_ENV,
+      'radar-refresh',
+      'in_progress',
+      FAKE_CRON
+    );
+    expect(mockPostCheckIn).toHaveBeenNthCalledWith(
+      2,
+      FAKE_ENV,
+      'radar-refresh',
+      'ok',
+      FAKE_CRON,
+      'fake-id-abc'
+    );
+
+    // The loser invocation emitted exactly one dedup safeLog line.
+    const dedupLogs = mockSafeLog.mock.calls.filter(
+      (call) => call[0]?.event === 'cron.scheduled.deduplicated'
+    );
+    expect(dedupLogs).toHaveLength(1);
+  });
+
+  it('fail-open: Upstash unreachable (acquire returns true even on no-client) → handler runs full work', async () => {
+    // `acquire` in `single-flight-lock.ts` returns `true` when createMcpClient
+    // returns null (Upstash creds unbound) — same fail-open semantics as
+    // the OAuth refresh lock. Verified at module level here: the handler
+    // proceeds to run the work as if the lock were uncontested. The trade-off
+    // is intentional: occasional double-firing during an Upstash outage is
+    // strictly better than silently skipping a cron firing.
+    mockAcquire.mockResolvedValueOnce(true); // simulates "fail-open: no Upstash, just proceed"
+    vi.mocked(cron.refreshRadarSnapshot).mockResolvedValue({
+      kind: 'success',
+      wireItems: 0,
+      fyiItems: 0,
+      callsConsumed: 6,
+    });
+    const { ctx, waitUntilPromises } = makeCtx();
+    handler.scheduled!(makeScheduledEvent(), FAKE_ENV, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(cron.refreshRadarSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockPostCheckIn).toHaveBeenCalledTimes(2);
   });
 });

--- a/mcp-server/wrangler.toml
+++ b/mcp-server/wrangler.toml
@@ -199,8 +199,18 @@ dataset = "mcp_events"
 # the 2026-05-15 BL-032.6 demo-day Zone-1 exhaustion incident — see
 # BL-032_5_TESTING_FINDINGS.md § Section Z and BACKLOG.md § BL-032.7.
 # Corrected to `0 */6 * * *` (every 6h, top of UTC hour) on
-# 2026-05-16; matches cache TTL exactly; ~24 Inoreader calls/day,
-# well under the per-app 100/day Zone-1 budget. Production-only —
-# staging deliberately runs no cron (see staging block above).
+# 2026-05-16; matches cache TTL exactly. Budget math: 4 firings ×
+# 6 calls = 24/day under the 100/day Zone-1 cap.
+#
+# **2026-05-29 BL-032.77 discovery**: Cloudflare's `scheduled` handler
+# may be invoked multiple times for the same scheduledTime (documented
+# platform behavior). Production observation 2026-05-29 confirmed every
+# firing was double-invoked, doubling the actual Zone-1 spend (36/day
+# observed against 24 expected). Fixed via single-flight Upstash lock
+# keyed on `event.cron:event.scheduledTime` at the top of the scheduled
+# handler — losers exit cleanly and emit `cron_outcome:'deduplicated'`
+# to AE so the dedup rate stays visible. Steady-state post-fix: 24/day
+# as the budget math claims. Production-only — staging deliberately
+# runs no cron (see staging block above).
 [env.production.triggers]
 crons = ["0 */6 * * *"]

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -2335,6 +2335,20 @@ The BL-032.75 Phase 1 closeout audit (PR #179) explicitly claimed "NO manual pro
 
 **This is the kind of doc claim that needs adversarial-audit verification against production reality, not just doc-vs-doc reading.** Cloudflare's own docs were the source of the wrong claim — the audit verified the claim against docs but didn't verify the docs against a real deploy. Lesson for future plan-audit cycles: when a doc-cited fact gates a deploy step, prove it with a dry-run against a real account before declaring the audit clean.
 
+#### Post-deploy discovery — Cloudflare double-firing scheduled handlers (2026-05-29)
+
+**Symptom**: Inoreader Developer API dashboard showed 36 Zone-1 calls today after 3 cron firings (00:00, 06:00, 12:00 UTC). Expected math: 3 × 6 = 18. Actual was exactly 2×. Sentry's `radar-refresh` Crons monitor showed two distinct `check_in_id`s at 06:00 UTC, one Timed Out and one Okay (marked Early for the next slot). Workers Logs at the 06:00 firing emitted `oauth.refresh.cached-by-peer` after waiting 996ms for a peer SETNX lock — proving a concurrent invocation was running.
+
+**Root cause**: Cloudflare's `ScheduledController` may invoke the `scheduled` handler multiple times for the same scheduled fire time. Both invocations independently run the full work (Inoreader fetches, Upstash writes, Sentry check-ins), doubling Zone-1 spend and producing orphan `in_progress` check-ins.
+
+**Resolution**: single-flight Upstash lock at the top of `worker.ts` scheduled handler, keyed on `event.cron:event.scheduledTime`. Reused the existing `mcp-server/src/lib/single-flight-lock.ts` primitive (originally introduced by BL-032.8 for OAuth refresh dedup; same `SET NX EX` semantics, same fail-open behavior). Loser invocation emits a `cron.scheduled.deduplicated` safeLog + a `cron_outcome:'deduplicated'` AE event (new value added to `OUTCOME_VALUES.cron_outcome`) so the dedup rate stays visible. Lock TTL: 300s.
+
+**Correction to PR #183 spend-accounting reasoning**: the `DRIFT_THRESHOLD_ABS=6` rationale ("one full cron firing's worth of parallel calls") was based on incorrect assumption that one scheduledTime = one invocation. With dedup, the threshold still works: it absorbs the parallel-fetch race within one invocation, which is what the BL-032.77 PR #183 audit found in the original drift event payload (`counter=4 observed=1`). No threshold change needed.
+
+**Spend-accounting correction**: prior docs (`MCP_SERVER_OBSERVABILITY_BL-032_75.md`, `wrangler.toml` cron comment) cited "24 calls/day" as the cron-radar baseline. That number was correct as the _intended_ baseline but actual production spend was 48/day pre-dedup. Post-dedup, the docs now match reality.
+
+**Lesson**: production substrate behavior can be subtly different from documented behavior in ways that pure unit tests can't catch. Inoreader Developer API quota dashboards and Sentry monitor histories are the ground-truth surfaces — local counters can lie if they're incrementing in handlers that get invoked multiple times. **Always reconcile against an external authoritative count when first deploying spend-sensitive instrumentation.**
+
 ---
 
 ### BL-033: MCP Server — External Pilot (Phase 3)


### PR DESCRIPTION
## Summary

Eliminates Cloudflare's double-firing of the scheduled handler. Production data confirms today's Inoreader Zone-1 spend was exactly 2× expected (36 calls vs 18 from 3 firings × 6 calls each). Both invocations of each firing were independently running the full work.

## Production evidence

- Inoreader Developer API: 36 Zone-1 calls today (May 29) after 3 scheduled firings
- `/health.inoreaderSpend.byCategory`: `cron-radar: 36, live-radar: 0, http-radar-snapshot: 0, oauth-refresh: 1, 401-retry: 0` — confirms ALL excess spend is from cron path
- Sentry Crons monitor: two distinct `check_in_id`s at 06:00 UTC (one Timed Out + one Okay marked Early for next slot)
- Workers Logs at 06:00 UTC: `oauth.refresh.cached-by-peer` after 996ms — proves a concurrent invocation was holding the SETNX lock

## Root cause

Cloudflare's `ScheduledController` may invoke the `scheduled` handler multiple times for the same scheduled fire (documented platform behavior). Both invocations independently ran:
- 6 Inoreader Zone-1 calls
- Upstash writes (counter increments, cache writes)
- Sentry `in_progress` check-ins (with different `check_in_id`s)
- Refresh work

The OAuth refresh peer-cache (BL-032.8 single-flight lock at `inoreader-oauth.ts`) was deduplicating just the OAuth token exchange but NOT the full handler work — hence the visible `cached-by-peer` log alongside the doubled spend.

## Fix

Single-flight Upstash lock at the very top of `worker.ts` scheduled handler IIFE, BEFORE `postSentryCheckIn(in_progress)`:

\`\`\`ts
const lockKey = \`mcp:lock:cron-radar-refresh:\${event.cron}:\${event.scheduledTime}\`;
const acquired = await acquire(env, lockKey, 300);
if (!acquired) {
  safeLog({ event: 'cron.scheduled.deduplicated', ... });
  if (env.METRICS) {
    emit(new AnalyticsEngineSink(env.METRICS), { event_type: 'cron_outcome', outcome: 'deduplicated', ... });
  }
  return;
}
// ... existing work
\`\`\`

**Reuses existing `mcp-server/src/lib/single-flight-lock.ts`** (originally introduced by BL-032.8 for OAuth refresh dedup). The adversarial-audit caught that inventing a new \`cron-lock.ts\` was the wrong direction — reuse is correct.

**Lock key includes `event.cron`** so future multi-cron configs won't collide on the same `scheduledTime`.

**TTL: 300s** — outlasts typical 2-10s firing duration with margin for Inoreader worst-case caps; auto-expires on Worker crash.

**Fail-open semantics**: if Upstash is unreachable, both invocations run. Better to occasionally double-fetch than to silently skip a firing during an Upstash outage.

## Observability — loser path is NOT silent

The audit flagged that silent invisibility would hide future regressions. Loser invocations emit:

1. `cron.scheduled.deduplicated` safeLog with `cron` + `scheduledTime` correlation fields
2. New AE `cron_outcome: 'deduplicated'` event (added to `OUTCOME_VALUES.cron_outcome` schema; snapshot test updated)

Operators querying the AE dashboard can now see Cloudflare's double-firing rate directly.

## Adversarial audit findings — all addressed

| Audit finding | Resolution |
|---|---|
| **B1 (blocker)** — plan invented `cron-lock.ts` when `single-flight-lock.ts` already existed | Reused existing `acquire()`; deleted the new-file proposal |
| **B2** — `event.scheduledTime` platform assumption undocumented | Inline docstring in `worker.ts` cites Cloudflare's `ScheduledController` type; backlog stanza captures the discovery |
| **D5** — single-cron assumption fragile | Key includes `event.cron` so multi-cron configs are safe |
| **O1** — safeLog payload missing correlation fields | Added `cron` and `scheduledTime` to `LogEvent` interface + the loser-path emit |
| **O2** — loser path silent to AE | New `'deduplicated'` outcome value with schema update + snapshot refresh |
| **T1** — no concurrency test (the property being introduced) | Added: two parallel invocations with same scheduledTime → exactly 1 ran the work |
| **T3, T4** — lock key format / TTL not pinned | Added regression tests |
| **D1** — wrangler.toml comment had stale `24/day` math | Updated to explain the discovery + post-fix steady state |
| **D4** — BACKLOG.md BL-032.77 stanza missing correction | Added "Post-deploy discovery" subsection with full symptom/cause/resolution |

## Test plan

- [x] `npm run typecheck` clean
- [x] **966/966 tests pass** (up from 961; +5 new dedup tests including the concurrency test)
- [x] Adversarial audit incorporated before code
- [ ] Post-deploy: tomorrow's Inoreader Developer API should show ~24 Zone-1 calls/day (4 firings × 6 calls), not 48
- [ ] `mcp_events` AE dataset should show `cron_outcome:'deduplicated'` events alongside the `'success'` ones — confirms dedup is firing on schedule

## What this does NOT change

- BL-032.77 PR #183 drift threshold (still 6 — still right for parallel intra-firing races)
- Phase 0 spend-accounting categories
- Cron schedule
- Sentry monitor config (Fix A from prior plan — `failure_issue_threshold` raise — was deliberately deferred per the operator's instruction; remains valid as belt-and-suspenders for rare envelope-drop scenarios but not bundled here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)