### PR TITLE
feat(mcp): BL-053 citation array form — multi-bullet claim support (v0.15.0)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -29,6 +29,34 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.15.0 — 2026-06-04 — BL-053 — citation array form on `compose_dossier_envelope` + `validate_irl_provenance` (multi-bullet claim support)
+
+**Theme**: pre-BL-053 the verifier rejected multi-bullet claims as non-substring even when every supporting bullet existed in the IRL — the model's natural citation style joins multiple supporting bullets with semicolons but the substring check then fails the aggregate. The structural false-negative forced the model into bad workarounds: under-attribute (cite only the first bullet), misrepresent provenance (drop to `Section --` partner-supplied sentinel), or accept inflated `unverified` flags. BL-053 closes the gap at the schema layer.
+
+**Surface impact** (minor — additive schema change; backward-compatible):
+
+- **`compose_dossier_envelope.claims[].citation`**: now `string | string[]` (1-8 elements). String form unchanged; array form is verified per-element with strict aggregation.
+- **`validate_irl_provenance.citations[].citation`**: same union shape, same per-element + aggregation behavior. Lets the BL-051 envelope-precheck workflow exercise multi-bullet claims on the fast verifier consistently.
+- **Aggregation rule** (per-claim verdict from per-element verdicts):
+  - ANY element `unverified` → aggregate `unverified` (weakest verdict dominates failure).
+  - ALL elements `partner-supplied` → `partner-supplied`.
+  - ALL elements `verified` verbatim → `verified`.
+  - Mixed `verified` + `partner-supplied` (no fuzzy, no unverified) → `verified`.
+  - Any `verified-fuzzy` in the mix → `verified-fuzzy`.
+- **Tier-discipline preserved**: declared tier-1 + any element fails substring → `tier-mismatch:` auto-append (existing rule, now element-aware). Declared tier-2 + derived fabrication → `tier-fabrication:` (BL-049 v11 Finding B closure, now element-aware).
+- **`(K)` provenance footer rendering**: array-form citations render as `[N citations] elem1 ; elem2 ; …` so partners see at a glance which claims rest on multi-bullet derivations.
+- **`ValidateIrlProvenanceVerdict.citation`**: type widened to `string | string[]` (echoes back the original shape so callers can attribute verdicts to their emitted citation structure unchanged).
+
+**Acceptance criterion**: a v13+ live exercise on a derivation-heavy IRL (TechPar/ICG/Tech Debt verdicts that cite multiple supporting bullets) should see verification rate lift to ≥85% as the model adopts the array form for multi-bullet claims that previously rode the structural false-negative.
+
+**Versioning**: `mcp-server` 0.14.0 → 0.15.0 (minor — additive schema change; existing single-string call sites unchanged). Prompt body NOT bumped — no prompt-body change required to make the array form available, although future prompt-body work could direct the model to prefer the array form for multi-bullet claims. Manifest hash + all body hashes unchanged (no prompt name/version drift).
+
+**Test surface**: 1257 mcp-server tests pass (+16 new BL-053 tests covering aggregation rule cases, schema acceptance/rejection, tier-discipline interaction, mixed-shape calls, and footer rendering).
+
+**Filed under**: BL-053 (`src/docs/development/BACKLOG.md`).
+
+---
+
 ## 0.14.0 — 2026-06-04 — BL-051 — envelope precheck via `validate_irl_provenance` (citation iteration on the fast tool before the heavyweight one)
 
 **Theme**: the v12 StoreForce live exercise empirically established that the `compose_dossier_envelope` tool's input dictation cost (~30KB of claims + gaps + filledIrl + meta JSON) is the workflow throughput bottleneck. When the model iterates citation correctness directly on the envelope, each correction round re-dictates the entire input — minutes per cycle for a per-claim verdict refinement that is fundamentally small. BL-051 redirects the convergence loop to `validate_irl_provenance` (the purpose-built fast verifier — minimal input, per-claim verdict output), then calls the envelope ONCE on the clean set. Net effect: 1 envelope call instead of 2-5, verification rate lifts (each unverified claim got a real correction opportunity), workflow ships minutes faster.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/schemas/compose-dossier-envelope.ts
