### PR TITLE
fix(ci): BL-037 deploy workflow — match feature/** and master branches

### DIFF
--- a/.github/workflows/deploy-mcp-staging.yml
+++ b/.github/workflows/deploy-mcp-staging.yml
@@ -20,20 +20,24 @@ on:
   workflow_run:
     workflows: ['MCP Server Test Suite']
     types: [completed]
-    # `feature/**` is required because GitHub Actions globs treat `/` as a
-    # path separator — `feature-*` does NOT match `feature/bl-038-...`
-    # (slash-style is the team's actual convention; dash-style left in for
-    # back-compat). `master` is included so the merge commit ALSO gets a
-    # staging validation, closing the gap where the post-merge tip ships to
-    # production without ever touching staging.
-    branches: [master, dev, 'feature/**', 'feature-*']
+    # Branch list harmonized with `test.yml` and `test-mcp-server.yml` — all
+    # three workflows now share the canonical set so the chain is never
+    # short-circuited by a filter mismatch (BL-037 follow-up after BL-038
+    # surfaced two gaps: `feature-*` didn't match slash-style branches, and
+    # `master` was missing so the merge commit never got staging validation).
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
 
 permissions:
   contents: read
 
 concurrency:
+  # Per-branch group: rapid successive merges to the same branch queue rather
+  # than race. `cancel-in-progress: false` because mid-flight cancellation of
+  # `wrangler deploy` could leave the Worker partially uploaded — for a
+  # deploy workflow the queue-and-wait semantic is the correct safety
+  # property, even though "only the latest matters" is intuitively appealing.
   group: deploy-mcp-staging-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-staging:
@@ -64,10 +68,27 @@ jobs:
         env:
           DEPLOYED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
+          # `deploy.mjs` pins SHA to `--short=7`, so we compare against the
+          # leading 7 chars of the workflow_run head_sha. The two must agree
+          # byte-for-byte; if either side ever changes the abbreviation
+          # length, this probe will fail loud rather than silently mismatching.
           EXPECTED=${DEPLOYED_SHA:0:7}
+          if ! [[ "$EXPECTED" =~ ^[0-9a-f]{7}$ ]]; then
+            echo "Refusing to probe: EXPECTED='$EXPECTED' is not a 7-char hex SHA"
+            exit 1
+          fi
           echo "Expecting /health.gitSha to report $EXPECTED"
           for i in $(seq 1 10); do
-            ACTUAL=$(curl -fsS https://mcp-staging.globalstrategic.tech/health | jq -r .gitSha || echo "")
+            # Cache-buster query + no-cache headers defeat any Cloudflare-edge
+            # caching of `/health` between attempts. The query string is part
+            # of the cache key by default; the headers cover origin-side
+            # caches if /health ever sprouts one.
+            CACHE_BUSTER="t=$(date +%s%N)"
+            ACTUAL=$(curl -fsS \
+              -H "Cache-Control: no-cache" \
+              -H "Pragma: no-cache" \
+              "https://mcp-staging.globalstrategic.tech/health?${CACHE_BUSTER}" \
+              | jq -r .gitSha || echo "")
             if [ "$ACTUAL" = "$EXPECTED" ]; then
               echo "Smoke probe OK: gitSha=$ACTUAL on attempt $i"
               exit 0

--- a/.github/workflows/deploy-mcp-staging.yml
+++ b/.github/workflows/deploy-mcp-staging.yml
@@ -20,7 +20,13 @@ on:
   workflow_run:
     workflows: ['MCP Server Test Suite']
     types: [completed]
-    branches: [dev, 'feature-*']
+    # `feature/**` is required because GitHub Actions globs treat `/` as a
+    # path separator — `feature-*` does NOT match `feature/bl-038-...`
+    # (slash-style is the team's actual convention; dash-style left in for
+    # back-compat). `master` is included so the merge commit ALSO gets a
+    # staging validation, closing the gap where the post-merge tip ships to
+    # production without ever touching staging.
+    branches: [master, dev, 'feature/**', 'feature-*']
 
 permissions:
   contents: read

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,52 @@
+name: npm audit
+
+# Production-dependency vulnerability scan. Runs:
+#   - Weekly cron (Monday 06:00 UTC) — catches advisories published after the
+#     last lockfile change, so dormant dependencies don't quietly age into
+#     CVE territory.
+#   - On lockfile change — every PR that touches `package-lock.json` or
+#     `mcp-server/package-lock.json` runs the audit so new vulnerabilities
+#     surface at the moment the dependency is added.
+#
+# Moved out of the main Test Suite (2026-05-31) — running on every code
+# change was wasteful: the audit result is a function of the lockfile only,
+# not of source. The CLAUDE.md policy stays the same: "production
+# dependencies must stay at zero advisories (enforced via
+# `--audit-level=moderate --omit=dev` in CI). Dev-only advisories are
+# tolerated case-by-case."
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
+    paths:
+      - 'package-lock.json'
+      - 'mcp-server/package-lock.json'
+      - '.github/workflows/npm-audit.yml'
+  pull_request:
+    branches: [master]
+    types: [opened, reopened]
+    paths:
+      - 'package-lock.json'
+      - 'mcp-server/package-lock.json'
+      - '.github/workflows/npm-audit.yml'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: npm audit (production dependencies only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - name: npm audit --audit-level=moderate --omit=dev
+        run: npm audit --audit-level=moderate --omit=dev

--- a/.github/workflows/test-mcp-server.yml
+++ b/.github/workflows/test-mcp-server.yml
@@ -15,7 +15,7 @@ permissions:
 
 on:
   push:
-    branches: [master, dev, 'feat/**', 'fix/**', 'feature-*']
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
     paths:
       - 'mcp-server/**'
       - '!mcp-server/**/*.md'
