### PR TITLE
fix(mcp): BL-077c realign IRL body cache key to mcp: namespace (v0.30.3)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -29,6 +29,46 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.30.3 — 2026-06-07 — BL-077c realign IRL body cache key to `mcp:` namespace
+
+**Theme**: closes the BL-076 staging incident. BL-077b's `upstash.set.failed` event captured the actual Upstash error on the next staging exercise:
+
+```
+NOPERM this user has no permissions to access one of the keys used as arguments
+```
+
+The shared Upstash token has ACL scoped to `+@all ~mcp:*` (single DB shared between staging and production, confirmed 2026-06-07). BL-076 originally shipped with the prefix `gst-mcp:irl-body:` — outside that scope — so every `prepare_irl_body` call's cache write was rejected with `NOPERM`. The 64KB body size that looked like a smoking gun was a coincidence; the same body shape hit the same error regardless of size.
+
+**Surface impact**:
+
+- **CHANGED** `UPSTASH_KEY_PREFIX` in [`mcp-server/src/cache/irl-body-cache.ts`] from `'gst-mcp:irl-body:'` to `'mcp:irl-body:'`. Aligns with the namespace discipline documented at [`upstash-cache-store.ts:12-16`] ("All keys written here use the `mcp:` prefix").
+- **NEW** regression-guard unit test asserting `UPSTASH_KEY_PREFIX.startsWith('mcp:')` so a future refactor can't silently reintroduce the ACL failure.
+- **No public contract change.** No prompt-body change, no schema change, no manifest hash drift.
+- **No data migration**: pre-existing `gst-mcp:irl-body:*` keys never made it to Upstash (writes were rejected). No stale entries to clean up.
+
+**Acceptance** (in-session):
+
+- 1 new regression-guard unit test + existing 13 cache tests + 7 BL-076 integration tests still green with the new prefix value.
+- 1461 mcp-server tests green; tsc clean.
+
+**Operator follow-up** (the diagnostic chain closes here):
+
+1. Deploy 0.30.3 to staging.
+2. Operator re-runs the same `gst_irl_ingestion` exercise that produced the `NOPERM` event.
+3. `prepare_irl_body` writes succeed → `compose_dossier_envelope` re-hydrates successfully → dossier completes end-to-end with the BL-076 latency win.
+4. BL-077a/b diagnostic instrumentation (read-after-write probe, `bl077.cache.*` events, `upstash.set.failed` event) stays in place for now — light cost; revisit removal after one week of stable production traces. The read-after-write probe in particular adds ~50–100ms to every `prepare_irl_body` call and should come out once the substrate is proven stable.
+
+**Risks**: minimal. The prefix change is a one-line constant. No callers outside this module reference the prefix. The Upstash ACL accepts `mcp:irl-body:*` writes — confirmed by inference from existing `mcp:resource:*`, `mcp:ratelimit:*`, `mcp:circuit:*` traffic which succeeds today.
+
+**Diagnostic chain summary** (for the operator runbook):
+
+- BL-076 (v0.30.0) — body-by-hash mechanism shipped; latency-win design correct, but cache write silently failed in Worker mode due to ACL scope drift.
+- BL-077a (v0.30.1) — fail-loud + read-after-write probe + `bl077.cache.*` logging surfaced "write returns false."
+- BL-077b (v0.30.2) — `upstash.set.failed` logging surfaced the actual NOPERM error.
+- BL-077c (v0.30.3 — this release) — namespace alignment closes the loop.
+
+---
+
 ## 0.30.2 — 2026-06-07 — BL-077b surface Upstash error in `CacheStore.set`
 
 **Theme**: continuation of BL-077a diagnostic chain. BL-077a's `bl077.cache.set` event on staging confirmed `outcome: write-returned-false` at a 64KB body — the underlying Upstash write was failing — but the actual Upstash error was being swallowed inside `CacheStore.set`'s `catch {}` block. Pre-BL-077b, we could see WHICH layer was failing but not WHY. This patch adds one `safeLog` line inside the catch so `wrangler tail` captures the actual Upstash error message in the next exercise.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/cache/irl-body-cache.ts
+++ b/mcp-server/src/cache/irl-body-cache.ts
@@ -52,8 +52,22 @@ export const IRL_BODY_CACHE_TTL_SECONDS = 4 * 60 * 60;
 /** Stdio LRU cap. 16 entries covers a deep iteration session for one operator. */
 export const IN_MEMORY_LRU_CAPACITY = 16;
 
