### PR TITLE
feat(security): BL-041 Phase A — Upstash ACL hardening engineering artifacts

### DIFF
--- a/mcp-server/scripts/Test-UpstashAcl.ps1
+++ b/mcp-server/scripts/Test-UpstashAcl.ps1
@@ -1,0 +1,225 @@
+<#
+.SYNOPSIS
+    Verify a scoped Upstash REST token honors the BL-041 ACL contract.
+
+.DESCRIPTION
+    BL-041 mints scoped Upstash users (`mcp-worker-rw`, `mcp-readonly-ops`)
+    with the deny-by-default ACL:
+
+        ACL SETUSER <name> on >{PWD} ~mcp:* -@all +@read +@write +@string +@sortedset +@scripting
+
+    Before binding a freshly-minted REST token to the Worker via
+    `wrangler secret put UPSTASH_MCP_REST_TOKEN`, run this script against
+    the same token to verify:
+
+      Positive (must succeed) — every Redis command the Worker actually
+      issues against `gst-mcp`:
+        - SET / GET / DEL  (token store, status, locks)
+        - INCR / INCRBY / EXPIRE / TTL  (egress counters, day counter,
+          OAuth TTL probe)
+        - MGET  (egress total + per-category read in /health)
+        - SET NX EX  (single-flight lock, daily drift debounce)
+        - ZADD / ZREMRANGEBYSCORE / ZCARD  (@upstash/ratelimit sliding-window)
+        - SCRIPT LOAD "return 1"  (audit B2 fix — raw probe so we don't
+          rely on an SDK NOSCRIPT cache hit masking the gap)
+        - Ratelimit.slidingWindow().limit() end-to-end  (audit M1 fix —
+          delegated to a Node sibling so the real SDK is exercised, not
+          a manual ZADD+EVAL approximation)
+
+      Negative (must return NOPERM) — substrate dangerous commands the
+      scoped user must NOT be able to issue:
+        - FLUSHDB / FLUSHALL  (would wipe the substrate)
+        - CONFIG GET           (info disclosure)
+        - DEBUG OBJECT         (info disclosure)
+        - CLUSTER NODES        (cluster surface)
+        - SHUTDOWN             (substrate kill)
+        - KEYS *               (full-scan info disclosure + perf risk)
+
+      Keyspace deny (must return NOPERM) — proves `~mcp:*` keypattern
+      restriction works:
+        - SET inoreader:foo "x"  (outside the allowed pattern)
+
+    Audit-baked design:
+      - Token is supplied via `$env:UPSTASH_TEST_TOKEN` + URL via
+        `$env:UPSTASH_TEST_URL` — never inlined into arguments / scrollback.
+      - Probe keys are prefixed `mcp:test:acl:<uuid>:*` so a botched run
+        leaves no permanent residue; cleanup is best-effort DEL at the end.
+      - Exit code 0 only when EVERY positive succeeded AND EVERY negative
+        returned NOPERM (or the keyspace-deny variant). Anything else is a
+        loud red FAIL.
+
+.PARAMETER SkipRatelimit
+    Skip the Node-side Ratelimit SDK probe. Useful when iterating on the
+    PS1 surface; do NOT skip when verifying a real rotation.
+
+.EXAMPLE
+    PS> $env:UPSTASH_TEST_URL = 'https://<db>.upstash.io'
+    PS> $env:UPSTASH_TEST_TOKEN = '<scoped REST token from ACL RESTTOKEN>'
+    PS> .\scripts\Test-UpstashAcl.ps1
+
+.NOTES
+    Mint procedure for the scoped token lives in
+    [DEPLOY.md § "Upstash ACL hardening"](../src/docs/operations/DEPLOY.md).
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipRatelimit
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $env:UPSTASH_TEST_URL) {
+    throw 'UPSTASH_TEST_URL not set. Set to https://<db>.upstash.io for the gst-mcp database.'
+}
+if (-not $env:UPSTASH_TEST_TOKEN) {
+    throw 'UPSTASH_TEST_TOKEN not set. Set to the REST token minted via ACL RESTTOKEN <user> <pwd>.'
+}
+
+$Url = $env:UPSTASH_TEST_URL.TrimEnd('/')
+$Token = $env:UPSTASH_TEST_TOKEN
+$ProbeUuid = [guid]::NewGuid().ToString('N').Substring(0, 8)
+$ProbeKeyPrefix = "mcp:test:acl:$ProbeUuid"
+
+$passes = 0
+$fails = 0
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Invoke-UpstashCommand {
+    param([string[]]$Command)
+    $body = ConvertTo-Json $Command -Compress
+    try {
+        $resp = Invoke-RestMethod -Uri $Url -Method Post `
+            -Headers @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' } `
+            -Body $body
+        return @{ Ok = $true; Result = $resp.result; Error = $null }
+    } catch {
+        # Upstash returns 4xx with a JSON body like {"error":"NOPERM ..."}
+        $errorBody = $null
+        if ($_.ErrorDetails.Message) {
+            try { $errorBody = ($_.ErrorDetails.Message | ConvertFrom-Json).error } catch {}
+        }
+        return @{ Ok = $false; Result = $null; Error = ($errorBody ?? $_.Exception.Message) }
+    }
+}
+
+function Assert-Positive {
+    param([string]$Label, [string[]]$Command)
+    $r = Invoke-UpstashCommand -Command $Command
+    if ($r.Ok) {
+        $script:passes++
+        Write-Host "  PASS  $Label" -ForegroundColor Green
+    } else {
+        $script:fails++
+        $script:failures.Add("POS $Label  ->  $($r.Error)")
+        Write-Host "  FAIL  $Label  ->  $($r.Error)" -ForegroundColor Red
+    }
+}
+
+function Assert-Noperm {
+    param([string]$Label, [string[]]$Command)
+    $r = Invoke-UpstashCommand -Command $Command
+    if (-not $r.Ok -and ($r.Error -match 'NOPERM' -or $r.Error -match 'no permission')) {
+        $script:passes++
+        Write-Host "  PASS  $Label  (NOPERM as expected)" -ForegroundColor Green
+    } elseif ($r.Ok) {
+        $script:fails++
+        $script:failures.Add("NEG $Label  ->  command succeeded but should have been denied")
+        Write-Host "  FAIL  $Label  ->  command SUCCEEDED but ACL should deny it" -ForegroundColor Red
+    } else {
+        $script:fails++
+        $script:failures.Add("NEG $Label  ->  unexpected error: $($r.Error)")
+        Write-Host "  FAIL  $Label  ->  expected NOPERM, got: $($r.Error)" -ForegroundColor Red
+    }
+}
+
+Write-Host ""
+Write-Host "=== BL-041 ACL contract probe ($Url, prefix $ProbeKeyPrefix) ===" -ForegroundColor Cyan
+
+Write-Host ""
+Write-Host "-- Positive: Worker's actual command surface --" -ForegroundColor DarkCyan
+Assert-Positive 'SET'                    @('SET', "$ProbeKeyPrefix:string", 'v')
+Assert-Positive 'GET'                    @('GET', "$ProbeKeyPrefix:string")
+Assert-Positive 'SET NX EX (single-flight lock pattern)' @('SET', "$ProbeKeyPrefix:lock", 'owner', 'NX', 'EX', '60')
+Assert-Positive 'INCR (egress counter)'  @('INCR', "$ProbeKeyPrefix:counter")
+Assert-Positive 'INCRBY (cron day counter)' @('INCRBY', "$ProbeKeyPrefix:counter", '6')
+Assert-Positive 'EXPIRE (counter TTL)'   @('EXPIRE', "$ProbeKeyPrefix:counter", '3600')
+Assert-Positive 'TTL (OAuth token expiry probe)' @('TTL', "$ProbeKeyPrefix:counter")
+Assert-Positive 'MGET (egress total + per-cat read)' @('MGET', "$ProbeKeyPrefix:string", "$ProbeKeyPrefix:counter")
+Assert-Positive 'DEL (lock release, cache invalidation)' @('DEL', "$ProbeKeyPrefix:string")
+
+Write-Host ""
+Write-Host "-- Positive: @upstash/ratelimit sliding-window surface --" -ForegroundColor DarkCyan
+Assert-Positive 'ZADD (ratelimit window)' @('ZADD', "$ProbeKeyPrefix:zset", '1', 'm1')
+Assert-Positive 'ZADD (second member)'    @('ZADD', "$ProbeKeyPrefix:zset", '2', 'm2')
+Assert-Positive 'ZCARD (ratelimit count)' @('ZCARD', "$ProbeKeyPrefix:zset")
+Assert-Positive 'ZREMRANGEBYSCORE (window prune)' @('ZREMRANGEBYSCORE', "$ProbeKeyPrefix:zset", '0', '1')
+
+Write-Host ""
+Write-Host "-- Positive: scripting surface (audit B2 raw probe) --" -ForegroundColor DarkCyan
+# Raw SCRIPT LOAD — NOT via SDK, so a cached SHA on the substrate from a
+# prior admin-token run cannot mask the NOPERM gap. Returns the SHA1 of the
+# loaded script body on success.
+Assert-Positive 'SCRIPT LOAD "return 1"' @('SCRIPT', 'LOAD', 'return 1')
+Assert-Positive 'EVAL "return 1"'        @('EVAL', 'return 1', '0')
+
+Write-Host ""
+Write-Host "-- Negative: substrate-dangerous commands (NOPERM expected) --" -ForegroundColor DarkCyan
+Assert-Noperm 'FLUSHDB'      @('FLUSHDB')
+Assert-Noperm 'FLUSHALL'     @('FLUSHALL')
+Assert-Noperm 'CONFIG GET'   @('CONFIG', 'GET', 'maxmemory')
+Assert-Noperm 'DEBUG OBJECT' @('DEBUG', 'OBJECT', "$ProbeKeyPrefix:counter")
+Assert-Noperm 'CLUSTER NODES' @('CLUSTER', 'NODES')
+Assert-Noperm 'SHUTDOWN'     @('SHUTDOWN', 'NOSAVE')
+Assert-Noperm 'KEYS *'       @('KEYS', '*')
+
+Write-Host ""
+Write-Host "-- Negative: keyspace deny (outside ~mcp:* pattern) --" -ForegroundColor DarkCyan
+Assert-Noperm 'SET inoreader:foo (outside ~mcp:*)' @('SET', 'inoreader:foo', 'x')
+Assert-Noperm 'GET inoreader:foo (outside ~mcp:*)' @('GET', 'inoreader:foo')
+
+if (-not $SkipRatelimit) {
+    Write-Host ""
+    Write-Host "-- Positive: @upstash/ratelimit end-to-end (Node SDK delegate) --" -ForegroundColor DarkCyan
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) {
+        $fails++
+        $failures.Add('Ratelimit SDK probe SKIPPED — node not on PATH')
+        Write-Host "  FAIL  node not on PATH (cannot run ratelimit SDK probe)" -ForegroundColor Red
+    } else {
+        $scriptPath = Join-Path $PSScriptRoot 'verify-ratelimit-acl.mjs'
+        $env:UPSTASH_TEST_URL = $Url
+        $env:UPSTASH_TEST_TOKEN = $Token
+        $env:UPSTASH_TEST_PROBE_KEY = "$ProbeKeyPrefix:ratelimit"
+        & node $scriptPath
+        if ($LASTEXITCODE -eq 0) {
+            $passes++
+            Write-Host "  PASS  Ratelimit.slidingWindow().limit() end-to-end" -ForegroundColor Green
+        } else {
+            $fails++
+            $failures.Add("Ratelimit SDK probe FAILED (exit $LASTEXITCODE) — see node output above")
+            Write-Host "  FAIL  Ratelimit SDK probe (exit $LASTEXITCODE)" -ForegroundColor Red
+        }
+    }
+}
+
+# Best-effort cleanup of probe keys we created.
+Write-Host ""
+Write-Host "-- Cleanup (best-effort) --" -ForegroundColor DarkGray
+foreach ($suffix in @(':string', ':lock', ':counter', ':zset', ':ratelimit')) {
+    Invoke-UpstashCommand -Command @('DEL', "$ProbeKeyPrefix$suffix") | Out-Null
+}
+
+Write-Host ""
+Write-Host "===========================================================" -ForegroundColor Cyan
+if ($fails -eq 0) {
+    Write-Host "ALL CHECKS PASSED  ($passes positive + negative assertions)" -ForegroundColor Green
+    Write-Host "Token is safe to bind via wrangler secret put." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "$fails FAILED, $passes passed" -ForegroundColor Red
+    Write-Host "Failures:" -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host "  - $f" -ForegroundColor Red }
+    Write-Host ""
+    Write-Host "DO NOT bind this token — investigate the ACL string or REST-token mint." -ForegroundColor Red
+    exit 1
+}