@@ -29,7 +29,11 @@ on:
       - '.github/workflows/test-mcp-server.yml'
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened]
+    # Deliberately NOT listening to `synchronize` — push covers every commit
+    # added to a PR'd branch, and `synchronize` would duplicate-fire on every
+    # PR sync. `opened` + `reopened` still gives one PR-context run on the
+    # synthetic merge SHA so the merge result is independently validated.
+    types: [opened, reopened]
     paths:
       - 'mcp-server/**'
       - '!mcp-server/**/*.md'
@@ -64,7 +68,22 @@ jobs:
           node-version: '22.x'
           cache: 'npm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        id: nm-cache
+        with:
+          # `setup-node`'s `cache: 'npm'` only caches the ~/.npm tarball
+          # cache — `npm ci` still does the link/install pass (~30-40s).
+          # Caching node_modules directly skips that step on cache hit.
+          # Key includes lockfile + node version + a manual epoch we can
+          # bump when we want to force a fresh install.
+          path: |
+            node_modules
+            mcp-server/node_modules
+          key: nm-v1-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,14 @@ permissions:
 
 on:
   push:
-    branches: [master, dev, 'feat/**', 'fix/**']
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened]
+    # Deliberately NOT listening to `synchronize` — push covers every commit
+    # added to a PR'd branch, and `synchronize` would duplicate-fire on every
+    # PR sync. `opened` + `reopened` still gives one PR-context run on the
+    # synthetic merge SHA so the merge result is independently validated.
+    types: [opened, reopened]
 
 concurrency:
   # Include event_name in the group so push and pull_request runs on the
@@ -139,8 +143,18 @@ jobs:
           node-version: '22.x'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Cache node_modules
         if: needs.changes.outputs.should_run == 'true'
+        uses: actions/cache@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            mcp-server/node_modules
+          key: nm-v1-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: needs.changes.outputs.should_run == 'true' && steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Astro type check
@@ -158,10 +172,6 @@ jobs:
       - name: Prettier check
         if: needs.changes.outputs.should_run == 'true'
         run: npx prettier --check .