-/** Upstash key prefix for IRL body cache entries. */
-export const UPSTASH_KEY_PREFIX = 'gst-mcp:irl-body:';
+/**
+ * Upstash key prefix for IRL body cache entries.
+ *
+ * **MUST start with `mcp:`** to conform to the namespace discipline documented
+ * at [`mcp-server/src/lib/upstash-cache-store.ts:12-16`]:
+ *
+ *   > Namespace discipline (Q13 / Path 2): this store talks ONLY to the MCP
+ *   > DB via createMcpClient(env). All keys written here use the `mcp:` prefix
+ *
+ * The shared Upstash token has ACL scoped to `+@all ~mcp:*`. BL-076 originally
+ * shipped with the prefix `gst-mcp:irl-body:` (single staging exercise on
+ * 2026-06-07 surfaced `NOPERM this user has no permissions to access one of
+ * the keys used as arguments` via the BL-077a/b diagnostic chain). BL-077c
+ * realigns the prefix with the documented discipline.
+ */
+export const UPSTASH_KEY_PREFIX = 'mcp:irl-body:';
 
 /**
  * Thrown by `IrlBodyCache.set` when the body byte-length exceeds

--- a/mcp-server/tests/unit/cache/irl-body-cache.test.ts
+++ b/mcp-server/tests/unit/cache/irl-body-cache.test.ts
@@ -137,6 +137,17 @@ describe('UpstashIrlBodyCache', () => {
     };
   }
 
+  it('UPSTASH_KEY_PREFIX starts with "mcp:" — BL-077c namespace discipline regression guard', () => {
+    // The shared Upstash token has ACL scoped to `+@all ~mcp:*` (single DB
+    // shared between staging and production per BL-077c verification on
+    // 2026-06-07). The BL-076 original prefix `gst-mcp:irl-body:` produced
+    // a NOPERM error on every prepare_irl_body call. Pin the prefix to the
+    // `mcp:` namespace so a future refactor can't silently reintroduce the
+    // ACL-rejection failure mode.
+    expect(UPSTASH_KEY_PREFIX.startsWith('mcp:')).toBe(true);
+    expect(UPSTASH_KEY_PREFIX).toBe('mcp:irl-body:');
+  });
+
   it('round-trips a body via the Upstash store with the BL-076 key prefix', async () => {
     const { store, writes } = makeFakeStore();
     const cache = new UpstashIrlBodyCache(store);

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -3880,6 +3880,38 @@ The bug is operator-visible (block carries the fabricated list) but not partner-
 
 ---
 
+### BL-077c: Realign IRL body cache key to `mcp:` namespace ✅ CLOSED 2026-06-07 (shipped at mcp-server 0.30.3)
+
+**Problem**: BL-077b's `upstash.set.failed` event on staging surfaced the actual Upstash error blocking BL-076:
+
+```
+NOPERM this user has no permissions to access one of the keys used as arguments
+```
+
+The shared Upstash token (single DB shared between staging and production per operator confirmation 2026-06-07) has ACL scoped to `+@all ~mcp:*`. BL-076 originally shipped with the IRL body cache prefix `gst-mcp:irl-body:` — outside that scope — so every `prepare_irl_body` cache write was rejected with `NOPERM`. The 64KB body size that earlier diagnostics flagged was a coincidence; the same body shape hit the same error regardless of size.
+
+**Scope**: one-line constant change in `mcp-server/src/cache/irl-body-cache.ts` — `UPSTASH_KEY_PREFIX: 'gst-mcp:irl-body:' → 'mcp:irl-body:'`. Aligns with the namespace discipline documented at `upstash-cache-store.ts:12-16` ("All keys written here use the `mcp:` prefix"). Plus a regression-guard unit test asserting `UPSTASH_KEY_PREFIX.startsWith('mcp:')` so a future refactor can't silently reintroduce the ACL failure.
+
+**Surface impact**: `mcp-server` 0.30.2 → 0.30.3 (patch). No public contract change. No prompt-body change, no schema change, no manifest hash drift. No data migration (pre-existing `gst-mcp:irl-body:*` keys never made it to Upstash; writes were all rejected).
+
+**Acceptance** (in-session):
+
+- 1 new regression-guard test + existing 13 cache tests + 7 BL-076 integration tests still green with the new prefix value.
+- 1461 mcp-server tests green; tsc clean.
+
+**Operator follow-up**: deploy 0.30.3 to staging. Run `gst_irl_ingestion` exercise. Expected: `prepare_irl_body` cache writes succeed → `compose_dossier_envelope` re-hydrates successfully → dossier completes end-to-end with the BL-076 latency win. The BL-077a/b instrumentation (read-after-write probe, `bl077.cache.*` events, `upstash.set.failed` event) stays in place for now — light cost; revisit removal after one week of stable traces. Reserve as **BL-078**: remove BL-077 diagnostic instrumentation after stable trace window.
+
+**Diagnostic chain summary** (closes here):
+
+- BL-076 (v0.30.0) — body-by-hash mechanism shipped; latency-win design correct, but cache write silently failed in Worker mode due to ACL scope drift.
+- BL-077a (v0.30.1) — fail-loud + read-after-write probe + `bl077.cache.*` logging surfaced "write returns false."
+- BL-077b (v0.30.2) — `upstash.set.failed` logging surfaced the actual NOPERM error.
+- BL-077c (v0.30.3) — namespace alignment closes the loop.
+
+**Related**: BL-076 (the body-by-hash mechanism this completes), BL-077a (cache-layer fail-loud), BL-077b (substrate-layer error surfacing), BL-078 (reserved — remove BL-077 diagnostic instrumentation after stable trace window).
+
+---
+
 ### BL-077b: Surface Upstash error in `CacheStore.set` ✅ CLOSED 2026-06-07 (shipped at mcp-server 0.30.2)
 
 **Problem**: BL-077a's `bl077.cache.set` event on staging (1 hour after 0.30.1 deploy) confirmed `outcome: write-returned-false` at a 64054-byte body — Upstash KV write was failing — but the actual Upstash error message was being swallowed inside `CacheStore.set`'s `catch {}` block. We knew WHICH layer was failing but not WHY.


### PR DESCRIPTION
## Summary

**Closes the BL-076 staging incident.** The complete diagnostic chain over PRs #243 → #245 → #246 → #247 converged on a one-line root cause.

BL-077b's `upstash.set.failed` event on staging surfaced the actual Upstash error:

```
NOPERM this user has no permissions to access one of the keys used as arguments
```

The shared Upstash token (operator-confirmed: single DB shared between staging and production, 2026-06-07) has ACL scoped to `+@all ~mcp:*`. BL-076 originally shipped with the IRL body cache prefix `gst-mcp:irl-body:` — **outside that scope** — so every `prepare_irl_body` cache write was rejected with `NOPERM`. The 64KB body size that earlier diagnostics flagged was a coincidence; the same body shape hit the same error regardless of size.

## The fix

One-line constant change in [`mcp-server/src/cache/irl-body-cache.ts`](mcp-server/src/cache/irl-body-cache.ts):

```diff
-export const UPSTASH_KEY_PREFIX = 'gst-mcp:irl-body:';
+export const UPSTASH_KEY_PREFIX = 'mcp:irl-body:';
```

Aligns with the namespace discipline documented at [`upstash-cache-store.ts:12-16`](mcp-server/src/lib/upstash-cache-store.ts#L12-L16) ("All keys written here use the `mcp:` prefix").

Plus a regression-guard unit test that asserts `UPSTASH_KEY_PREFIX.startsWith('mcp:')` so a future refactor can't silently reintroduce the ACL failure.

## Surface impact

- **No public contract change.** No prompt-body change, no schema change, no manifest hash drift, no body hash rebaseline.
- **No data migration**: pre-existing `gst-mcp:irl-body:*` keys never made it to Upstash (writes were all rejected). No stale entries to clean up.
- BL-077a/b instrumentation stays in place for now — light cost; reserve BL-078 to remove after one week of stable traces.

## Acceptance

- **1 new regression-guard unit test** + existing 13 cache tests + 7 BL-076 integration tests still green with the new prefix value.
- **1461 mcp-server tests green**; tsc clean.

## Test plan

- [x] `cd mcp-server && npx tsc --noEmit` — clean
- [x] `cd mcp-server && npx vitest run` — 1461 / 1461 pass
- [ ] **Post-merge operator follow-up** — the payoff:
  1. Deploy 0.30.3 to staging
  2. Run `gst_irl_ingestion` exercise
  3. Expected: `prepare_irl_body` cache writes succeed → `compose_dossier_envelope` re-hydrates successfully → dossier completes end-to-end with the BL-076 latency win (40–80% reduction)
  4. `wrangler tail` should show `bl077.cache.set` with `outcome: success` (the smoking gun replaced by the goal posts)

## Diagnostic chain summary

For the operator runbook — this is what the full chain captured:

| Version | BL | What it did |
|---|---|---|
| 0.30.0 | BL-076 | Shipped body-by-hash mechanism. Latency-win design correct, but cache write silently failed on Worker due to ACL scope drift (introduced by the wrong prefix). |
| 0.30.1 | BL-077a | Fail-loud + read-after-write probe + `bl077.cache.*` logging. Surfaced "write returns false." |
| 0.30.2 | BL-077b | `upstash.set.failed` logging. Surfaced the actual NOPERM error message. |
| 0.30.3 | BL-077c | Namespace alignment closes the loop. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)