### PR TITLE
fix(techpar): scope-pierce chip styles so PresetInput chips inherit them

### DIFF
--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -1509,7 +1509,14 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
   }
 
   /* ── ARR quick-pick chips ──────────────────────────────────── */
-  .tp-arr-quick {
+  /* :global() because these selectors are also targeted by chips rendered
+     from <PresetInput> (src/components/techpar/PresetInput.astro), which
+     carries its own Astro scope hash. Without :global(), Astro adds
+     index.astro's hash to the selector and the component-rendered chips
+     fall back to unstyled <button>s — visible regression on TechPar's
+     Costs tab. The ARR chips inside this file still match because the
+     selectors are global; class structure unchanged. */
+  :global(.tp-arr-quick) {
     display: flex;
     flex-wrap: wrap;
     margin-bottom: var(--spacing-sm);
@@ -1518,7 +1525,7 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
     max-width: 280px;
   }
 
-  .tp-arr-chip {
+  :global(.tp-arr-chip) {
     flex: 1;
     background: transparent;
     border: none;
@@ -1536,27 +1543,27 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
     text-align: center;
   }
 
-  .tp-arr-chip:nth-child(4),
-  .tp-arr-chip:last-child {
+  :global(.tp-arr-chip:nth-child(4)),
+  :global(.tp-arr-chip:last-child) {
     border-right: none;
   }
 
-  .tp-arr-chip:focus-visible {
+  :global(.tp-arr-chip:focus-visible) {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
 
-  .tp-arr-chip:hover:not(.tp-arr-chip--active) {
+  :global(.tp-arr-chip:hover:not(.tp-arr-chip--active)) {
     color: var(--text-secondary);
   }
 
-  .tp-arr-chip--active {
+  :global(.tp-arr-chip--active) {
     background: transparent;
     color: var(--color-primary);
     box-shadow: inset 0 0 0 2px var(--color-primary);
   }
 
-  .tp-arr-chip--active:hover {
+  :global(.tp-arr-chip--active:hover) {
     background: transparent;
     color: var(--color-primary);
   }


### PR DESCRIPTION
## Summary

Hotfix for the visible TechPar Costs-tab regression introduced by PR #209 (BL-042).

**Root cause**: The BL-042 plan asserted "component inherits" the `.tp-arr-chip` / `.tp-arr-quick` / `.tp-arr-chip--active` styles defined in \`src/pages/hub/tools/techpar/index.astro\`'s \`<style>\` block. Wrong — Astro \`<style>\` blocks are scoped by default. The rules carry index.astro's astro-cid hash attribute, so chips rendered from \`<PresetInput>\` (which carries its own component hash) don't match. Result: cost-preset chips on the Costs tab fall back to unstyled \`<button>\`s. ARR chips on the Profile tab are unaffected because they still live inside index.astro and pick up its scoped hash.

**Fix**: wrap the 8 affected selectors in \`:global(...)\`. Class structure unchanged; in-file ARR chips still match.

## Verification

- \`npx astro check\` — 0 / 0 / 0
- \`npm run lint:css\` — clean
- \`npm run test:run\` — 1111 / 1111 passing
- **Manual**: load /hub/tools/techpar on Vercel preview → click any chip in the Costs tab → confirm chip styling matches the ARR chips on the Profile tab. This is the BL-042 M1 live smoke that was deferred to post-deployment.

## Notes

- Followup (not in this PR): the \`.tp-arr-chip\` family is a shared design-system primitive used by both ARR (in-file) and PresetInput (component) consumers. Should eventually move to \`src/styles/components/\` (a new \`preset-chips.css\` or into the existing \`tool-ui.css\`). Hotfix favored minimal blast radius.

## Test plan

- [ ] CI green
- [ ] Vercel preview /hub/tools/techpar — Costs tab chips render with brutalist border/active state matching the Profile-tab ARR chips
- [ ] Toggle infra period monthly↔annual — both chip groups render styled
- [ ] Print preview still hides the chip groups (uses the \`[data-preset-for]\` fallback selector — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)