--- a/mcp-server/scripts/verify-ratelimit-acl.mjs
+++ b/mcp-server/scripts/verify-ratelimit-acl.mjs
@@ -1,0 +1,66 @@
+/**
+ * BL-041 — end-to-end @upstash/ratelimit verification against a scoped ACL token.
+ *
+ * Why this exists as a Node sibling of Test-UpstashAcl.ps1:
+ *   The PS1 issues raw Redis commands via the Upstash REST POST shape. That
+ *   surface CANNOT exercise the real @upstash/ratelimit `slidingWindow` flow,
+ *   which orchestrates EVALSHA → (on NOSCRIPT) SCRIPT LOAD → EVAL with a
+ *   specific script body + key naming. A manual approximation would be
+ *   fragile — pin a SHA, get a false positive when the real SDK changes the
+ *   script body. So we import the actual SDK at the version pinned in
+ *   mcp-server/package.json and let it do the round-trip.
+ *
+ * Inputs (env vars set by the parent PS1):
+ *   UPSTASH_TEST_URL        — https://<db>.upstash.io
+ *   UPSTASH_TEST_TOKEN      — REST token (must be the scoped one being verified)
+ *   UPSTASH_TEST_PROBE_KEY  — probe identifier, e.g. mcp:test:acl:abc12345:ratelimit
+ *
+ * Exit code 0 = ratelimit completed end-to-end (limiter accepted the call
+ * and returned a `success`/`remaining` envelope). Non-zero = NOPERM somewhere
+ * in the script-load / EVAL / ZADD chain.
+ */
+import { Redis } from '@upstash/redis';
+import { Ratelimit } from '@upstash/ratelimit';
+
+const url = process.env.UPSTASH_TEST_URL;
+const token = process.env.UPSTASH_TEST_TOKEN;
+const probeKey = process.env.UPSTASH_TEST_PROBE_KEY ?? `mcp:test:acl:${Date.now()}:ratelimit`;
+
+if (!url || !token) {
+  console.error('verify-ratelimit-acl: missing UPSTASH_TEST_URL or UPSTASH_TEST_TOKEN');
+  process.exit(2);
+}
+
+const redis = new Redis({ url, token });
+
+// Sliding-window: 5 ops per 60s. Numbers chosen to be obviously inside the
+// budget so any failure is an ACL/NOPERM signal, not a real rate-limit hit.
+const limiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, '60 s'),
+  prefix: probeKey,
+  analytics: false,
+});
+
+try {
+  const result = await limiter.limit(probeKey);
+  // Successful end-to-end roundtrip — SCRIPT LOAD + EVAL both worked under
+  // the scoped ACL. The actual success/remaining values aren't material;
+  // we only care that no command threw.
+  console.log(
+    `verify-ratelimit-acl: OK (success=${result.success} remaining=${result.remaining} limit=${result.limit})`
+  );
+  process.exit(0);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`verify-ratelimit-acl: FAILED — ${msg}`);
+  // Surface the NOPERM string explicitly in the output so the parent PS1
+  // log makes the failure mode obvious.
+  if (msg.includes('NOPERM') || msg.toLowerCase().includes('no permission')) {
+    console.error(
+      'verify-ratelimit-acl: NOPERM detected — scoped ACL is missing a category needed by Ratelimit.slidingWindow().'
+    );
+    console.error('Expected: +@read +@write +@string +@sortedset +@scripting on ~mcp:*');
+  }
+  process.exit(1);
+}

