### PR TITLE
fix(mcp): BL-077b surface Upstash error in CacheStore.set (v0.30.2)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -29,6 +29,35 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.30.2 — 2026-06-07 — BL-077b surface Upstash error in `CacheStore.set`
+
+**Theme**: continuation of BL-077a diagnostic chain. BL-077a's `bl077.cache.set` event on staging confirmed `outcome: write-returned-false` at a 64KB body — the underlying Upstash write was failing — but the actual Upstash error was being swallowed inside `CacheStore.set`'s `catch {}` block. Pre-BL-077b, we could see WHICH layer was failing but not WHY. This patch adds one `safeLog` line inside the catch so `wrangler tail` captures the actual Upstash error message in the next exercise.
+
+**Surface impact**:
+
+- **NEW** `upstash.set.failed` `safeLog` event emitted at [`mcp-server/src/lib/upstash-cache-store.ts`] whenever `redis.set` throws. Carries: `key` (the Upstash key being written), `byteLength` (size of the JSON-stringified `{storedAt, data}` envelope — the actual byte count Upstash received), `ttlSeconds`, `reason` (truncated to 300 chars), `errorCode: 'upstash-set-threw'`.
+- **No public contract change.** No prompt-body change, no schema change, no manifest hash drift, no body hash rebaseline.
+- **Affects ALL callers of `createCacheStore`**, not just BL-076's `UpstashIrlBodyCache`. Other consumers (`resource-cache.ts`, etc.) also gain the visibility — backward-compatible at the contract level since the behavior on failure is still "return false."
+
+**Acceptance** (in-session):
+
+- 5 new unit tests at [`tests/unit/lib/upstash-cache-store-error-logging.test.ts`]: success path does NOT emit the failure event; throw path returns false AND emits with the actual error message; reason is truncated to 300 chars; non-Error throw values are handled; byte-length field is the JSON-wrapped envelope size (not just the raw value).
+- 1460 mcp-server tests green; tsc clean.
+
+**Operator follow-up**:
+
+1. Deploy 0.30.2 to staging.
+2. Operator re-runs the same `gst_irl_ingestion` exercise that produced the BL-077a `outcome: write-returned-false` event with `wrangler tail` active.
+3. The new `upstash.set.failed` event appears with the actual Upstash error in `reason`. Three most-likely:
+   - `REQUEST_TOO_LARGE` / `PAYLOAD_TOO_LARGE` → 64KB body wrapped in `{storedAt, data: <JSON-escaped body>}` exceeds Upstash REST request size limit. BL-077c fix: bypass the envelope for IRL body cache, OR compress the body before storing.
+   - `MAX_DAILY_REQUEST_SIZE_LIMIT_EXCEEDED` / quota error → staging Upstash plan quota hit. BL-077c fix: bump plan or rotate to a separate DB.
+   - `WRONGTYPE` / `NOAUTH` / network error → auth / config issue. BL-077c fix: rotate token or check binding.
+4. Paste the `upstash.set.failed` event back; file BL-077c with the targeted root-cause fix.
+
+**Risks**: low. One extra `safeLog` call per failed Upstash write; no behavior change on the success path. Existing log volume on staging is bounded since failed writes are the exception, not the rule.
+
+---
+
 ## 0.30.1 — 2026-06-07 — BL-077a `UpstashIrlBodyCache` fail-loud + diagnostic instrumentation
 
 **Theme**: post-BL-076 staging incident — three back-to-back `prepare_irl_body` → `compose_dossier_envelope` pairs all surfaced `Bl076BodyCacheMissError` on compose despite prepare returning the correct deterministic hash each time. Underlying `CacheStore.set` swallows Upstash write failures and returns `false`; pre-BL-077a, `UpstashIrlBodyCache.set` ignored the return value, so failed writes silently surfaced as confusing downstream cache misses. **No public contract change** — this is a patch release that converts the silent failure into an actionable structured error AT the moment of failure + emits diagnostic `safeLog` events that `wrangler tail` captures for root-cause analysis (see BL-077b follow-up for the actual fix once diagnosis lands).

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/lib/upstash-cache-store.ts
+++ b/mcp-server/src/lib/upstash-cache-store.ts
@@ -16,6 +16,7 @@
  * `inoreader-token-store.ts` against the Inoreader DB's Read-Only client.
  */
 
+import { safeLog } from '../auth/safe-logger';
 import { createMcpClient } from './upstash-clients';
 import type { Env } from '../worker';
 