-
-      - name: npm audit (production dependencies only)
-        if: needs.changes.outputs.should_run == 'true'
-        run: npm audit --audit-level=moderate --omit=dev
 
       - name: Skipped (docs-only or duplicate run)
         if: needs.changes.outputs.should_run != 'true'
@@ -190,8 +200,18 @@ jobs:
           node-version: '22.x'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Cache node_modules
         if: needs.changes.outputs.should_run == 'true'
+        uses: actions/cache@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            mcp-server/node_modules
+          key: nm-v1-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: needs.changes.outputs.should_run == 'true' && steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run tests with coverage
@@ -259,8 +279,18 @@ jobs:
           node-version: '22.x'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Cache node_modules
         if: needs.changes.outputs.should_run == 'true'
+        uses: actions/cache@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            mcp-server/node_modules
+          key: nm-v1-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: needs.changes.outputs.should_run == 'true' && steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Get Playwright version

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ export default [
       'dist/**',
       '**/dist/**',
       '.astro/**',
+      '**/.astro/**',
       '.vercel/**',
       'coverage/**',
       'playwright-report/**',

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -2,3 +2,7 @@ dist/
 node_modules/
 coverage/
 *.tsbuildinfo
+# Local skip-cache for scripts/generate-regulations-index.mjs — input-hash
+# based; safe to delete (next run will regenerate it). Not committed because
+# its hash includes absolute paths that differ per checkout.
+src/content/.regen-cache.json

--- a/mcp-server/scripts/deploy.mjs
+++ b/mcp-server/scripts/deploy.mjs
@@ -60,15 +60,19 @@ if (!ALLOWED_ENVS.includes(env)) {
 
 let sha;
 try {
-  sha = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+  // `--short=7` pins the length explicitly. The default `--short` honors
+  // `core.abbrev` AND auto-extends on ambiguity — both of which would silently
+  // break the CI smoke probe's prefix compare. Pinning to 7 keeps deploy.mjs
+  // and the workflow probe agreeing byte-for-byte.
+  sha = execSync('git rev-parse --short=7 HEAD', { encoding: 'utf-8' }).trim();
 } catch (err) {
   console.error(`Failed to read git SHA: ${err.message}`);
   console.error('Are you inside a git repo? Refusing to deploy without a SHA.');
   process.exit(1);
 }
 
-// `git rev-parse --short` returns 7+ hex chars. Anything else is suspicious.
-if (!/^[0-9a-f]{7,}$/.test(sha)) {
+// `git rev-parse --short=7` returns exactly 7 hex chars. Anything else is suspicious.
+if (!/^[0-9a-f]{7}$/.test(sha)) {
   console.error(
     `Refusing to deploy: git rev-parse returned a suspicious value: ${JSON.stringify(sha)}`
   );

--- a/mcp-server/scripts/generate-regulations-index.mjs
+++ b/mcp-server/scripts/generate-regulations-index.mjs
@@ -18,10 +18,109 @@
 
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { format, resolveConfig } from 'prettier';
 
 const here = dirname(fileURLToPath(import.meta.url));
+
+// ─── Content-hash skip cache ─────────────────────────────────────────────────
+//
+// The script is invoked by `prebuild`, `pretypecheck`, AND `pretest` — so on
+// a typical CI workflow it runs at least 3× per job, plus once per local
+// `npm test` invocation. The work is deterministic (same inputs → identical
+// outputs after prettier), so each rerun after the first is wasted I/O.
+//
+// Skip cache: compute a SHA-256 over (regulation JSONs + library MDs + this
+// script + prettier config), compare against `.regen-cache.json` stored
+// alongside the outputs. If matched and both outputs exist, exit early. If
+// any input file is touched, the hash changes and we regenerate from
+// scratch. Cache invalidation is automatic; no manual `clean` step needed.
+//
+// The cache file lives inside `mcp-server/src/content/` so it travels with
+// the generated artifacts under a single output directory.
+
+function sha256(buf) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function hashFile(path) {
+  return sha256(readFileSync(path));
+}
+
+function listDirRecursive(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  const out = [];
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listDirRecursive(full));
+    } else if (entry.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function computeInputHash() {
+  const regulationsDir = resolve(here, '../../src/data/regulatory-map');
+  const libraryDir = resolve(here, '../../src/data/library');
+  const scriptPath = fileURLToPath(import.meta.url);
+  const prettierConfigPath = resolve(here, '../../.prettierrc.json');
+
+  const inputFiles = [
+    ...listDirRecursive(regulationsDir),
+    ...listDirRecursive(libraryDir),
+    scriptPath,
+  ];
+  if (existsSync(prettierConfigPath)) inputFiles.push(prettierConfigPath);
+
+  // Hash each input file independently then combine — order-insensitive
+  // because we sort inside listDirRecursive.
+  const combined = inputFiles.map((p) => `${p}:${hashFile(p)}`).join('\n');
+  return sha256(Buffer.from(combined, 'utf8'));
+}
+
+const CACHE_FILE = resolve(here, '../src/content/.regen-cache.json');
+const REGULATIONS_OUT = resolve(here, '../src/content/regulations-data.generated.ts');
+const LIBRARY_OUT = resolve(here, '../src/content/library-data.generated.ts');
+
+function tryReadCache() {
+  if (!existsSync(CACHE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(CACHE_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function outputsExist() {
+  return existsSync(REGULATIONS_OUT) && existsSync(LIBRARY_OUT);
+}
+
+{
+  const inputHash = computeInputHash();
+  const cached = tryReadCache();
+  if (cached && cached.inputHash === inputHash && outputsExist()) {
+    // Belt-and-braces: also verify outputs haven't been touched since the
+    // cache was last written. If a contributor edited a generated file by
+    // hand, the mtime will be newer than the cache file — force regen.
+    const cacheStat = statSync(CACHE_FILE);
+    const regulationsStat = statSync(REGULATIONS_OUT);
+    const libraryStat = statSync(LIBRARY_OUT);
+    if (
+      regulationsStat.mtimeMs <= cacheStat.mtimeMs + 1000 &&
+      libraryStat.mtimeMs <= cacheStat.mtimeMs + 1000
+    ) {
+      console.log(`[gst-mcp] regen skipped — inputs unchanged (hash ${inputHash.slice(0, 12)})`);
+      process.exit(0);
+    }
+  }
+  // No cache hit — full regen below. Cache is rewritten at the end.
+  globalThis.__GST_REGEN_INPUT_HASH__ = inputHash;
+}
 
 /**
  * Format a string of TypeScript source with the project's prettier config
@@ -127,3 +226,22 @@ async function writeFormatted(filePath, content) {
   await writeFormatted(outFile, content);
   console.log(`[gst-mcp] generated library-data.generated.ts (${records.length} articles)`);
 }
+
+// Persist the input hash so the next invocation can short-circuit if nothing
+// changed. Written LAST so a mid-script failure leaves the cache stale (next
+// run regenerates fresh rather than skipping with a half-written output).
+writeFileSync(
+  CACHE_FILE,
+  JSON.stringify(
+    {
+      inputHash: globalThis.__GST_REGEN_INPUT_HASH__,
+      generatedAt: new Date().toISOString(),
+    },
+    null,
+    2
+  ) + '\n',
+  'utf8'
+);
+console.log(
+  `[gst-mcp] regen-cache updated (hash ${globalThis.__GST_REGEN_INPUT_HASH__.slice(0, 12)})`
+);

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -88,7 +88,7 @@ git commit -m "..."
 
 **Important**: the hook runs **before** the commit is recorded. A file you staged with double-quotes and 4-space indent may end up in the commit with single-quotes and 2-space indent — that's Prettier doing its job between the stash and the record. If you see your commit look different than your working tree expected, that's why.
 
-### On every push to `master`, `dev`, `feat/**`, `fix/**` and PRs to `master`
+### On every push to `master`, `dev`, `feat/**`, `fix/**`, `feature/**` and PRs to `master`
 
 The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workflows/test.yml) runs a 3-job parallel-then-gate pipeline:
 
@@ -114,8 +114,10 @@ The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workfl
 │   │  astro check                  │                             │
 │   │  eslint .                     │ runs in parallel            │
 │   │  stylelint                    │ with the tests job          │
-│   │  npm audit --omit=dev         │                             │
+│   │  prettier --check .           │                             │
 │   │  (~30-60s when code changed)  │                             │
+│   │  (npm audit moved to its own  │                             │
+│   │   workflow — see § npm audit) │                             │
 │   └───────────────┐                                             │
 │                   │                                             │
 │   ┌─ Unit & Integration Tests ─┐  │                             │
@@ -219,9 +221,12 @@ The `actions: write` permission on the gate job is required by skip-duplicate-ac
 | [eslint.config.mjs](../../../eslint.config.mjs)                   | ESLint flat config — recommended rules + overrides for tests, node scripts, and browser globals |
 | [.stylelintrc.json](../../../.stylelintrc.json)                   | CSS lint rules                                                                                  |
 | [tsconfig.json](../../../tsconfig.json)                           | TypeScript config, including the `@/*` → `src/*` path alias                                     |
-| [.husky/pre-commit](../../../.husky/pre-commit)                   | Single line: `npx lint-staged`                                                                  |
-| [.github/workflows/test.yml](../../../.github/workflows/test.yml) | CI pipeline (3 jobs + changes gate)                                                             |
-| [.github/dependabot.yml](../../../.github/dependabot.yml)         | Automated dependency updates (npm + GitHub Actions)                                             |
+| [.husky/pre-commit](../../../.husky/pre-commit)                                   | Single line: `npx lint-staged`                                                                  |
+| [.github/workflows/test.yml](../../../.github/workflows/test.yml)                 | Website CI pipeline (3 jobs + changes gate)                                                     |
+| [.github/workflows/test-mcp-server.yml](../../../.github/workflows/test-mcp-server.yml) | MCP server CI (runs in parallel to the website Test Suite)                                |
+| [.github/workflows/deploy-mcp-staging.yml](../../../.github/workflows/deploy-mcp-staging.yml) | Auto-deploys the MCP Worker to staging on a green MCP test run (BL-037 Phase A)         |
+| [.github/workflows/npm-audit.yml](../../../.github/workflows/npm-audit.yml)       | Production-dep vuln scan — weekly cron + lockfile-change trigger                                 |
+| [.github/dependabot.yml](../../../.github/dependabot.yml)                         | Automated dependency updates (npm + GitHub Actions)                                             |
 
 ---
 
@@ -546,11 +551,17 @@ If you need to add or remove supported browsers:
 
 ## npm audit policy
 
-Phase 2 CI runs:
+Production-dep audit lives in its own workflow at [.github/workflows/npm-audit.yml](../../../.github/workflows/npm-audit.yml). It runs on:
+
+- **Weekly cron** (Mondays 06:00 UTC) — catches advisories published between lockfile changes.
+- **Lockfile-change push or PR** — runs the moment a dependency is added, so new vulnerabilities are surfaced at the PR diff rather than at the next weekly cron tick.
+- **Manual `workflow_dispatch`** — for ad-hoc verification after editing the `overrides` block.
 
 ```bash
 npm audit --audit-level=moderate --omit=dev
 ```
+
+Moved here from the main Test Suite (2026-05-31): the audit result is a function of the lockfile only, so running on every code push was pure waste.
 
 **Why `--omit=dev`**: dev-only advisories (e.g., `@astrojs/check` → `yaml-language-server` → `yaml`) affect local development tooling but never reach users. Production dependencies must stay at zero advisories; dev-only moderate advisories are tolerated and revisited case-by-case.
 


### PR DESCRIPTION
## Summary

After BL-038 (#200) merged, an impartial adversarial audit of the CI/CD setup surfaced **2 critical + 4 significant + 3 optimization** issues plus the original branch-filter bug. Per CLAUDE.md § 4a "no deferred tech debt," **every valid finding is addressed in this PR** — no follow-up tickets.

## What this PR does

### Branch filters + duplicate-fire (criticals)

- **Harmonized branch filter** across `test.yml`, `test-mcp-server.yml`, and `deploy-mcp-staging.yml` to the canonical set `[master, dev, 'feat/**', 'fix/**', 'feature/**']`. Previously each disagreed; net effect was that `feat/foo` ran tests but never deployed, and `feature/foo` (the actual slash-style team convention) deployed but the upstream test only fired on the PR synthetic merge.
- **Dropped `pull_request: synchronize` trigger** from both test workflows. `push` covers every commit on a PR'd branch; `synchronize` was just duplicating ~1m22s of CI per PR sync. `opened` + `reopened` still validate the synthetic merge.

### Deploy hardening (significants)

- **`cancel-in-progress: false`** on the deploy concurrency group — queue-and-wait protects against mid-flight `wrangler deploy` cancellation leaving the Worker partially uploaded.
- **Smoke probe hardened**: `deploy.mjs` pins `git rev-parse --short=7 HEAD` (was `--short`, which honors `core.abbrev` AND auto-extends on ambiguity); workflow regex-validates EXPECTED is 7-char hex before any curl; adds `?t=<epoch-ns>` cache-buster + `Cache-Control: no-cache` + `Pragma: no-cache` headers to defeat Cloudflare-edge caching.
- **`pretest` regen behind content-hash cache**: new SHA-256 over (regulation JSONs + library MDs + script + prettier config), stored in `mcp-server/src/content/.regen-cache.json`. First run 254ms, cached run 97ms. Runs 3× per `npm test`, multiplied by CI jobs.

### CI efficiency (optimizations)

- **Shared `node_modules` via `actions/cache@v5`** on all 4 test jobs, keyed on lockfile hash. `setup-node@v6`'s `cache: 'npm'` only caches the ~/.npm tarball — `npm ci` still does ~30-40s of link/install. New cache skips that step on hit.
- **`npm audit` moved to its own workflow** (`.github/workflows/npm-audit.yml`): weekly Monday cron + lockfile-change push/PR + manual dispatch. The audit result is a function of the lockfile only, so running on every code push was pure waste.

### Bonus fixes surfaced during local validation

- **eslint ignore**: `.astro/**` only matched at root, missing `mcp-server/.astro/` (auto-generated). Added `**/.astro/**`. Pre-existing latent bug.
- **DEVELOPER_TOOLING.md updated** per CLAUDE.md § 11: branch list, pipeline diagram (`npm audit` moved out), workflow inventory now includes test-mcp-server, deploy-mcp-staging, npm-audit.
- **mcp-server `.gitignore`** adds `src/content/.regen-cache.json`.

## Audit findings NOT addressed (with explicit justification — not deferral)

- **`@v6` typo concern**: verified `actions/checkout@v6.0.2` and `actions/setup-node@v6.4.0` are real stable releases via `gh api`. Not a bug.
- **`workflow_run` runs from default-branch context**: documented expectation and security feature; workflow uses `head_sha` for code while running the workflow definition from master. Correct.

## Verification (local, Windows)

- `npx astro check` — 0 errors
- `npm run lint` — clean (post-eslint-ignore fix)
- `npm run lint:css` — clean
- `npm run test:run` — 1103/1103 passing
- `cd mcp-server && npm run typecheck && npm test` — 1105/1105 passing
- regen-cache empirical: 254ms first / 97ms cached

## Test plan

- [ ] Merge to master. Confirm: ONLY ONE run of each workflow per push (no `synchronize` duplicate).
- [ ] Next MCP-touching PR after this merges: confirm `MCP Server Test Suite` → `Deploy MCP Worker — staging` chain fires on the feature branch push AND on the master-merge commit (closes both gaps from the original BL-037 Phase A bug surfaced by BL-038).
- [ ] Confirm `/health.gitSha` matches deployed SHA via the hardened smoke probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)