--- a/mcp-server/src/docs/operations/DEPLOY.md
+++ b/mcp-server/src/docs/operations/DEPLOY.md
@@ -179,6 +179,144 @@ If the MCP-DB Standard token is ever compromised, regenerate it from the Upstash
 
 ---
 
+## A.3.5 — Upstash ACL hardening (BL-041)
+
+> **Audience**: operator hardening the Upstash MCP DB to per-purpose ACL users + scoped REST tokens, retiring the default admin token from the Worker binding. Run after § A.3 has provisioned the database. Independent of every other section — safe to run on a live deploy.
+
+### Why
+
+The default `UPSTASH_MCP_REST_TOKEN` (minted in § A.3) is bound to Upstash's `default` user with **full admin permissions on the entire keyspace**. A leak gives an attacker `FLUSHDB`, `CONFIG SET`, `SCRIPT FLUSH`, `KEYS *`, and access to every key — not just our `mcp:*` namespace. The Worker only needs read+write on `mcp:*`. Closing this gap before [BL-033](../../../../src/docs/development/BACKLOG.md#bl-033) broadens the operator pool means access-control is settled before stakes rise.
+
+### The ACL strings
+
+Two scoped users, deny-by-default (whitelist style):
+
+```
+ACL SETUSER mcp-worker-rw   on >{PWD_A} ~mcp:* -@all +@read +@write +@string +@sortedset +@scripting
+ACL SETUSER mcp-readonly-ops on >{PWD_B} ~mcp:* -@all +@read
+```
+
+**Category rationale** — do **NOT** add categories beyond what's listed. Particularly: do **NOT** add `+@keyspace`; it would grant `FLUSHDB`/`KEYS`/`SCAN` and reopen the very gap this section closes.
+
+| Category     | Why we need it                                                                                               | What it grants                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `@read`      | Cron day-counter GET; `/health` cached-status reads; circuit-breaker `GET`+`TTL`; ratelimit window scans     | `GET`, `MGET`, `TTL`, `EXISTS`, `ZRANGE`, `ZCARD`, `STRLEN`, ...          |
+| `@write`     | `SET`/`DEL`/`INCR`/`INCRBY`/`EXPIRE` across egress, lock, status, cache, token-store; `ZADD`/`ZREM*`         | `SET`, `DEL`, `INCR`, `INCRBY`, `EXPIRE`, `ZADD`, `ZREMRANGEBYSCORE`, ... |
+| `@string`    | Every counter, cache value, status JSON blob is a string in Redis terms                                      | `SET`/`GET`/`INCR`/`APPEND`/... — strings only                            |
+| `@sortedset` | `@upstash/ratelimit` `slidingWindow` uses sorted sets for window-rolling                                     | `ZADD`, `ZRANGE`, `ZREMRANGEBYSCORE`, `ZCARD`, ...                        |
+| `@scripting` | `@upstash/ratelimit` round-trips via `SCRIPT LOAD` → `EVALSHA`; without this the rate limiter silently fails | `EVAL`, `EVALSHA`, `SCRIPT LOAD`, `SCRIPT EXISTS`                         |
+
+Commands UNION categories — `EXPIRE` is `@keyspace @write @fast`, so `+@write` grants it without needing `+@keyspace`. Same logic for `DEL` (`@keyspace @write @slow`) and `TTL` (`@keyspace @read @fast`). The `~mcp:*` keypattern restricts every grant to keys with the `mcp:` prefix.
+
+### Steps
+
+**Phase 1 — Mint users + REST tokens** (Upstash console)
+
+1. Upstash console → MCP DB → **ACL** tab → **Create** button → **Advanced** tab (free-text editor)
+2. Paste:
+   ```
+   ACL SETUSER mcp-worker-rw on >REPLACE_WITH_STRONG_PWD_A ~mcp:* -@all +@read +@write +@string +@sortedset +@scripting
+   ```
+   Use a strong random password (e.g. PowerShell: `[Convert]::ToBase64String((1..32 | % { [byte](Get-Random -Max 256) }))`). Save `PWD_A` to 1Password under "Upstash gst-mcp ACL — mcp-worker-rw".
+3. Click **Create**. Repeat for `mcp-readonly-ops` with `PWD_B`.
+4. Switch to the **CLI** tab. Run:
+   ```
+   ACL RESTTOKEN mcp-worker-rw <PWD_A>
+   ```
+   Copy the returned token (e.g. `AYNg...DQ=`) into 1Password under "Upstash gst-mcp REST — mcp-worker-rw". Repeat for `mcp-readonly-ops`.
+
+**Phase 2 — Verify the scoped token before binding** (local)
+
+5. Smoke-probe the new token end-to-end (positive surface + negative surface + Ratelimit SDK round-trip):
+   ```powershell
+   cd c:\Code\gst-website\mcp-server
+   $env:UPSTASH_TEST_URL   = 'https://<db>.upstash.io'          # from § A.3
+   $env:UPSTASH_TEST_TOKEN = '<paste mcp-worker-rw REST token>'
+   .\scripts\Test-UpstashAcl.ps1
+   ```
+   Exit code 0 means: every Worker command path passed AND `FLUSHDB`/`CONFIG GET`/`KEYS *`/etc. returned NOPERM AND the `@upstash/ratelimit` SDK round-trip completed cleanly. **If anything fails, do not bind the token** — investigate the ACL string (compare to the Category Rationale table above).
+
+**Phase 3 — Rotate the Worker binding** (one env at a time)
+
+6. **Staging first**:
+   ```powershell
+   npx wrangler secret put UPSTASH_MCP_REST_TOKEN --env staging
+   # paste the mcp-worker-rw REST token; never inline it on the CLI
+   npm run deploy:staging
+   ```
+7. Verify staging:
+   ```powershell
+   curl https://mcp-staging.globalstrategic.tech/health | ConvertFrom-Json |
+     Select-Object upstashMcp, aclSelfCheck
+   ```
+   Expect `upstashMcp: 'ok'` AND `aclSelfCheck.status: 'ok'`. (`aclSelfCheck` is set in the background by the first request after deploy — give it a few seconds, then re-probe.)
+8. Dry-run the cron handler so the 6h cron-window doesn't sit on uncertainty:
+   ```powershell
+   npx wrangler dev --env staging --test-scheduled
+   # in another terminal, with the dev server running:
+   curl 'http://localhost:8787/__scheduled?cron=0+*/6+*+*+*'
+   ```
+   Confirm logs show `cron.scheduled.started` → `cron.radar-refresh.success` (no NOPERM).
+9. Run the integration suite against staging:
+
+   ```powershell
+   $env:MCP_URL = 'https://mcp-staging.globalstrategic.tech'
+   .\scripts\Test-Bl0325.ps1
+   ```
+
+   All checks pass = scoped token covers the live tool/resource/prompt surface.
+
+10. **Production**: repeat steps 6–9 with `--env production` and `https://mcp.globalstrategic.tech`.
+
+**Phase 4 — Rollback semantics** (only if something breaks)
+
+`wrangler secret put` and `wrangler deploy` are NOT atomic. If `secret put` succeeds but `deploy` fails (lint gate, build error, network blip), Cloudflare has the new token but the running Worker is still on the OLD secret. To recover:
+
+```powershell
+# 1. Re-put the original admin token (kept in 1Password from § A.3)
+npx wrangler secret put UPSTASH_MCP_REST_TOKEN --env staging   # or production
+# 2. Redeploy to refresh the binding
+npm run deploy:staging                                          # or :production
+# 3. Verify
+curl https://mcp-staging.globalstrategic.tech/health | ConvertFrom-Json |
+  Select-Object upstashMcp, aclSelfCheck
+```
+
+Worker should return to baseline within ~30 s of the redeploy. The default admin token never gets revoked in Upstash — it stays as the break-glass credential.
+
+### Scoped-token rotation (annual or after suspected leak)
+
+Distinct from the admin-token rotation in [§ A.3 — Reference](#reference--rotating-the-mcp-db-token):
+
+1. Upstash console → CLI tab → `ACL RESTTOKEN mcp-worker-rw <PWD_A>` (yes, the same password — the command re-mints a fresh REST token; the old one is invalidated server-side)
+2. Update 1Password with the new token + rotation date
+3. Follow Phase 3 above (verify locally → rotate staging → rotate production)
+
+### Using `mcp-readonly-ops`
+
+The readonly user is operator-only — no Worker binding. Use it from `redis-cli` (TLS) or the Upstash console CLI tab for incident triage:
+
+- Inspect `mcp:inoreader:*` to debug OAuth state without risking a mutation
+- Inspect `mcp:radar:cache:*` to confirm a Cron firing landed
+- Inspect `mcp:ratelimit:*` / `mcp:circuit:*` to debug a rate-limit incident
+
+Connection string + credentials live in 1Password under "Upstash gst-mcp — mcp-readonly-ops".
+
+### Account-level MFA (defense in depth)
+
+Even with scoped tokens on the data plane, an attacker who phishes the operator's Upstash account login can mint a new admin token. Two layers:
+
+1. **Upstream SSO MFA** — log into the upstream auth provider (GitHub / Google) and confirm MFA is enforced organization-wide.
+2. **Upstash account TOTP** — Upstash supports a 2FA setting in account preferences independent of SSO. **Enable this too** — covers the case where someone bypasses SSO via Upstash's email/password fallback.
+
+Record both checks in [`SECRETS_INVENTORY.md`](../../../../src/docs/operations/SECRETS_INVENTORY.md) → Upstash ACL users subsection.
+
+### What you've completed
+
+✅ Worker binds a scoped REST token minted from `mcp-worker-rw`; the default admin token remains in 1Password as break-glass only. `mcp-readonly-ops` available for operator triage. Account-level MFA enforced on every member. `/health.aclSelfCheck` surfaces NOPERM regressions as a deploy-level signal — see [`acl-selfcheck.ts`](../../observability/acl-selfcheck.ts) for the probe surface.
+
+---
+
 ## A.4 — Inoreader credentials — copy from Vercel
 
 ### What you need

--- a/mcp-server/src/observability/acl-selfcheck.ts
+++ b/mcp-server/src/observability/acl-selfcheck.ts
@@ -1,0 +1,174 @@
+/**
+ * BL-041 — Worker-side ACL self-check.
+ *
+ * **Why this exists**: after a scoped Upstash REST token rotation, a
+ * misconfigured ACL surfaces as scattered NOPERM errors only when specific
+ * code paths are hit. The rate limiter's fail-open semantics
+ * (`ratelimit/limiter.ts` returns `null` on Upstash errors) mean a NOPERM
+ * inside `Ratelimit.slidingWindow().limit()` silently disables rate-limiting
+ * rather than throwing — a quiet outage of a security control.
+ *
+ * This module exercises the full Worker command surface once per deploy:
+ *
+ *   1. `SET` + `EXPIRE`          — token store / counter writes
+ *   2. `INCR`                    — egress counter / day counter
+ *   3. `ZADD` + `ZREMRANGEBYSCORE` — `@upstash/ratelimit` sorted-set surface
+ *   4. `SCRIPT LOAD "return 1"`  — proves `@scripting` covers SCRIPT LOAD
+ *                                   under whatever Redis fork Upstash runs
+ *                                   (audit B2 — version varies)
+ *
+ * Coordination — first isolate to acquire the gate runs the probe; all
+ * later isolates see the result and skip the work. Gate + result live in
+ * `mcp:acl-selfcheck:gate:<gitSha>` (SET NX EX, ~24h TTL) and
+ * `mcp:acl-selfcheck:result:<gitSha>` (JSON, same TTL). `gitSha` keys both
+ * so a new deploy automatically re-runs the probe.
+ *
+ * Result is surfaced via `/health.aclSelfCheck`:
+ *
+ *   { status: 'ok' | 'degraded' | 'unknown', failedCommand?: string, ranAt?: string }
+ *
+ * `'unknown'` covers both "probe hasn't run yet this deploy" and "Upstash
+ * unreachable at probe time" — operators investigating `'degraded'` know
+ * exactly which Redis command broke under the new ACL.
+ */
+import type { Redis } from '@upstash/redis';
+import { createMcpClient } from '../lib/upstash-clients';
+import { safeLog } from '../auth/safe-logger';
+import type { Env } from '../worker';
+
+const GATE_PREFIX = 'mcp:acl-selfcheck:gate:';
+const RESULT_PREFIX = 'mcp:acl-selfcheck:result:';
+const TTL_SECONDS = 24 * 60 * 60;
+
+export type AclSelfCheckStatus = 'ok' | 'degraded' | 'unknown';
+
+export interface AclSelfCheckResult {
+  status: AclSelfCheckStatus;
+  failedCommand?: string;
+  ranAt?: string;
+}
+
+function gateKey(gitSha: string): string {
+  return `${GATE_PREFIX}${gitSha}`;
+}
+
+function resultKey(gitSha: string): string {
+  return `${RESULT_PREFIX}${gitSha}`;
+}
+
+/**
+ * Read the recorded result for the current deploy. Best-effort — Upstash
+ * unreachable or missing key both return `'unknown'`.
+ */
+export async function readAclSelfCheck(env: Env): Promise<AclSelfCheckResult> {
+  const gitSha = env.GIT_SHA ?? 'unknown';
+  const redis = createMcpClient(env);
+  if (!redis) return { status: 'unknown' };
+
+  try {
+    const raw = await redis.get<AclSelfCheckResult | string | null>(resultKey(gitSha));
+    if (raw == null) return { status: 'unknown' };
+    return typeof raw === 'string' ? (JSON.parse(raw) as AclSelfCheckResult) : raw;
+  } catch {
+    return { status: 'unknown' };
+  }
+}
+
+/**
+ * Run the probe if no other isolate has yet for this deploy. Returns the
+ * recorded result (whether this call ran the probe or another isolate
+ * already did).
+ *
+ * Best-effort throughout: every individual probe failure is caught + the
+ * first failing command name is recorded; Upstash unreachable returns
+ * `'unknown'`. Never throws to the caller.
+ */
+export async function runAclSelfCheckOnce(env: Env): Promise<AclSelfCheckResult> {
+  const gitSha = env.GIT_SHA ?? 'unknown';
+  const redis = createMcpClient(env);
+  if (!redis) return { status: 'unknown' };
+
+  // Gate: first isolate to SET wins the probe; losers either see the
+  // recorded result or `'unknown'` if it hasn't landed yet.
+  let acquired: boolean;
+  try {
+    const r = await redis.set(gateKey(gitSha), '1', { nx: true, ex: TTL_SECONDS });
+    acquired = r === 'OK';
+  } catch {
+    // Gate write failed — Upstash unreachable or NOPERM on SET itself.
+    // Surface as `'unknown'` without persisting a result; next probe attempt
+    // re-tries naturally.
+    return { status: 'unknown' };
+  }
+
+  if (!acquired) {
+    return await readAclSelfCheck(env);
+  }
+
+  const result = await probeAclSurface(redis, gitSha);
+  try {
+    await redis.set(resultKey(gitSha), JSON.stringify(result), { ex: TTL_SECONDS });
+  } catch {
+    // Probe ran but result didn't persist; surface to caller anyway.
+  }
+  if (result.status === 'degraded') {
+    safeLog({
+      event: 'acl.selfcheck.degraded',
+      reason: result.failedCommand,
+      success: false,
+      errorCode: 'acl-selfcheck-failed',
+    });
+  }
+  return result;
+}
+
+/**
+ * Exercise every Redis command the Worker actually issues against
+ * `gst-mcp` under the scoped ACL. Returns the FIRST command that throws —
+ * subsequent paths are not exercised, since the operator's debugging task
+ * is "which command broke," not "how many commands broke."
+ *
+ * Probe keys are isolated under `mcp:acl-selfcheck:probe:<gitSha>:*` so
+ * concurrent /health calls during the gate-acquire race don't collide.
+ */
+async function probeAclSurface(redis: Redis, gitSha: string): Promise<AclSelfCheckResult> {
+  const ranAt = new Date().toISOString();
+  const k = (suffix: string): string => `mcp:acl-selfcheck:probe:${gitSha}:${suffix}`;
+
+  const steps: Array<{ cmd: string; run: () => Promise<unknown> }> = [
+    { cmd: 'SET', run: () => redis.set(k('s'), '1', { ex: 60 }) },
+    { cmd: 'INCR', run: () => redis.incr(k('c')) },
+    { cmd: 'EXPIRE', run: () => redis.expire(k('c'), 60) },
+    { cmd: 'ZADD', run: () => redis.zadd(k('z'), { score: 1, member: 'm' }) },
+    { cmd: 'ZREMRANGEBYSCORE', run: () => redis.zremrangebyscore(k('z'), 0, 0) },
+    // SCRIPT LOAD via the SDK's eval helper — exercises the same NOSCRIPT →
+    // SCRIPT LOAD → EVALSHA path as @upstash/ratelimit. `eval` against a
+    // trivial body forces the substrate to load the script and prove
+    // SCRIPT LOAD is permitted under the scoped ACL.
+    { cmd: 'EVAL/SCRIPT LOAD', run: () => redis.eval('return 1', [], []) },
+  ];
+
+  for (const step of steps) {
+    try {
+      await step.run();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        status: 'degraded',
+        failedCommand: `${step.cmd}: ${msg.slice(0, 200)}`,
+        ranAt,
+      };
+    }
+  }
+
+  // Cleanup — best-effort. A residual probe key auto-evicts via its TTL.
+  try {
+    await redis.del(k('s'));
+    await redis.del(k('c'));
+    await redis.del(k('z'));
+  } catch {
+    // intentionally ignored
+  }
+
+  return { status: 'ok', ranAt };
+}