@@ -62,11 +63,32 @@ export function createCacheStore(env: Env): CacheStore | null {
     },
 
     async set<T>(key: string, value: T, ttlSeconds: number): Promise<boolean> {
+      let serializedByteLength: number | undefined;
       try {
         const entry: Entry<T> = { storedAt: Date.now(), data: value };
-        await redis.set(key, JSON.stringify(entry), { ex: ttlSeconds });
+        const serialized = JSON.stringify(entry);
+        serializedByteLength = Buffer.byteLength(serialized, 'utf8');
+        await redis.set(key, serialized, { ex: ttlSeconds });
         return true;
-      } catch {
+      } catch (err) {
+        // BL-077b — surface the Upstash error before swallowing.
+        // Pre-BL-077b, this catch silently returned `false`, hiding the
+        // actual failure mode (size limit, quota, auth, network).
+        // BL-077a's read-after-write probe (on `UpstashIrlBodyCache`)
+        // catches the symptom; this logs the cause exactly once at the
+        // substrate level so `wrangler tail` operators can see which
+        // Upstash failure is firing. The `reason` field is truncated to
+        // 300 chars to keep log lines bounded — sufficient for the typical
+        // Upstash error envelope (`{"error":"..."}` or HTTP status text).
+        safeLog({
+          event: 'upstash.set.failed',
+          key,
+          byteLength: serializedByteLength,
+          ttlSeconds,
+          reason: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300),
+          success: false,
+          errorCode: 'upstash-set-threw',
+        });
         return false;
       }
     },

