### PR TITLE
fix(ci): catch prettier non-idempotency at commit + scope CI check to PR diff

### DIFF
--- a/.github/workflows/prettier-drift-check.yml
+++ b/.github/workflows/prettier-drift-check.yml
@@ -1,0 +1,117 @@
+name: Prettier drift check (weekly)
+
+# Counter-pressure for the diff-scoped PR check at `test.yml` —
+# `test.yml` only validates files changed in the PR, so latent drift
+# in unrelated files would otherwise accumulate invisibly. This weekly
+# cron runs `prettier --check` against the whole repo and opens (or
+# updates) a `tech-debt + prettier-drift` Issue listing any drifted
+# files. Drift surfaces weekly; doesn't block PRs.
+#
+# Operator-triggerable via `workflow_dispatch` for ad-hoc validation
+# (e.g., right after merging a major refactor).
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    # Mondays 13:00 UTC = 10:00 Sao Paulo (UTC-3) — operator sees the
+    # Issue during work hours.
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    name: Run prettier --check against the whole repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: npm
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            mcp-server/node_modules
+          key: nm-v1-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run prettier --check on the whole repo
+        id: drift
+        shell: bash
+        run: |
+          # `tee` always exits 0; capture prettier's actual exit via
+          # PIPESTATUS[0]. Same pattern as test.yml's vitest step —
+          # without this, a failing prettier-check would be masked by
+          # tee's success exit and the workflow would silently pass.
+          npx prettier --check . 2>&1 | tee /tmp/drift.txt
+          PRETTIER_EXIT=${PIPESTATUS[0]}
+          if [ "$PRETTIER_EXIT" -eq 0 ]; then
+            echo "drift_found=false" >> "$GITHUB_OUTPUT"
+            echo "No drift. Repo is prettier-clean."
+          else
+            echo "drift_found=true" >> "$GITHUB_OUTPUT"
+            # Capture the file list for the Issue body
+            grep -E '^\[warn\]' /tmp/drift.txt | sed 's/^\[warn\] //' > /tmp/drift-files.txt
+            DRIFT_COUNT=$(wc -l < /tmp/drift-files.txt)
+            echo "Drift found in $DRIFT_COUNT files. Will open/update Issue."
+          fi
+
+      - name: Ensure labels exist
+        if: steps.drift.outputs.drift_found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # `gh issue create --label` fails if the label doesn't exist.
+          # Pre-create idempotently; --force is a no-op if it already
+          # exists with the same settings.
+          gh label create prettier-drift \
+            --color "fbca04" \
+            --description "Latent prettier-check drift surfaced by the weekly cron" \
+            --force
+          gh label create tech-debt \
+            --color "d73a4a" \
+            --description "Accumulated technical debt requiring cleanup" \
+            --force
+
+      - name: Open or update drift Issue
+        if: steps.drift.outputs.drift_found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BODY="$(cat <<EOF
+          Weekly \`prettier --check\` against the whole repo found drift in the following files. Run \`npx prettier --write .\` locally and open a cleanup PR.
+
+          \`\`\`
+          $(cat /tmp/drift-files.txt)
+          \`\`\`
+
+          **Workflow run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          **Why this Issue exists**: PRs use a diff-scoped prettier check (see \`.github/workflows/test.yml\`) so latent drift can't block unrelated PRs. This cron is the counter-pressure that prevents drift from accumulating invisibly. Close this Issue once the drift is fixed; the workflow reopens it weekly only when new drift appears.
+          EOF
+          )"
+          # Look for an existing open Issue with the label; update if found,
+          # create new otherwise.
+          EXISTING=$(gh issue list --label "prettier-drift" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+            echo "Updated existing Issue #$EXISTING"
+          else
+            NEW=$(gh issue create \
+              --title "Prettier drift detected ($(date -u +%Y-%m-%d))" \
+              --label "tech-debt,prettier-drift" \
+              --body "$BODY")
+            echo "Opened new Issue: $NEW"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,9 +169,44 @@ jobs:
         if: needs.changes.outputs.should_run == 'true'
         run: npm run lint:css
 
-      - name: Prettier check
+      - name: Prettier check (PR-diff scoped)
+        # Scoped to files changed in this PR so latent drift in unrelated
+        # files cannot block an otherwise-clean PR. The weekly drift cron
+        # at `.github/workflows/prettier-drift-check.yml` is the counter-
+        # pressure that surfaces accumulated drift in a tracked Issue.
         if: needs.changes.outputs.should_run == 'true'
-        run: npx prettier --check .
+        shell: bash
+        run: |
+          # Determine the base SHA to diff against:
+          #   - PR events: github.event.pull_request.base.sha
+          #   - Push to a tracked branch: github.event.before
+          #   - First push to a fresh branch (before=000...): fall back to
+          #     the merge-base against origin/master
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="$(git merge-base origin/master HEAD)"
+          fi
+          echo "Diffing against base: $BASE_SHA"
+
+          # `--diff-filter=AMRCT` excludes deletions (D) and untracked (U).
+          DIFF_FILES=$(git diff --name-only --diff-filter=AMRCT "$BASE_SHA"...HEAD -- \
+            '*.ts' '*.tsx' '*.mjs' '*.cjs' '*.js' '*.astro' \
+            '*.css' '*.json' '*.md' '*.yaml' '*.yml' || true)
+
+          if [ -z "$DIFF_FILES" ]; then
+            echo "No prettier-relevant files changed; skipping check"
+            exit 0
+          fi
+
+          FILE_COUNT=$(echo "$DIFF_FILES" | wc -l)
+          echo "Checking $FILE_COUNT files in PR diff:"
+          echo "$DIFF_FILES" | sed 's/^/  - /'
+
+          # `.prettierignore` is honored when files are passed as explicit
+          # args (verified — prettier 2.x+ behavior). `--ignore-unknown`
+          # silently skips unknown extensions, defense-in-depth.
+          # `xargs` to defeat shell arg-length limits on big PRs.
+          echo "$DIFF_FILES" | xargs npx prettier --check --ignore-unknown
 
       - name: Skipped (docs-only or duplicate run)
         if: needs.changes.outputs.should_run != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,12 @@ jobs:
           #     the merge-base against origin/master
           BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
           if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            # actions/checkout is shallow (depth=1) by default; origin/master
+            # isn't in the clone. Fetch enough of master to compute a
+            # merge-base. Depth 50 covers any realistic feature-branch fork
+            # point; if a contributor's branch diverged >50 commits behind
+            # they probably need to rebase anyway.
+            git fetch origin master --depth=50
             BASE_SHA="$(git merge-base origin/master HEAD)"
           fi
           echo "Diffing against base: $BASE_SHA"

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "lint-staged": "^17.0.5",
         "playwright": "^1.58.0",
         "postcss-html": "^1.8.1",
-        "prettier": "^3.8.3",
+        "prettier": "3.8.3",
         "prettier-plugin-astro": "^0.14.1",
         "stylelint": "^17.12.0",
         "stylelint-config-html": "^1.1.0",
@@ -69,7 +69,7 @@
     },
     "mcp-server": {
       "name": "@gst/mcp-server",
-      "version": "0.3.13",
+      "version": "0.3.15",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint-staged": "^17.0.5",
     "playwright": "^1.58.0",
     "postcss-html": "^1.8.1",
-    "prettier": "^3.8.3",
+    "prettier": "3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "stylelint": "^17.12.0",
     "stylelint-config-html": "^1.1.0",
@@ -109,19 +109,23 @@
   "lint-staged": {
     "*.{ts,tsx,mjs,cjs,js}": [
       "eslint --fix",
-      "prettier --write"
+      "prettier --write",
+      "prettier --check"
     ],
     "*.astro": [
       "eslint --fix",
       "stylelint --fix",
-      "prettier --write"
+      "prettier --write",
+      "prettier --check"
     ],
     "*.css": [
       "stylelint --fix",
-      "prettier --write"
+      "prettier --write",
+      "prettier --check"
     ],
     "*.{json,md,yaml,yml}": [
-      "prettier --write"
+      "prettier --write",
+      "prettier --check"
     ]
   }
 }

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -114,8 +114,8 @@ The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workfl
 │   │  astro check                  │                             │
 │   │  eslint .                     │ runs in parallel            │
 │   │  stylelint                    │ with the tests job          │
-│   │  prettier --check .           │                             │
-│   │  (~30-60s when code changed)  │                             │
+│   │  prettier --check <pr-diff>   │ (PR-scoped — see § Prettier │
+│   │  (~30-60s when code changed)  │  idempotency + drift)       │
 │   │  (npm audit moved to its own  │                             │
 │   │   workflow — see § npm audit) │                             │
 │   └───────────────┐                                             │
@@ -228,6 +228,7 @@ The `actions: write` permission on the gate job is required by skip-duplicate-ac
 | [.github/workflows/deploy-mcp-production.yml](../../../.github/workflows/deploy-mcp-production.yml) | Auto-deploys the MCP Worker to production on master merge, gated by the `mcp-production` GitHub Environment's required-reviewer approval (BL-037 Phase B) |
 | [.github/workflows/rollback-mcp.yml](../../../.github/workflows/rollback-mcp.yml) | Manual `workflow_dispatch` rollback of the MCP Worker to a prior deployment ID; production rollbacks gated by the `mcp-production-rollback` environment (BL-037 Phase C) |
 | [.github/workflows/npm-audit.yml](../../../.github/workflows/npm-audit.yml)       | Production-dep vuln scan — weekly cron + lockfile-change trigger                                 |
+| [.github/workflows/prettier-drift-check.yml](../../../.github/workflows/prettier-drift-check.yml) | Weekly cron + manual `workflow_dispatch` — runs `prettier --check .` repo-wide; opens a `tech-debt` Issue if drift accumulates (counter-pressure for the diff-scoped PR check; see § Prettier idempotency + drift) |
 | [.github/dependabot.yml](../../../.github/dependabot.yml)                         | Automated dependency updates (npm + GitHub Actions)                                             |
 
 ---
@@ -256,13 +257,25 @@ See [.prettierignore](../../../.prettierignore) for the full list. Notable entri
 - **Lock files**: `package-lock.json`
 - **Generated output**: `dist/`, `.astro/`, `.vercel/`, `coverage/`, `playwright-report/`, `test-results/`
 
-### Known gap — the full-codebase Prettier sweep is deferred
+## Prettier idempotency + drift detection
 
-Phase 2 Commit 4 added `.prettierrc.json` but deliberately did NOT run `prettier --write .` on the codebase. Instead, the pre-commit hook formats files incrementally as they're touched. `npm run format:check` currently fails on a large number of legacy files and is therefore NOT wired into CI.
+Four-part defense against the class of bug that surfaced in PR #207 (a markdown italic-context escape regression introduced by hand-editing in PR #206; the file landed prettier-clean at PR #206 commit time but a later prettier patch version disagreed, blocking unrelated PR #207's CI on an untouched file):
 
-**A full `prettier --write .` sweep is tracked as a Phase 9 backlog item** in [PLATFORM_HARDENING_V1.md](./PLATFORM_HARDENING_V1.md). Once the legacy files are swept, `format:check` will be added to the `lint-and-typecheck` CI job.
+1. **Pre-commit idempotency check** (`package.json` lint-staged): every chain runs `prettier --check` immediately after `prettier --write`. If `--write`'s output isn't its own fixed point at the currently-installed prettier version, the commit is rejected locally with prettier's standard error message. Contributors see the failure at commit time, not via CI on someone else's later unrelated PR. Catches the narrow class where prettier is internally inconsistent at commit time.
 
-Until then: if you want a specific file or directory formatted, run `npx prettier --write <path>` manually.
+2. **Prettier pinned to exact `3.8.3`** (`package.json` `devDependencies.prettier`): no caret. Every CI run installs exactly the same prettier version. Eliminates the patch-version-drift class that caused PR #207. To bump: edit `package.json` deliberately, run `npx prettier --write .` locally to flush any drift the new version surfaces, ship the bump alongside the cleanup in one PR.
+
+3. **CI Prettier check is scoped to PR diff** (`.github/workflows/test.yml` "Prettier check (PR-diff scoped)" step): computes the changed-files list against the merge base via `git diff --name-only --diff-filter=AMRCT <base>...HEAD -- <prettier-relevant globs>` and only checks those files. Latent drift in unrelated files no longer blocks a PR. The trade-off is intentional: PRs validate their own changes, not the whole repo's hygiene.
+
+4. **Weekly drift cron** (`.github/workflows/prettier-drift-check.yml`): runs `prettier --check .` against the whole repo every Monday 13:00 UTC (10:00 Sao Paulo). If drift exists, opens (or updates) a `tech-debt` + `prettier-drift` Issue listing the drifted files. The Issue is the visible counter-pressure that prevents latent drift from accumulating invisibly. Operator-triggerable via `workflow_dispatch` for ad-hoc validation.
+
+**Why all four**: each layer catches a different class.
+- (1) catches author-side prettier non-idempotency
+- (2) closes the version-drift class at root cause
+- (3) prevents one PR's latent debt from blocking another's CI
+- (4) ensures the latent debt that (3) tolerates doesn't grow unbounded
+
+If you see a `prettier-drift` Issue: run `npx prettier --write .` locally, open a cleanup PR with the resulting changes, close the Issue once merged.
 
 ---
 


### PR DESCRIPTION
## Summary

Direct fix for the bug class PR #207 hit (untouched-file CI failure on SECRETS_INVENTORY.md). Two adversarial audits walked back the original diagnosis: line-ending hygiene was a red herring; the actual root cause was a markdown italic-context escape regression I introduced in PR #206 + prettier-version drift between PR #206 merge-CI and PR #207 open-CI.

**4-layer defense, 3 commits**:

| Layer | Mechanism | What it catches |
|---|---|---|
| 1. Commit-time idempotency | `prettier --check` after `prettier --write` in every lint-staged chain | Narrow class: prettier internally inconsistent at commit time |
| 1.5. Version pin | `package.json` drops `^` → `prettier: 3.8.3` exact | Patch-version drift class (the actual PR #207 root cause) |
| 2. PR-diff-scoped CI | `.github/workflows/test.yml` Prettier check uses `git diff` against merge base | Stops latent drift in unrelated files from blocking PRs |
| 3. Weekly drift cron | New `.github/workflows/prettier-drift-check.yml` runs `prettier --check .` weekly, opens/updates a `tech-debt + prettier-drift` Issue | Counter-pressure so the latent drift (3) tolerates doesn't grow unbounded |

## Why all four

Each layer catches a different class. Without (1) author-side non-idempotency lands silently. Without (1.5) the underlying PR #207 cause recurs. Without (2) one PR's latent debt blocks every other PR's CI. Without (4) (2) lets drift accumulate invisibly forever.

## Discipline notes

This PR is the result of THREE adversarial audits. Findings incorporated:

- **Audit 1 (first plan)**: caught 2 hallucinated findings before any code was written. Mostly noise.
- **Audit 2 (after redirect)**: identified that the original `.gitattributes` line-ending plan was solving the wrong problem entirely. Smoking gun: PR #206's commit `26c3551` literally removed a `\` escape character — hand-editing regression, not CRLF. **Original plan discarded.**
- **Audit 3 (this plan)**: caught 1 BLOCKER + 4 MAJORS + 1 promoted MINOR. All addressed:
  - **B1**: lint-staged semantics mis-stated (commands operate on files on-disk, not on prior-step output). Wording corrected.
  - **M1**: idempotency check honest-scope statement added — it does NOT catch the actual PR #207 class.
  - **M3**: labels must pre-exist for `gh issue create`. Workflow now pre-creates `prettier-drift` and `tech-debt` idempotently.
  - **M4**: cron timing shifted from 04:00 to 10:00 Sao Paulo so the operator sees the Issue during work hours.
  - **M5**: prettier version pinning added as commit 1.5 (was originally out-of-scope; audit argued it's the root-cause fix for PR #207).
  - **M6**: `tee` swallows prettier's exit code. Workflow now uses `PIPESTATUS[0]` — same pattern this repo's test.yml already uses.

## What's out of scope (explicit)

- `.gitattributes` LF canonicalize — verified pre-flight that all 708 text files are already `i/lf` in the index. Preventive medicine for a different (hypothetical) class. Not bundled.
- `.editorconfig` — same reasoning.
- Adjacent flushes (eslint, stylelint repo-wide) — scope-creep.

## Verification

- [x] `npx astro check` — 0 errors
- [x] Pre-commit hook self-validation: every commit in this branch ran through the new `prettier --check` step at commit time without warning
- [x] Pre-flight: master is currently prettier-clean (0 drift), so the first cron run will pass and not open an Issue
- [x] YAML parse on the new workflow — clean
- [ ] After merge: `gh workflow run "Prettier drift check (weekly)"` for end-to-end validation
- [ ] Next PR opened after this merges: confirm CI Prettier check runs only against PR-diff files (look for the "Diffing against base:" log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)