--- a/mcp-server/src/observability/health.ts
+++ b/mcp-server/src/observability/health.ts
@@ -59,6 +59,7 @@ import {
 } from './inoreader-status';
 import { createMcpClient } from '../lib/upstash-clients';
 import { readInoreaderSpend, type InoreaderEgressCategory } from '../lib/inoreader-egress';
+import { readAclSelfCheck, type AclSelfCheckResult } from './acl-selfcheck';
 import type { Env } from '../worker';
 
 const VERSION = '0.1.0'; // bumped in lockstep with mcp-server/package.json (see BREAKING_CHANGES.md)
@@ -116,6 +117,19 @@ interface HealthResponse {
     total: number;
     byCategory: Record<InoreaderEgressCategory, number>;
   };
+  /**
+   * BL-041 — Worker-side ACL self-check result for the current deploy.
+   * Set after the first request post-deploy via `runAclSelfCheckOnce`;
+   * `'unknown'` until the probe lands or when Upstash is unreachable.
+   * `'degraded'` carries the first command that returned NOPERM so an
+   * operator can pinpoint the missing ACL category at a glance.
+   *
+   * **Read-only here**: this endpoint never RUNS the probe; the worker.ts
+   * fetch handler triggers it once per deploy in the background. /health
+   * reads the recorded result so a uptime monitor or operator curl sees
+   * the same value regardless of which isolate served the request.
+   */
+  aclSelfCheck: AclSelfCheckResult;
 }
 
 const HEALTH_PROBE_KEY_PREFIX = 'mcp:health:probe:';