+++ b/mcp-server/src/schemas/compose-dossier-envelope.ts
@@ -37,6 +37,7 @@ import { z } from 'zod';
 import { CONDITIONAL_TRIGGER_NAMES } from '../prompts/extraction-rules';
 import { ORCHESTRATED_TOOLS } from '../prompts/irl-ingestion';
 import {
+  citationFieldSchema,
   runIrlProvenanceCheck,
   type ValidateIrlProvenanceVerdict,
 } from './validate-irl-provenance';
@@ -132,12 +133,14 @@ const claimSchema = z.object({
     .describe(
       'Short prose label of the load-bearing claim (e.g., "NRR 106%", "TechPar 46.8% above zone", "Tech Debt carrying cost $2.85M CAD/yr").'
     ),
-  citation: z
-    .string()
-    .min(1)
-    .describe(
-      'IRL citation backing the claim, in the BL-045 audit shape: "Section NN row M — <excerpt>" or, for partner-supplied (non-IRL) inputs, "Section -- — partner-supplied form input — <description>".'
-    ),
+  // BL-053: citation accepts EITHER a string (legacy single-bullet form) OR
+  // an array of strings (1-8 elements) for multi-bullet claims. Array form is
+  // verified per-element with strict aggregation (any unverified element →
+  // aggregate unverified). Closes the structural false-negative for
+  // derivation-heavy syntheses where the model's natural citation style
+  // joins multiple supporting bullets — pre-BL-053 the verifier rejected
+  // these as non-substring even though every supporting bullet existed.
+  citation: citationFieldSchema,
   tier: z
     .enum(tierValues)
     .describe(
@@ -361,6 +364,15 @@ export function renderGapList(gaps: ComposeDossierEnvelopeInput['gaps']): string
   return lines.join('\n');
 }
 
+// BL-053: render a citation field that may be string OR string[] for the
+// (K) provenance footer. Array form is rendered as semicolon-joined elements
+// with an explicit element count prefix so partners reading the dossier can
+// see at a glance which claims rest on multi-bullet derivations.
+function renderCitationField(citation: string | string[]): string {
+  if (typeof citation === 'string') return citation;
+  return `[${citation.length} citations] ${citation.join(' ; ')}`;
+}
+
 export function renderProvenanceFooter(
   claims: ComposeDossierEnvelopeInput['claims'],
   verdicts: ValidateIrlProvenanceVerdict[]
@@ -377,7 +389,9 @@ export function renderProvenanceFooter(
           : v.status === 'partner-supplied'
             ? '◇ partner-supplied'
             : '✗ unverified';
-    lines.push(`- ${c.claim} ← ${c.citation} (tier ${c.tier}) [${verdictTag}]`);
+    lines.push(
+      `- ${c.claim} ← ${renderCitationField(c.citation)} (tier ${c.tier}) [${verdictTag}]`
+    );
   }
   return lines.join('\n');
 }

--- a/mcp-server/src/schemas/validate-irl-provenance.ts
+++ b/mcp-server/src/schemas/validate-irl-provenance.ts
@@ -40,6 +40,17 @@ import { z } from 'zod';
 
 // ─── Schema ─────────────────────────────────────────────────────────────
 
+// BL-053: citation accepts EITHER a single string (the historical shape) OR
+// an array of citation strings for multi-bullet claims. Array elements are
+// verified per-element; the verdict is aggregated. Cap at 8 elements — beyond
+// that the citation is doing the work of a section reference and should be
+// re-shaped.
+const citationFieldSchema = z
+  .union([z.string().min(1), z.array(z.string().min(1)).min(1).max(8)])
+  .describe(
+    'The citation backing the claim. EITHER a single citation string ("Section NN — <excerpt>" or "Section -- — partner-supplied form input — <description>") OR an array of citation strings (1-8 elements) when the claim genuinely derives from multiple supporting IRL bullets. When an array, the verifier checks each element independently and aggregates: any element unverified → aggregate unverified; all elements verified verbatim → verified; mixed verified + verified-fuzzy → verified-fuzzy; all partner-supplied → partner-supplied. Use the array form for multi-bullet syntheses (TechPar verdicts citing eng count + hosting + salary; comparables joining portfolio rows; derivations spanning Section 04 + 07).'
+  );
+
 const citationEntrySchema = z.object({
   path: z
     .string()
@@ -47,13 +58,10 @@ const citationEntrySchema = z.object({
     .describe(
       'Dot-path identifying the citation site in the dossier or _audit payload, e.g., "_audit.revenueRange.citation" or "section-C.headline". The tool echoes this back in the verdict so the model can attribute each verdict to the right claim.'
     ),
-  citation: z
-    .string()
-    .min(1)
-    .describe(
-      'The citation string the model emitted. Form: "Section NN — <excerpt>" or "Section -- — partner-supplied form input — <description>".'
-    ),
+  citation: citationFieldSchema,
 });
+
+export { citationFieldSchema };
 
 export const ValidateIrlProvenanceInputSchema = z.object({
   filledIrl: z
@@ -74,7 +82,8 @@ export type ValidateIrlProvenanceInput = z.infer<typeof ValidateIrlProvenanceInp
 
 export interface ValidateIrlProvenanceVerdict {
   path: string;
-  citation: string;
+  /** Echoes back the original citation shape — string for legacy single-bullet form, array for BL-053 multi-bullet form. */
+  citation: string | string[];
   status: 'verified' | 'verified-fuzzy' | 'partner-supplied' | 'unverified';
   matchedSpan?: string;
 }
@@ -202,9 +211,90 @@ function longestContiguousRun(needleWords: string[], haystackWords: string[]): n
 export const FUZZY_MIN_RUN = 8;
 
 /**
+ * Verify a single citation string against the normalized IRL.
+ * Extracted from `runIrlProvenanceCheck` so the BL-053 array-form
+ * aggregator can reuse the same logic per-element.
+ */
+type ElementStatus = 'verified' | 'verified-fuzzy' | 'partner-supplied' | 'unverified';
+
+function verifyCitationString(
+  citation: string,
+  haystackNorm: string,
+  haystackWords: string[]
+): { status: ElementStatus; matchedSpan?: string } {
+  if (isPartnerSupplied(citation)) {
+    return { status: 'partner-supplied' };
+  }
+  const excerpt = extractExcerpt(citation);
+  const excerptNorm = normalizeForMatching(excerpt);
+  if (excerptNorm.length === 0) {
+    return { status: 'unverified' };
+  }
+  if (haystackNorm.includes(excerptNorm)) {
+    return { status: 'verified', matchedSpan: excerptNorm };
+  }
+  const excerptWords = excerptNorm.split(' ').filter((w) => w.length > 0);
+  const runLen = longestContiguousRun(excerptWords, haystackWords);
+  if (runLen >= FUZZY_MIN_RUN) {
+    return {
+      status: 'verified-fuzzy',
+      matchedSpan: `<run of ${runLen} consecutive words matched>`,
+    };
+  }
+  return { status: 'unverified' };
+}
+
+/**
+ * BL-053 aggregation rule for array-form citations. Applied when an
+ * entry's `citation` is an array of strings (multi-bullet claim).
+ *
+ *   - ANY element unverified  → aggregate `unverified` (weakest verdict
+ *     dominates failure — the claim has unsupported provenance).
+ *   - ALL elements partner-supplied → `partner-supplied`.
+ *   - ALL elements verified verbatim → `verified`.
+ *   - Mixed verified + partner-supplied (no fuzzy, no unverified) → `verified`.
+ *   - Any verified-fuzzy in the mix → `verified-fuzzy` (fuzzy taints
+ *     the aggregate down to fuzzy verification).
+ *
+ * Rationale: a claim genuinely supported by multiple IRL bullets should
+ * verify only when EVERY supporting bullet is anchored. Allowing
+ * partner-supplied to mask unverified would invert the incentive.
+ */
+function aggregateArrayVerdict(
+  elementStatuses: ElementStatus[],
+  elementSpans: (string | undefined)[]
+): { status: ElementStatus; matchedSpan?: string } {
+  if (elementStatuses.some((s) => s === 'unverified')) {
+    return { status: 'unverified' };
+  }
+  const allPartner = elementStatuses.every((s) => s === 'partner-supplied');
+  if (allPartner) {
+    return { status: 'partner-supplied' };
+  }
+  const anyFuzzy = elementStatuses.some((s) => s === 'verified-fuzzy');
+  if (anyFuzzy) {
+    return {
+      status: 'verified-fuzzy',
+      matchedSpan: `<${elementStatuses.length}-element citation array, includes fuzzy>`,
+    };
+  }
+  const firstSpan = elementSpans.find((s) => s !== undefined);
+  return {
+    status: 'verified',
+    matchedSpan: `<${elementStatuses.length}-element citation array, all verified${firstSpan ? `, first: ${firstSpan}` : ''}>`,
+  };
+}
+
+/**
  * Run the provenance verification engine over an input payload.
  * Pure function — no I/O, no global state. Suitable for unit testing
  * the matching logic in isolation from the MCP transport.
+ *
+ * BL-053: when `entry.citation` is an array, each element is verified
+ * independently with `verifyCitationString` and aggregated with
+ * `aggregateArrayVerdict`. The per-entry verdict echoes back the
+ * original citation shape (string or array) so the model can attribute
+ * verdicts to its emitted citation structure unchanged.
  */
 export function runIrlProvenanceCheck(
   input: ValidateIrlProvenanceInput
@@ -219,42 +309,38 @@ export function runIrlProvenanceCheck(
   let unverified = 0;
 
   for (const entry of input.citations) {
-    if (isPartnerSupplied(entry.citation)) {
-      verdicts.push({ path: entry.path, citation: entry.citation, status: 'partner-supplied' });
-      partnerSupplied++;
-      continue;
+    let aggregate: { status: ElementStatus; matchedSpan?: string };
+    if (typeof entry.citation === 'string') {
+      aggregate = verifyCitationString(entry.citation, haystackNorm, haystackWords);
+    } else {
+      const elementResults = entry.citation.map((c) =>
+        verifyCitationString(c, haystackNorm, haystackWords)
+      );
+      aggregate = aggregateArrayVerdict(
+        elementResults.map((r) => r.status),
+        elementResults.map((r) => r.matchedSpan)
+      );
     }
-    const excerpt = extractExcerpt(entry.citation);
-    const excerptNorm = normalizeForMatching(excerpt);
-    if (excerptNorm.length === 0) {
-      verdicts.push({ path: entry.path, citation: entry.citation, status: 'unverified' });
-      unverified++;
-      continue;
+    verdicts.push({
+      path: entry.path,
+      citation: entry.citation,
+      status: aggregate.status,
+      ...(aggregate.matchedSpan ? { matchedSpan: aggregate.matchedSpan } : {}),
+    });
+    switch (aggregate.status) {
+      case 'verified':
+        verified++;
+        break;
+      case 'verified-fuzzy':
+        verifiedFuzzy++;
+        break;
+      case 'partner-supplied':
+        partnerSupplied++;
+        break;
+      case 'unverified':
+        unverified++;
+        break;
     }
-    if (haystackNorm.includes(excerptNorm)) {
-      verdicts.push({
-        path: entry.path,
-        citation: entry.citation,
-        status: 'verified',
-        matchedSpan: excerptNorm,
-      });
-      verified++;
-      continue;
-    }
-    const excerptWords = excerptNorm.split(' ').filter((w) => w.length > 0);
-    const runLen = longestContiguousRun(excerptWords, haystackWords);
-    if (runLen >= FUZZY_MIN_RUN) {
-      verdicts.push({
-        path: entry.path,
-        citation: entry.citation,
-        status: 'verified-fuzzy',
-        matchedSpan: `<run of ${runLen} consecutive words matched>`,
-      });
-      verifiedFuzzy++;
-      continue;
-    }
-    verdicts.push({ path: entry.path, citation: entry.citation, status: 'unverified' });
-    unverified++;
   }
 
   return {

--- a/mcp-server/tests/unit/schemas/compose-dossier-envelope.test.ts
+++ b/mcp-server/tests/unit/schemas/compose-dossier-envelope.test.ts
@@ -441,3 +441,152 @@ describe('ComposeDossierEnvelopeInputSchema — promptVersion handling', () => {
     expect(result.metaFenceMarkdown).not.toContain('99.99.99');
   });
 });
+
+// ─── BL-053 — citation array form (multi-bullet claim support) ──────────
+
+describe('compose_dossier_envelope — BL-053 citation array form', () => {
+  it('accepts a claim with citation as array of strings', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'TechPar paradigm: high R&D efficiency given FTE/ARR ratio',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 02 — Engineering FTE count: 58 total',
+        ],
+        tier: '2',
+      },
+    ];
+    const parsed = ComposeDossierEnvelopeInputSchema.safeParse(input);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an empty citation array', () => {
+    const input = baseInput();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (input.claims[0] as any).citation = [];
+    const parsed = ComposeDossierEnvelopeInputSchema.safeParse(input);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an over-length citation array (>8 elements)', () => {
+    const input = baseInput();
+    input.claims[0].citation = Array(9).fill('Section 00 — Annual recurring revenue: $45.2M');
+    const parsed = ComposeDossierEnvelopeInputSchema.safeParse(input);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('verifies multi-bullet claim as verified when ALL elements are verbatim IRL substrings', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Multi-bullet derivation',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 02 — Engineering FTE count: 58 total',
+        ],
+        tier: '2',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceVerification.verified).toBe(1);
+    expect(result.provenanceVerification.unverified).toBe(0);
+    expect(result.provenanceVerification.autoAppendedGaps).toBe(0);
+  });
+
+  it('verifies multi-bullet claim as unverified when ANY element is unverified (weakest wins)', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Derivation with one fabricated element',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 99 — Fabricated $999M ARR never tracked',
+        ],
+        tier: '2',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceVerification.unverified).toBe(1);
+    expect(result.provenanceVerification.verified).toBe(0);
+    // declared tier-2 + all elements derive as fabrication? No — one element
+    // verified, so the derived aggregate is unverified BUT not 'fabrication'
+    // (the deriveTier check looks at status, and unverified → fabrication).
+    // The auto-append rule for declared tier-2 + derived fabrication fires.
+    expect(result.provenanceVerification.tierFabrications).toBe(1);
+  });
+
+  it('renders array-form citation in (K) provenance footer with element count', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Multi-bullet derivation',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 02 — Engineering FTE count: 58 total',
+        ],
+        tier: '2',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceFooterMarkdown).toMatch(/\[2 citations\]/);
+    expect(result.provenanceFooterMarkdown).toContain('Annual recurring revenue: $45.2M');
+    expect(result.provenanceFooterMarkdown).toContain('Engineering FTE count: 58 total');
+  });
+
+  it('mixes single-string and array-form claims in the same call', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Single-citation claim (legacy shape)',
+        citation: 'Section 00 — Annual recurring revenue: $45.2M',
+        tier: '1',
+      },
+      {
+        claim: 'Multi-bullet derivation (BL-053 shape)',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 02 — Engineering FTE count: 58 total',
+        ],
+        tier: '2',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceVerification.verified).toBe(2);
+    expect(result.provenanceVerification.unverified).toBe(0);
+  });
+
+  it('verifies tier-1-declared array claim cleanly when all elements verify (no tier-mismatch)', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Tier-1 multi-bullet quote',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 02 — Engineering FTE count: 58 total',
+        ],
+        tier: '1',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceVerification.tierMismatches).toBe(0);
+    expect(result.provenanceVerification.verified).toBe(1);
+  });
+
+  it('flags tier-1-declared array claim as tier-mismatch when any element fails', () => {
+    const input = baseInput();
+    input.claims = [
+      {
+        claim: 'Tier-1 multi-bullet with fabricated element',
+        citation: [
+          'Section 00 — Annual recurring revenue: $45.2M',
+          'Section 99 — Fabricated row never in the IRL',
+        ],
+        tier: '1',
+      },
+    ];
+    const result = runComposeDossierEnvelope(input, SERVER_CTX);
+    expect(result.provenanceVerification.tierMismatches).toBe(1);
+    expect(result.gapListMarkdown).toMatch(/tier-mismatch/);
+  });
+});