--- a/mcp-server/tests/unit/lib/upstash-cache-store-error-logging.test.ts
+++ b/mcp-server/tests/unit/lib/upstash-cache-store-error-logging.test.ts
@@ -1,0 +1,127 @@
+/**
+ * BL-077b — upstash-cache-store error-logging tests.
+ *
+ * Pre-BL-077b, `CacheStore.set`'s `catch` swallowed the Upstash error
+ * silently and returned `false`. Operators saw the downstream symptom
+ * (`Bl076BodyCacheMissError` or cache miss) but not the cause (size limit,
+ * quota, auth, network). This patch adds one `safeLog` line inside the
+ * catch so `wrangler tail` captures the actual Upstash error message.
+ *
+ * Asserts:
+ *   - Successful `set` does NOT emit the failure event.
+ *   - When `redis.set` throws, `CacheStore.set` returns `false` AND emits
+ *     a `upstash.set.failed` event with the truncated reason + key +
+ *     serialized byte length + ttl.
+ *   - Error reason is truncated to 300 chars to keep log lines bounded.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockSafeLog, mockRedisSet, createMcpClientMock } = vi.hoisted(() => ({
+  mockSafeLog: vi.fn(),
+  mockRedisSet: vi.fn(),
+  createMcpClientMock: vi.fn(),
+}));
+
+vi.mock('../../../src/auth/safe-logger', () => ({
+  safeLog: mockSafeLog,
+}));
+
+vi.mock('../../../src/lib/upstash-clients', () => ({
+  createMcpClient: createMcpClientMock,
+}));
+
+import { createCacheStore } from '../../../src/lib/upstash-cache-store';
+import type { Env } from '../../../src/worker';
+
+const env: Env = {
+  UPSTASH_MCP_REST_URL: 'https://mcp.upstash.io',
+  UPSTASH_MCP_REST_TOKEN: 'token',
+};
+
+beforeEach(() => {
+  mockSafeLog.mockReset();
+  mockRedisSet.mockReset();
+  createMcpClientMock.mockReset();
+  createMcpClientMock.mockReturnValue({
+    get: vi.fn(),
+    set: mockRedisSet,
+    del: vi.fn(),
+  });
+});
+
+describe('CacheStore.set — BL-077b error logging', () => {
+  it('on successful set, does NOT emit upstash.set.failed', async () => {
+    mockRedisSet.mockResolvedValue('OK');
+    const store = createCacheStore(env);
+    expect(store).not.toBeNull();
+    const ok = await store!.set('gst-mcp:test:k1', 'body', 3600);
+    expect(ok).toBe(true);
+    const failureEvents = mockSafeLog.mock.calls.filter(
+      (c) => (c[0] as { event?: string }).event === 'upstash.set.failed'
+    );
+    expect(failureEvents).toHaveLength(0);
+  });
+
+  it('on redis.set throwing, returns false AND emits upstash.set.failed with the truncated reason', async () => {
+    const upstashErr = new Error('REQUEST_TOO_LARGE: payload exceeds 32 KiB');
+    mockRedisSet.mockRejectedValue(upstashErr);
+    const store = createCacheStore(env);
+    const ok = await store!.set('gst-mcp:irl-body:abc123', 'a-body', 14400);
+    expect(ok).toBe(false);
+    const failureEvents = mockSafeLog.mock.calls.filter(
+      (c) => (c[0] as { event?: string }).event === 'upstash.set.failed'
+    );
+    expect(failureEvents).toHaveLength(1);
+    const ev = failureEvents[0][0] as {
+      key: string;
+      byteLength: number;
+      ttlSeconds: number;
+      reason: string;
+      success: boolean;
+      errorCode: string;
+    };
+    expect(ev.key).toBe('gst-mcp:irl-body:abc123');
+    expect(ev.byteLength).toBeGreaterThan(0); // the JSON-wrapped envelope size
+    expect(ev.ttlSeconds).toBe(14400);
+    expect(ev.reason).toContain('REQUEST_TOO_LARGE');
+    expect(ev.success).toBe(false);
+    expect(ev.errorCode).toBe('upstash-set-threw');
+  });
+
+  it('truncates the reason to 300 characters', async () => {
+    const longMsg = 'x'.repeat(1000);
+    mockRedisSet.mockRejectedValue(new Error(longMsg));
+    const store = createCacheStore(env);
+    await store!.set('k', 'v', 60);
+    const ev = mockSafeLog.mock.calls
+      .map((c) => c[0] as { event?: string; reason?: string })
+      .find((e) => e.event === 'upstash.set.failed');
+    expect(ev?.reason).toBeDefined();
+    expect(ev!.reason!.length).toBe(300);
+  });
+
+  it('handles non-Error throw values gracefully (still logs, still returns false)', async () => {
+    mockRedisSet.mockRejectedValue('plain string error');
+    const store = createCacheStore(env);
+    const ok = await store!.set('k', 'v', 60);
+    expect(ok).toBe(false);
+    const ev = mockSafeLog.mock.calls
+      .map((c) => c[0] as { event?: string; reason?: string })
+      .find((e) => e.event === 'upstash.set.failed');
+    expect(ev?.reason).toContain('plain string error');
+  });
+
+  it('byteLength field reflects the JSON-stringified envelope size (BL-077b diagnostic for size-limit triage)', async () => {
+    mockRedisSet.mockRejectedValue(new Error('boom'));
+    const store = createCacheStore(env);
+    const body = 'x'.repeat(1000); // 1KB body
+    await store!.set('k', body, 60);
+    const ev = mockSafeLog.mock.calls
+      .map((c) => c[0] as { event?: string; byteLength?: number })
+      .find((e) => e.event === 'upstash.set.failed');
+    // JSON-wrapped: {"storedAt":<ts>,"data":"xxx..."} adds overhead; total > 1000 + envelope.
+    expect(ev?.byteLength).toBeGreaterThan(1000);
+    expect(ev?.byteLength).toBeLessThan(1500); // sanity ceiling
+  });
+});

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -3880,6 +3880,29 @@ The bug is operator-visible (block carries the fabricated list) but not partner-
 
 ---
 
+### BL-077b: Surface Upstash error in `CacheStore.set` ✅ CLOSED 2026-06-07 (shipped at mcp-server 0.30.2)
+
+**Problem**: BL-077a's `bl077.cache.set` event on staging (1 hour after 0.30.1 deploy) confirmed `outcome: write-returned-false` at a 64054-byte body — Upstash KV write was failing — but the actual Upstash error message was being swallowed inside `CacheStore.set`'s `catch {}` block. We knew WHICH layer was failing but not WHY.
+
+**Scope**: one-line patch to [`mcp-server/src/lib/upstash-cache-store.ts`] — add `safeLog({ event: 'upstash.set.failed', ... })` inside the existing `catch` block before returning `false`. Carries: key, JSON-stringified envelope byte length, TTL, truncated error reason, errorCode. Affects ALL callers of `createCacheStore` (resource cache, BL-076 body cache, etc.) — backward-compatible at the contract level since the behavior on failure is still "return false."
+
+**Surface impact**: `mcp-server` 0.30.1 → 0.30.2 (patch). No public contract change. No prompt-body change, no schema change, no manifest hash drift.
+
+**Acceptance** (in-session):
+
+- 5 new unit tests covering success-path-no-log, throw-path-emits-with-reason, 300-char-truncation, non-Error-throw-values, byte-length-reflects-envelope-size.
+- 1460 mcp-server tests green; tsc clean.
+
+**Operator follow-up**: deploy 0.30.2 to staging; re-run the same `gst_irl_ingestion` exercise with `wrangler tail` active. The new `upstash.set.failed` event will appear with the actual Upstash error in `reason`. Likely candidates:
+
+- `REQUEST_TOO_LARGE` / `PAYLOAD_TOO_LARGE` → 64KB body wrapped in `{storedAt, data: <JSON-escaped body>}` exceeds Upstash REST size limit. BL-077c: bypass envelope for IRL body cache OR compress before store.
+- Quota / rate limit → bump plan or rotate to separate DB.
+- Auth / network → config issue, rotate token or check binding.
+
+**Related**: BL-077a (the cache-layer fail-loud + symptom logging this patch extends to the substrate layer), BL-076 (the body-by-hash mechanism this instruments), BL-077c (reserved — the targeted root-cause fix, scoped after this exercise's tail output).
+
+---
+
 ### BL-077a: `UpstashIrlBodyCache` fail-loud + diagnostic instrumentation ✅ CLOSED 2026-06-07 (shipped at mcp-server 0.30.1)
 
 **Problem**: post-BL-076 deploy on Cloudflare Worker staging — three back-to-back `prepare_irl_body` → `compose_dossier_envelope` pairs in a live opus-4-8 exercise all surfaced `Bl076BodyCacheMissError` on compose despite prepare returning the correct deterministic hash (`2255981b665d27d1`, 3046 bytes) every time. Stdio path unaffected. Root cause unknown — three plausible explanations from impartial audit:


### PR DESCRIPTION
## Summary

Continuation of the BL-077a diagnostic chain. After PR #245 (BL-077a) merged + deployed, the operator ran a `gst_irl_ingestion` exercise on staging with `wrangler tail` active and captured the smoking gun:

```json
{"event":"bl077.cache.set","outcome":"write-returned-false",
 "storeId":2,"key":"gst-mcp:irl-body:68da2101bc47c731",
 "byteLength":64054,"ttlSeconds":14400,"success":false,
 "errorCode":"cache-write-returned-false"}
```

Confirmed: the Upstash KV write is failing at the 64KB body size. But the actual Upstash error message was being **swallowed inside `CacheStore.set`'s `catch {}` block**. We knew WHICH layer was failing but not WHY.

This patch adds one `safeLog` line inside that catch so `wrangler tail` captures the actual Upstash error message in the next exercise.

## Surface impact

- **NEW** `upstash.set.failed` `safeLog` event emitted at [`mcp-server/src/lib/upstash-cache-store.ts`](mcp-server/src/lib/upstash-cache-store.ts) whenever `redis.set` throws. Carries:
  - `key` — the Upstash key being written
  - `byteLength` — size of the JSON-stringified `{storedAt, data}` envelope (the actual byte count Upstash received, not the raw body size)
  - `ttlSeconds`
  - `reason` — truncated to 300 chars
  - `errorCode: 'upstash-set-threw'`
- **No public contract change.** No prompt-body change, no schema change, no manifest hash drift.
- **Affects ALL callers of `createCacheStore`** (resource cache, BL-076 body cache, etc.) — backward-compatible at the contract level since the behavior on failure is still "return false."

## Acceptance

- **5 new unit tests** at [`tests/unit/lib/upstash-cache-store-error-logging.test.ts`](mcp-server/tests/unit/lib/upstash-cache-store-error-logging.test.ts):
  - Success path does NOT emit the failure event
  - Throw path returns false AND emits with the actual error message + truncated reason
  - 300-char truncation enforced
  - Non-Error throw values handled (`reason` includes `String(err)`)
  - `byteLength` reflects the JSON-wrapped envelope size (proves the diagnostic is correct for size-limit triage)
- **1460 mcp-server tests green**; tsc clean.

## Test plan

- [x] `cd mcp-server && npx tsc --noEmit` — clean
- [x] `cd mcp-server && npx vitest run` — 1460 / 1460 pass
- [ ] **Post-merge operator follow-up**: deploy 0.30.2 to staging, run the same `gst_irl_ingestion` exercise that produced the BL-077a `outcome: write-returned-false` with `wrangler tail` active. The new `upstash.set.failed` event will appear with the actual Upstash error in `reason`. Three most-likely:
  - `REQUEST_TOO_LARGE` / `PAYLOAD_TOO_LARGE` → 64KB body wrapped in `{storedAt, data: <JSON-escaped body>}` exceeds Upstash REST request size limit. BL-077c fix: bypass envelope OR compress before store.
  - `MAX_DAILY_REQUEST_SIZE_LIMIT_EXCEEDED` / quota → bump plan or rotate to separate DB.
  - `WRONGTYPE` / `NOAUTH` / network → config issue.
- [ ] **File BL-077c** with the tail output + the targeted root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)