@@ -206,12 +220,14 @@ async function probeRadarSnapshotAge(env: Env): Promise<number | null> {
  * the Inoreader DB probe) shaved one Upstash round-trip off this path.
  */
 export async function buildHealthPayload(env: Env): Promise<HealthResponse> {
-  const [upstashMcp, inoreader, radarSnapshotAgeSeconds, inoreaderSpend] = await Promise.all([
-    probeMcp(env),
-    readInoreaderStatus(env),
-    probeRadarSnapshotAge(env),
-    readInoreaderSpend(env),
-  ]);
+  const [upstashMcp, inoreader, radarSnapshotAgeSeconds, inoreaderSpend, aclSelfCheck] =
+    await Promise.all([
+      probeMcp(env),
+      readInoreaderStatus(env),
+      probeRadarSnapshotAge(env),
+      readInoreaderSpend(env),
+      readAclSelfCheck(env),
+    ]);
 
   // ok: true iff MCP DB is reachable AND the last observed Inoreader API
   // call was not degraded. `inoreader: 'unknown'` is intentionally NOT a
@@ -233,5 +249,6 @@ export async function buildHealthPayload(env: Env): Promise<HealthResponse> {
     inoreaderObservedSource: inoreader.source,
     radarSnapshotAgeSeconds,
     inoreaderSpend,
+    aclSelfCheck,
   };
 }