--- a/mcp-server/tests/unit/schemas/validate-irl-provenance.test.ts
+++ b/mcp-server/tests/unit/schemas/validate-irl-provenance.test.ts
@@ -261,3 +261,142 @@ describe('runIrlProvenanceCheck — aggregate counts', () => {
     expect(result.verdicts.map((v) => v.path)).toEqual(['a', 'b', 'c']);
   });
 });
+
+// ─── BL-053 — citation array form (multi-bullet claim support) ──────────
+//
+// Each test pairs an array-form citation with the expected aggregate
+// verdict per the BL-053 aggregation rule:
+//
+//   - ANY element unverified → aggregate unverified.
+//   - ALL partner-supplied → partner-supplied.
+//   - ALL verified verbatim → verified.
+//   - Mixed verified + partner-supplied (no fuzzy, no unverified) → verified.
+//   - Any verified-fuzzy in the mix → verified-fuzzy.
+//
+// Verdict echoes back the array shape unchanged so callers can attribute
+// the verdict to their emitted citation structure.
+
+describe('runIrlProvenanceCheck — BL-053 array-form citations', () => {
+  it('aggregates ALL-verified array as verified', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        {
+          path: 'techpar-paradigm',
+          citation: [
+            'Section 02 — Engineering FTE count: 58 total',
+            'Section 00 — Annual recurring revenue: $45.2M Q1-FY26 annualized',
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].status).toBe('verified');
+    expect(result.verified).toBe(1);
+    expect(Array.isArray(result.verdicts[0].citation)).toBe(true);
+    expect((result.verdicts[0].citation as string[]).length).toBe(2);
+  });
+
+  it('aggregates ANY-unverified array as unverified (weakest verdict dominates)', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        {
+          path: 'mixed',
+          citation: [
+            'Section 02 — Engineering FTE count: 58 total', // verified
+            'Section 00 — Fabricated $999M ARR that does not appear anywhere', // unverified
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].status).toBe('unverified');
+    expect(result.unverified).toBe(1);
+  });
+
+  it('aggregates ALL-partner-supplied array as partner-supplied', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        {
+          path: 'kickoff-form',
+          citation: [
+            'Section -- — partner-supplied form input — engagement code name',
+            'Section -- — partner-supplied form input — partner lead name',
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].status).toBe('partner-supplied');
+    expect(result.partnerSupplied).toBe(1);
+  });
+
+  it('treats verified + partner-supplied mix as verified (partner-supplied does not taint)', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        {
+          path: 'verdict-with-form-input',
+          citation: [
+            'Section 02 — Engineering FTE count: 58 total',
+            'Section -- — partner-supplied form input — TechPar exit multiple assumption',
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].status).toBe('verified');
+    expect(result.verified).toBe(1);
+  });
+
+  it('downgrades to verified-fuzzy when any element verifies fuzzily', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      // First element is a verbatim substring; second is paraphrased with
+      // foreign trailing words so it's NOT a substring but has a contiguous
+      // ≥FUZZY_MIN_RUN-word run with the IRL — the (b) fuzzy verdict.
+      // Uses the same fuzzy pattern shape as the existing single-citation
+      // fuzzy test above (Eng squad breakdown line).
+      citations: [
+        {
+          path: 'verified-plus-fuzzy',
+          citation: [
+            'Section 02 — Engineering FTE count: 58 total',
+            'Section 02 — Eng squad breakdown listed as 38 product 8 SRE 3 security 7 data 2 platform across the company',
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].status).toBe('verified-fuzzy');
+    expect(result.verifiedFuzzy).toBe(1);
+  });
+
+  it('echoes the original array shape back in the verdict (string vs array)', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        { path: 'single', citation: 'Section 02 — Engineering FTE count: 58 total' },
+        {
+          path: 'multi',
+          citation: ['Section 02 — Engineering FTE count: 58 total'],
+        },
+      ],
+    });
+    expect(typeof result.verdicts[0].citation).toBe('string');
+    expect(Array.isArray(result.verdicts[1].citation)).toBe(true);
+  });
+
+  it('reports matchedSpan indicating multi-element aggregation', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: [
+        {
+          path: 'multi',
+          citation: [
+            'Section 02 — Engineering FTE count: 58 total',
+            'Section 00 — Annual recurring revenue: $45.2M Q1-FY26 annualized',
+          ],
+        },
+      ],
+    });
+    expect(result.verdicts[0].matchedSpan).toMatch(/2-element citation array/);
+  });
+});


### PR DESCRIPTION
## Status

**✅ Ready for review.** Single-commit additive schema change to `compose_dossier_envelope` + `validate_irl_provenance`. Backward-compatible — every existing single-string call site continues to work unchanged. 1257 mcp-server tests pass (+16 new BL-053 cases); 1111 root tests pass; lint + astro-check clean.

## TL;DR

Pre-BL-053 the verifier rejected multi-bullet claims as non-substring even when every supporting bullet existed in the IRL. The model's natural citation style for derivation-heavy claims (TechPar verdicts citing eng count + hosting + salary; comparables joining portfolio rows; syntheses spanning Section 04 + 07) joins multiple supporting bullets with semicolons — but the substring check then fails the aggregate. The structural false-negative forced bad workarounds: under-attribute, misrepresent provenance with the `Section --` partner-supplied sentinel, or accept inflated `unverified` flags.

BL-053 closes the gap at the schema layer by accepting `citation: string | string[]` on both tools. Array elements are verified per-element with strict aggregation.

## What changed

**Additive schema change only — no prompt-body change, no manifest hash drift.**

- `compose_dossier_envelope.claims[].citation`: now `z.union([z.string(), z.array(z.string()).min(1).max(8)])`. Single-string form unchanged.
- `validate_irl_provenance.citations[].citation`: same union shape. Lets the BL-051 envelope-precheck workflow exercise multi-bullet claims on the fast verifier consistently.
- `ValidateIrlProvenanceVerdict.citation`: type widened to `string | string[]` (echoes back the original shape so callers attribute verdicts unchanged).
- `(K)` provenance footer renders array-form as `[N citations] elem1 ; elem2 ; …`.