--- a/mcp-server/src/worker.ts
+++ b/mcp-server/src/worker.ts
@@ -41,6 +41,7 @@ import { AnalyticsEngineSink, emit } from './metrics/_index';
 import type { RefreshOutcome } from './cron/radar-refresh';
 import { postSentryCheckIn, postSentryEvent } from './observability/sentry-envelope';
 import { buildHealthPayload } from './observability/health';
+import { runAclSelfCheckOnce } from './observability/acl-selfcheck';
 import { acquire } from './lib/single-flight-lock';
 import { refreshRadarSnapshot } from './cron/radar-refresh';
 import { readWireLive, readFyiLive } from './content/radar-live-store';
@@ -320,6 +321,13 @@ export const handler: ExportedHandler<Env> = {
   async fetch(request, env, ctx): Promise<Response> {
     const url = new URL(request.url);
     const origin = request.headers.get('Origin');
+
+    // BL-041: one-shot ACL self-check per deploy. Fire-and-forget via
+    // waitUntil — first isolate to win the Upstash gate runs the probe;
+    // every other request no-ops cheaply at the gate. Result lands in
+    // `mcp:acl-selfcheck:result:<gitSha>` and is surfaced by /health.
+    // Never blocks the request path; fail-open if Upstash is down.
+    ctx.waitUntil(runAclSelfCheckOnce(env).catch(() => undefined));
 
     // 1. CORS preflight — never authenticated; never logged (high-volume noise).
     if (isPreflight(request)) {

--- a/mcp-server/tests/unit/observability/acl-selfcheck.test.ts
+++ b/mcp-server/tests/unit/observability/acl-selfcheck.test.ts
@@ -1,0 +1,198 @@
+/**
+ * BL-041 — ACL self-check module tests.
+ *
+ * Asserts the gate-then-probe contract:
+ *   - Gate SET NX EX is attempted with the per-deploy key
+ *   - Probe runs only when the gate is captured
+ *   - Result is recorded in the per-deploy result key
+ *   - Concurrent callers see the recorded result via the read path
+ *   - NOPERM on any probe step short-circuits with the failing command name
+ *   - Upstash unreachable → `'unknown'` (never throws)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const {
+  MockRedis,
+  mockSet,
+  mockGet,
+  mockIncr,
+  mockExpire,
+  mockZadd,
+  mockZremrange,
+  mockEval,
+  mockDel,
+} = vi.hoisted(() => {
+  const mockSet = vi.fn();
+  const mockGet = vi.fn();
+  const mockIncr = vi.fn();
+  const mockExpire = vi.fn();
+  const mockZadd = vi.fn();
+  const mockZremrange = vi.fn();
+  const mockEval = vi.fn();
+  const mockDel = vi.fn();
+  class MockRedis {
+    set = mockSet;
+    get = mockGet;
+    incr = mockIncr;
+    expire = mockExpire;
+    zadd = mockZadd;
+    zremrangebyscore = mockZremrange;
+    eval = mockEval;
+    del = mockDel;
+  }
+  return {
+    MockRedis,
+    mockSet,
+    mockGet,
+    mockIncr,
+    mockExpire,
+    mockZadd,
+    mockZremrange,
+    mockEval,
+    mockDel,
+  };
+});
+
+vi.mock('@upstash/redis', () => ({ Redis: MockRedis }));
+
+import { runAclSelfCheckOnce, readAclSelfCheck } from '../../../src/observability/acl-selfcheck';
+import type { Env } from '../../../src/worker';
+
+const env: Env = {
+  UPSTASH_MCP_REST_URL: 'https://y.upstash.io',
+  UPSTASH_MCP_REST_TOKEN: 'rw',
+  GIT_SHA: 'abc1234',
+};
+
+beforeEach(() => {
+  mockSet.mockReset();
+  mockGet.mockReset();
+  mockIncr.mockReset();
+  mockExpire.mockReset();
+  mockZadd.mockReset();
+  mockZremrange.mockReset();
+  mockEval.mockReset();
+  mockDel.mockReset();
+});
+
+describe('runAclSelfCheckOnce — happy path', () => {
+  it('captures the gate, runs every probe step, records ok, returns ok', async () => {
+    // Gate SET succeeds (acquired); every probe step resolves.
+    mockSet.mockResolvedValueOnce('OK'); // gate
+    mockIncr.mockResolvedValue(1);
+    mockExpire.mockResolvedValue(1);
+    mockZadd.mockResolvedValue(1);
+    mockZremrange.mockResolvedValue(0);
+    mockEval.mockResolvedValue(1);
+    // First probe step is SET — second SET call.
+    mockSet.mockResolvedValueOnce('OK');
+    // Result-record SET.
+    mockSet.mockResolvedValueOnce('OK');
+    mockDel.mockResolvedValue(1);
+
+    const result = await runAclSelfCheckOnce(env);
+
+    expect(result.status).toBe('ok');
+    expect(result.ranAt).toBeTypeOf('string');
+    expect(mockIncr).toHaveBeenCalled();
+    expect(mockEval).toHaveBeenCalled();
+    // gate (set #1) + probe SET (set #2) + result-record (set #3) = 3
+    expect(mockSet).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('runAclSelfCheckOnce — gate not captured', () => {
+  it('reads the recorded result instead of probing again', async () => {
+    // Gate SET returns null (peer already holds it).
+    mockSet.mockResolvedValueOnce(null);
+    // Recorded result GET returns ok payload.
+    mockGet.mockResolvedValueOnce({ status: 'ok', ranAt: '2026-05-30T10:00:00Z' });
+
+    const result = await runAclSelfCheckOnce(env);
+
+    expect(result.status).toBe('ok');
+    expect(mockIncr).not.toHaveBeenCalled();
+    expect(mockEval).not.toHaveBeenCalled();
+  });
+
+  it('returns unknown when peer holds gate but no result has been written yet', async () => {
+    mockSet.mockResolvedValueOnce(null);
+    mockGet.mockResolvedValueOnce(null);
+
+    const result = await runAclSelfCheckOnce(env);
+
+    expect(result.status).toBe('unknown');
+  });
+});
+
+describe('runAclSelfCheckOnce — NOPERM short-circuit', () => {
+  it('records degraded with the failing command when EVAL throws NOPERM', async () => {
+    mockSet.mockResolvedValueOnce('OK'); // gate
+    mockSet.mockResolvedValueOnce('OK'); // probe SET ok
+    mockIncr.mockResolvedValue(1);
+    mockExpire.mockResolvedValue(1);
+    mockZadd.mockResolvedValue(1);
+    mockZremrange.mockResolvedValue(0);
+    mockEval.mockRejectedValueOnce(new Error('NOPERM no permission to run command'));
+    // Result-record SET should still fire.
+    mockSet.mockResolvedValueOnce('OK');
+
+    const result = await runAclSelfCheckOnce(env);
+
+    expect(result.status).toBe('degraded');
+    expect(result.failedCommand).toMatch(/EVAL/);
+    expect(result.failedCommand).toMatch(/NOPERM/);
+    // del cleanup should NOT have been called (we short-circuited).
+    expect(mockDel).not.toHaveBeenCalled();
+  });
+
+  it('stops at the first failing step (does not exercise later steps)', async () => {
+    mockSet.mockResolvedValueOnce('OK'); // gate
+    mockSet.mockResolvedValueOnce('OK'); // probe SET ok
+    mockIncr.mockRejectedValueOnce(new Error('NOPERM'));
+    mockSet.mockResolvedValueOnce('OK'); // result-record
+
+    const result = await runAclSelfCheckOnce(env);
+
+    expect(result.status).toBe('degraded');
+    expect(result.failedCommand).toMatch(/INCR/);
+    expect(mockExpire).not.toHaveBeenCalled();
+    expect(mockZadd).not.toHaveBeenCalled();
+    expect(mockEval).not.toHaveBeenCalled();
+  });
+});
+
+describe('runAclSelfCheckOnce — Upstash unreachable', () => {
+  it('returns unknown when gate SET throws (never throws to caller)', async () => {
+    mockSet.mockRejectedValueOnce(new Error('network'));
+    const result = await runAclSelfCheckOnce(env);
+    expect(result.status).toBe('unknown');
+  });
+});
+
+describe('readAclSelfCheck', () => {
+  it('returns unknown when no result is recorded', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    const result = await readAclSelfCheck(env);
+    expect(result.status).toBe('unknown');
+  });
+
+  it('returns the recorded result', async () => {
+    mockGet.mockResolvedValueOnce({ status: 'degraded', failedCommand: 'EVAL: NOPERM' });
+    const result = await readAclSelfCheck(env);
+    expect(result.status).toBe('degraded');
+    expect(result.failedCommand).toBe('EVAL: NOPERM');
+  });
+
+  it('parses JSON string responses (Upstash auto-stringify variant)', async () => {
+    mockGet.mockResolvedValueOnce(JSON.stringify({ status: 'ok', ranAt: '2026-05-30T10:00:00Z' }));
+    const result = await readAclSelfCheck(env);
+    expect(result.status).toBe('ok');
+  });
+
+  it('returns unknown when redis.get throws', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network'));
+    const result = await readAclSelfCheck(env);
+    expect(result.status).toBe('unknown');
+  });
+});

--- a/src/docs/operations/SECRETS_INVENTORY.md
+++ b/src/docs/operations/SECRETS_INVENTORY.md
@@ -174,7 +174,31 @@ When values disagree across stores (the situation that caused today's confusion)
 | `SENTRY_DSN` (each project)     | Sentry project settings | Sentry owns it; build env mirrors                                                                                                                                                                                                                                                                                                                                                                                          | Copy from Sentry → `vercel env add` / `wrangler secret put`             |
 | `CLOUDFLARE_AE_READ_TOKEN`      | Cloudflare API tokens   | ✅ **Minted 2026-05-29** (Phase 1 verification — rotates annually). Read-only token for Account Analytics; consumed by `mcp-server/scripts/Verify-AeEmission.ps1` today and by Grafana / `/status` page when Phase 3 lands. Procedure: [`mcp-server/src/docs/operations/DEPLOY.md` § C.X — Analytics Engine SQL query](../../../mcp-server/src/docs/operations/DEPLOY.md#cx--analytics-engine-sql-query-bl-03275-phase-3). | Re-mint via Cloudflare dashboard → API Tokens (annual rotation cadence) |
 
-**Rule of thumb**: if a Vercel and Worker value disagree, the Worker wins for shared-secret cases (`MCP_KEY_WEBSITE_RADAR`); the upstream provider wins for everything else (Sentry DSN, Upstash token, Inoreader OAuth).
+**Rule of thumb**: if a Vercel and Worker value disagree, the Worker wins for shared-secret cases (`MCP_KEY_WEBSITE_RADAR`); the upstash provider wins for everything else (Sentry DSN, Upstash token, Inoreader OAuth).
+
+---
+
+## Upstash ACL users (BL-041)
+
+The Worker's bound `UPSTASH_MCP_REST_TOKEN` is minted from a scoped ACL user, **not** the default admin token. The default token remains in 1Password as break-glass only — never bound to a Worker secret in steady state.
+
+**Procedure for minting + rotating scoped tokens**: [`mcp-server/src/docs/operations/DEPLOY.md` § A.3.5 — Upstash ACL hardening](../../../mcp-server/src/docs/operations/DEPLOY.md#a35--upstash-acl-hardening-bl-041).
+
+| Username           | Bound to             | Permissions (ACL string)                                          | 1Password item                            |
+| ------------------ | -------------------- | ----------------------------------------------------------------- | ----------------------------------------- |
+| `default`          | Break-glass only     | Full admin                                                        | "Upstash gst-mcp — default (break-glass)" |
+| `mcp-worker-rw`    | Worker (both envs)   | `on ~mcp:* -@all +@read +@write +@string +@sortedset +@scripting` | "Upstash gst-mcp ACL — mcp-worker-rw"     |
+| `mcp-readonly-ops` | Operator triage only | `on ~mcp:* -@all +@read`                                          | "Upstash gst-mcp ACL — mcp-readonly-ops"  |
+
+**Verification** (post-rotation): `mcp-server/scripts/Test-UpstashAcl.ps1` exit code 0 + `/health.aclSelfCheck.status: 'ok'` against the freshly deployed Worker. Both gate the rotation as complete.
+
+### MFA enforcement log
+
+| Date  | Member | Upstream SSO MFA | Upstash account TOTP | Verified by |
+| ----- | ------ | ---------------- | -------------------- | ----------- |
+| _TBD_ | _TBD_  | _TBD_            | _TBD_                | _TBD_       |
+
+> Phase D of BL-041 fills in this table during the rotation session. Re-verify on every team-membership change (add/remove operator).
 
 ---
 


### PR DESCRIPTION
## Summary

Lands the engineering side of [BL-041](src/docs/development/BACKLOG.md#bl-041-upstash-database-security-hardening--redis-acl--account-mfa) so the operator can mint scoped ACL users + REST tokens, verify locally, and rotate Worker bindings without breaking the rate limiter or burning a 6h cron-window on uncertainty.

**No Upstash state changes in this PR** — operator runs Phases B–D per the new [DEPLOY.md § A.3.5 runbook](mcp-server/src/docs/operations/DEPLOY.md) when they have a window.

- **Verification probes**: \`Test-UpstashAcl.ps1\` + Node sibling \`verify-ratelimit-acl.mjs\` (real \`@upstash/ratelimit\` SDK roundtrip — audit M1 fix)
- **Worker-side guardrail**: \`observability/acl-selfcheck.ts\` runs the full Redis command surface once per deploy, surfaces NOPERM at \`/health.aclSelfCheck\` so the rate limiter's fail-open doesn't hide regressions (audit M3 fix)
- **Operator runbook**: DEPLOY.md § A.3.5 with category-rationale table (audit B1 documentation fix), step-by-step mint via Upstash console + CLI tab (\`ACL RESTTOKEN\`), Phase 3 \`wrangler dev --test-scheduled\` cron dry-run, Phase 4 rollback semantics for non-atomic \`secret put\` + \`deploy\` (audit M2 fix), account-level MFA (audit O5 fix)
- **Inventory**: SECRETS_INVENTORY new "Upstash ACL users" subsection + MFA log

## Pre-impl audit

Two rounds of impartial audit caught 3 BLOCKERS + 3 MAJORS + 5 OVERLOOKED. All addressed in this commit — no deferred follow-ups per CLAUDE.md § 4a:

- **B1**: ACL category union semantics → category-rationale table prevents future +@keyspace widen
- **B2**: SCRIPT LOAD category varies by Redis fork version → raw \`SCRIPT LOAD\` probe in PS1 + EVAL probe in self-check
- **B3**: Upstash RBAC tier availability → confirmed via operator screenshot (UI w/ free-text Advanced tab)
- **M1**: PowerShell can't import SDK → Node sibling
- **M2**: \`wrangler secret put\` ≠ \`wrangler deploy\` atomicity → rollback runbook
- **M3**: Worker startup self-check → \`acl-selfcheck.ts\` + \`/health.aclSelfCheck\`
- **O4**: REST token mint surface → verified via Upstash docs (\`ACL RESTTOKEN\` runs from console CLI tab)
- **O5**: Upstash TOTP independent of SSO → both layers in Phase D checklist

## Test plan

- [x] \`npm run typecheck\` clean (mcp-server)
- [x] \`npm test\` — 85 files / 989 tests pass (10 new for \`acl-selfcheck.ts\`)
- [ ] **Operator Phase B-D after merge** (no rush — independent track):
  - Mint \`mcp-worker-rw\` + \`mcp-readonly-ops\` via Upstash console
  - Run \`Test-UpstashAcl.ps1 -Token <new>\` — expect exit 0
  - Rotate staging (\`wrangler secret put\` + deploy + \`wrangler dev --test-scheduled\` cron dry-run + \`/health.aclSelfCheck.status: 'ok'\`)
  - Rotate production same flow
  - Verify MFA per member; fill SECRETS_INVENTORY log; flip BL-041 ACs to \`[x]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)