## Aggregation rule

Per-element verdicts collapse to a per-claim verdict via:

- ANY element `unverified` → aggregate `unverified` (weakest verdict dominates failure — incentive-preserving)
- ALL elements `partner-supplied` → `partner-supplied`
- ALL elements `verified` verbatim → `verified`
- Mixed `verified` + `partner-supplied` (no fuzzy, no unverified) → `verified`
- Any `verified-fuzzy` in the mix → `verified-fuzzy`

Tier-discipline preserved end-to-end: declared tier-1 + any element fails substring → `tier-mismatch:` auto-append. Declared tier-2 + aggregate `unverified` (all elements fabricated) → `tier-fabrication:` (BL-049 v11 Finding B closure, now element-aware).

## Acceptance criterion

A v13+ live exercise on a derivation-heavy IRL (TechPar/ICG/Tech Debt verdicts citing multiple supporting bullets) should see verification rate lift to ≥85% as the model adopts the array form for multi-bullet claims that previously rode the structural false-negative.

## Test surface

**+16 new BL-053 cases** across the two schema test files, covering:

- Aggregation rule (all-verified, any-unverified, all-partner-supplied, mixed shapes, fuzzy-taints)
- Schema acceptance (valid array forms) and rejection (empty array, >8 elements)
- Tier-discipline interaction (tier-1 + array → tier-mismatch when element fails; tier-2 + array → tier-fabrication when aggregate fabricated)
- Mixed single-string + array-form claims in the same call
- `(K)` footer rendering with element count prefix
- Verdict echoes back the original shape (`string` vs `array`)

## Versioning + hashes

- `mcp-server`: 0.14.0 → **0.15.0** (minor — additive schema change; backward-compatible)
- Prompt body NOT bumped (no body change required to enable array form; future prompt-body work could direct the model to prefer the array form for multi-bullet claims)
- Manifest hash + all body hashes UNCHANGED (no prompt name/version drift)

## Test plan

- [x] 1257 mcp-server tests pass (+16 BL-053 cases)
- [x] 1111 root tests pass
- [x] `npx astro check && npm run lint` — 0 errors
- [x] `mcp-server/dist/index.js` rebuilt at v0.15.0
- [ ] **Reviewer sign-off**
- [ ] (Post-merge) v13+ live exercise validates the ≥85% verification rate criterion on a derivation-heavy IRL

## Reviewer focus areas

1. **Aggregation rule correctness**: that `ANY unverified → unverified` is the right call (vs. allowing partner-supplied to mask one unverified element). Rationale documented in `aggregateArrayVerdict` — preserves the incentive against citation laundering.
2. **Tier-discipline preservation**: the existing `tier-mismatch` and `tier-fabrication` auto-append paths still fire correctly when array-form claims aggregate to `unverified`. Covered by two dedicated tests.
3. **Backward compatibility**: existing single-string call sites and tests pass unchanged. Confirmed by all 1241 pre-BL-053 tests still green.

## Commits in this PR (1)

```
7d2e681 feat(mcp): BL-053 citation array form — multi-bullet claim support on compose_dossier_envelope + validate_irl_provenance (v0.15.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)