### PR TITLE
fix(mcp): BL-082 booleanFromWire for slash-command form interop (v0.30.4)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -29,6 +29,42 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.30.4 — 2026-06-07 — BL-082 `booleanFromWire` for slash-command form interop
+
+**Theme**: closes a structural bug in prompt-argument validation. Per the MCP wire protocol, prompt `arguments` are typed as `Record<string, string>` — every value the client sends is a string regardless of the conceptual type. Claude Desktop's slash-command form renders boolean fields as plain text inputs and ships `"true"` / `"TRUE"` / `"false"` rather than the JSON boolean. Pre-0.30.4, the `gst_irl_ingestion` prompt's `requireVerbatimBody: z.boolean().optional()` field rejected every string form with `expected boolean, received string`. The `arrayFromWire` / `numberFromWire` / `enumFromWire` adapters already existed at [`mcp-server/src/prompts/wire-shape.ts`] for the array / number / enum cases; the boolean case was missing.
+
+Operator hit this on 2026-06-07 when invoking `/gst_irl_ingestion` from Claude Desktop with the StoreForce partner-paste body:
+
+```
+Message from server: { error: { code: -32602,
+  message: "MCP error -32602: Invalid arguments for prompt gst_irl_ingestion: [
+    { expected: 'boolean', code: 'invalid_type',
+      path: ['requireVerbatimBody'],
+      message: 'Invalid input: expected boolean, received string' } ]"
+}}
+```
+
+**Surface impact**:
+
+- **NEW** `booleanFromWire` exported from `mcp-server/src/prompts/wire-shape.ts`. Mirrors the design of the existing `arrayFromWire` / `numberFromWire` / `enumFromWire` adapters. Accepts: typed booleans (forward-compat), case-insensitive `'true' / 'false'`, and ergonomic alternates `'yes' / 'no' / 'y' / 'n' / '1' / '0' / 'on' / 'off'`. Empty / whitespace-only strings normalize to `undefined` (unfilled-form-field convention shared with the other adapters). Garbage strings fall through to Zod for structured rejection.
+- **UPDATED** `gst_irl_ingestion` prompt argsSchema at [`mcp-server/src/prompts/irl-ingestion.ts`]:
+  - `requireVerbatimBody`: `z.boolean().optional()` → `booleanFromWire(z.boolean().optional())`
+  - `forceTools`: `z.array(z.enum(ORCHESTRATED_TOOLS)).optional()` → `arrayFromWire(z.array(z.enum(ORCHESTRATED_TOOLS)).optional())` (same root-cause bug class — array fields ship as strings from the slash-command form; the bug just hadn't been exercised empirically because no operator had used `forceTools` from the UI before)
+- **No public contract change**. The accepted JSON-boolean / JSON-array values still parse identically; the change is additive — the schema now also accepts the string forms the wire protocol actually delivers.
+- **No prompt-body change**, no schema change, no manifest hash drift, no body hash rebaseline.
+
+**Acceptance** (in-session):
+
+- 8 new `booleanFromWire` unit tests at [`tests/unit/prompts/wire-shape.test.ts`]: forward-compat boolean pass-through; canonical `'true'`/`'false'` parsing; case-insensitive (`'TRUE'` / `'False'` / `'TrUe'`); whitespace trimming; ergonomic alternates (yes/no/y/n/1/0/on/off); garbage rejection; non-boolean non-string rejection; empty/whitespace as not-supplied.
+- 5 new BL-082 regression tests at [`tests/unit/prompts/irl-ingestion.test.ts`]: full argsSchema accepts `requireVerbatimBody: 'true'` / `'TRUE'` / `'false'`; treats `''` as not-supplied; rejects `'definitely'`.
+- 1489 mcp-server tests green; tsc clean.
+
+**Operator unblock**: deploy 0.30.4 to staging; retry `/gst_irl_ingestion` with `requireVerbatimBody: TRUE`. The schema now accepts the string form the slash-command UI ships.
+
+**Risks**: minimal. The wire-shape adapter pattern is established and tested; this just fills the boolean gap. The change is additive (typed booleans still work), so any future MCP client that sends typed values experiences zero behavior difference.
+
+---
+
 ## 0.30.3 — 2026-06-07 — BL-077c realign IRL body cache key to `mcp:` namespace
 
 **Theme**: closes the BL-076 staging incident. BL-077b's `upstash.set.failed` event captured the actual Upstash error on the next staging exercise:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/scripts/extract-irl-markdown.mjs
+++ b/mcp-server/scripts/extract-irl-markdown.mjs
@@ -1,6 +1,15 @@
-#!/usr/bin/env node
 /**
  * Extract canonical IRL markdown from a populated GST IRL `.xlsx`.
+ *
+ * **No shebang**: this script is invoked via `node scripts/...` or
+ * `npm run irl:extract`, NOT as a self-executable. Vite's parser (which
+ * powers vitest's import path for this `.mjs` file in the round-trip
+ * tests) does not accept a `#!` shebang line and bails with
+ * `SyntaxError: Invalid or unexpected token` — even though raw Node 22
+ * special-cases shebangs in `.mjs` files. Default-importing the script
+ * via `import { extractIrlMarkdownFromRows } from '...mjs'` MUST work
+ * under both raw Node (CLI) and vitest (round-trip tests) — keeping
+ * the file shebang-free is the simplest portable answer.
  *
  * **What this is**: the structural inverse of
  * `mcp-server/src/tools/generate-information-request-list-xlsx.ts`. The
@@ -68,7 +77,16 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import * as XLSX from 'xlsx-js-style';
+import XLSX from 'xlsx-js-style';
+
+// `xlsx-js-style` is a CommonJS package. Raw Node 22's ESM resolver exposes
+// its `module.exports` shape under the `default` import — so the simple
+// default-import form gives us `XLSX.read(...)` + `XLSX.utils.sheet_to_json`
+// in both raw Node and vitest. Pre-fix the script used
+// `import * as XLSX from 'xlsx-js-style'`, which worked under vitest's Vite
+// resolver (which collapses the CJS default into the namespace) but blew
+// up in raw Node production with `XLSX.read is not a function`. Default
+// import is the portable form.
 
 const PRIMARY_SHEET_NAME = 'Information Request List';
 

--- a/mcp-server/src/prompts/irl-ingestion.ts
+++ b/mcp-server/src/prompts/irl-ingestion.ts
@@ -29,6 +29,7 @@ import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import type { GstPrompt } from './types';
 import { authorialIntentLine, embedLibraryArticle } from './embed';
+import { arrayFromWire, booleanFromWire } from './wire-shape';
 import {
   UNKNOWN_PROPAGATION_RULE,
   EU_AI_ACT_CONDITIONAL_TRIGGER,
@@ -126,18 +127,12 @@ const argsSchema = z.object({
     .describe(
       "Output verbosity. Defaults to 'verbose' (emits per-field provenance footers + schema-validated JSON-fence self-check directives). 'compact' elides both — useful when piping the dossier JSON downstream to automation that does not need the audit prose."
     ),
-  forceTools: z
-    .array(z.enum(ORCHESTRATED_TOOLS))
-    .optional()
-    .describe(
-      "Escape hatch — explicit override that bypasses inclusion gates for the listed tool names. Defaults to `[]` (gates fully apply). Use when (a) the partner wants a tool output despite sparse IRL signal, or (b) the partner is refining a single section. Strict enum — accepted values are derived from the prompt's orchestrates array at build time, so an unknown tool name is rejected at parse time."
-    ),
-  requireVerbatimBody: z
-    .boolean()
-    .optional()
-    .describe(
-      'BL-070 — accuracy-critical run gate. Set TRUE for high-stakes engagements (regulatory deliverable, M&A close, post-mortem) where BL-049 hash-bind authority MUST hold over the partner-supplied source — not the model-reconstructed body. When set, the `compose_dossier_envelope` tool REFUSES any `irlSource !== "partner-paste-verbatim"` with a structured error directing the operator to re-invoke with the IRL pasted as markdown into the `filledIrl` arg. Default unset (false) — drafting / exploration mode where the BL-072 (J) gap-list disclosure is sufficient.'
-    ),
+  forceTools: arrayFromWire(z.array(z.enum(ORCHESTRATED_TOOLS)).optional()).describe(
+    "Escape hatch — explicit override that bypasses inclusion gates for the listed tool names. Defaults to `[]` (gates fully apply). Use when (a) the partner wants a tool output despite sparse IRL signal, or (b) the partner is refining a single section. Strict enum — accepted values are derived from the prompt's orchestrates array at build time, so an unknown tool name is rejected at parse time."
+  ),
+  requireVerbatimBody: booleanFromWire(z.boolean().optional()).describe(
+    'BL-070 — accuracy-critical run gate. Set TRUE for high-stakes engagements (regulatory deliverable, M&A close, post-mortem) where BL-049 hash-bind authority MUST hold over the partner-supplied source — not the model-reconstructed body. When set, the `compose_dossier_envelope` tool REFUSES any `irlSource !== "partner-paste-verbatim"` with a structured error directing the operator to re-invoke with the IRL pasted as markdown into the `filledIrl` arg. Default unset (false) — drafting / exploration mode where the BL-072 (J) gap-list disclosure is sufficient.'
+  ),
 });
 
 const PROMPT_NAME = 'gst_irl_ingestion';

--- a/mcp-server/src/prompts/wire-shape.ts
+++ b/mcp-server/src/prompts/wire-shape.ts
@@ -126,6 +126,46 @@ function unwrapToEnumOptions(schema: z.ZodTypeAny): readonly string[] {
   );
 }
 
+/**
+ * Adapt a `z.boolean()` schema so it accepts either an actual boolean
+ * (forward-compat) or a string form (current Desktop wire shape). MCP
+ * prompt arguments arrive as `Record<string, string>` — Claude Desktop's
+ * slash-command form renders boolean fields as plain text inputs and ships
+ * `"true"` / `"TRUE"` / `"false"` / `"FALSE"` / `"1"` / `"0"` rather than
+ * the JSON boolean. Operators learned about this the hard way on 2026-06-07
+ * when `requireVerbatimBody: "true"` got rejected with `expected boolean,
+ * received string`.
+ *
+ * Accepted string forms (case-insensitive, whitespace-trimmed):
+ *   - `'true'`, `'1'`, `'yes'`, `'y'`, `'on'`  → `true`
+ *   - `'false'`, `'0'`, `'no'`, `'n'`, `'off'` → `false`
+ *
+ * Empty / whitespace-only strings normalize to `undefined`, so an unfilled
+ * form field is treated as "not supplied" (same convention as the array /
+ * number / enum adapters above). Unrecognized strings pass through so Zod's
+ * native diagnostic ("Invalid input: expected boolean") still surfaces with
+ * an actionable error message.
+ *
+ * `.optional()` / `.default(...)` MUST be applied to the inner schema —
+ * `booleanFromWire(z.boolean().optional())`, NOT
+ * `booleanFromWire(z.boolean()).optional()` — for the empty-string path to
+ * take effect (the latter sees `""` before the preprocess and mis-rejects).
+ */
+const TRUE_FORMS = new Set(['true', '1', 'yes', 'y', 'on']);
+const FALSE_FORMS = new Set(['false', '0', 'no', 'n', 'off']);
+export function booleanFromWire<S extends z.ZodTypeAny>(inner: S) {
+  return z.preprocess((v) => {
+    if (typeof v === 'boolean') return v; // forward-compat: typed boolean
+    if (typeof v === 'string') {
+      const lower = v.trim().toLowerCase();
+      if (lower === '') return undefined; // empty form field → not supplied
+      if (TRUE_FORMS.has(lower)) return true;
+      if (FALSE_FORMS.has(lower)) return false;
+    }
+    return v; // fall through — inner schema rejects with structured diagnostic
+  }, inner);
+}
+
 export function enumFromWire<T extends z.ZodTypeAny>(inner: T) {
   const options = unwrapToEnumOptions(inner);
   const canonicalByLower = new Map<string, string>(options.map((v) => [v.toLowerCase(), v]));

--- a/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
+++ b/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
@@ -657,6 +657,41 @@ describe('gst_irl_ingestion', () => {
         true
       );
     });
+
+    // BL-082 — slash-command form ships all values as strings per the MCP
+    // wire protocol (`arguments: Record<string, string>`). Operators learned
+    // about this the hard way on 2026-06-07 when `requireVerbatimBody: "TRUE"`
+    // got rejected with `expected boolean, received string`. These tests pin
+    // the booleanFromWire coercion at the argsSchema level — not just on the
+    // wire-shape helper in isolation.
+    it("BL-082: argsSchema accepts requireVerbatimBody: 'true' (string, from slash-command form)", () => {
+      const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: 'true' });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.requireVerbatimBody).toBe(true);
+    });
+
+    it("BL-082: argsSchema accepts requireVerbatimBody: 'TRUE' (uppercase, the exact failing 2026-06-07 case)", () => {
+      const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: 'TRUE' });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.requireVerbatimBody).toBe(true);
+    });
+
+    it("BL-082: argsSchema accepts requireVerbatimBody: 'false' (string)", () => {
+      const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: 'false' });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.requireVerbatimBody).toBe(false);
+    });
+
+    it("BL-082: argsSchema treats requireVerbatimBody: '' (empty form field) as not supplied", () => {
+      const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: '' });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.requireVerbatimBody).toBeUndefined();
+    });
+
+    it("BL-082: argsSchema rejects garbage strings ('definitely') with structured Zod error", () => {
+      const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: 'definitely' });
+      expect(r.success).toBe(false);
+    });
   });
 
   describe('BL-071 — serverToolCallCounts + precheck-derivation directive', () => {

--- a/mcp-server/tests/unit/prompts/wire-shape.test.ts
+++ b/mcp-server/tests/unit/prompts/wire-shape.test.ts
@@ -13,7 +13,12 @@
 
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { arrayFromWire, enumFromWire, numberFromWire } from '../../../src/prompts/wire-shape';
+import {
+  arrayFromWire,
+  booleanFromWire,
+  enumFromWire,
+  numberFromWire,
+} from '../../../src/prompts/wire-shape';
 
 describe('arrayFromWire', () => {
   const inner = z.array(z.string()).min(1);
@@ -175,5 +180,87 @@ describe('enumFromWire', () => {
     expect(innerOptional.safeParse('').success).toBe(true);
     expect(innerOptional.safeParse('   ').success).toBe(true);
     expect(innerOptional.safeParse('A').success).toBe(true);
+  });
+});
+
+// ─── BL-082 — booleanFromWire (slash-command form ships strings) ─────────
+
+describe('booleanFromWire', () => {
+  const wrapped = booleanFromWire(z.boolean());
+
+  it('passes through an already-typed boolean unchanged (forward-compat)', () => {
+    const r = wrapped.safeParse(true);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBe(true);
+    const f = wrapped.safeParse(false);
+    expect(f.success).toBe(true);
+    if (f.success) expect(f.data).toBe(false);
+  });
+
+  it("parses the canonical strings 'true' and 'false'", () => {
+    expect(wrapped.parse('true')).toBe(true);
+    expect(wrapped.parse('false')).toBe(false);
+  });
+
+  it('is case-insensitive — TRUE / False / TrUe all parse', () => {
+    expect(wrapped.parse('TRUE')).toBe(true);
+    expect(wrapped.parse('False')).toBe(false);
+    expect(wrapped.parse('TrUe')).toBe(true);
+  });
+
+  it("trims surrounding whitespace — '  true ' parses", () => {
+    expect(wrapped.parse('  true ')).toBe(true);
+    expect(wrapped.parse('\tfalse\n')).toBe(false);
+  });
+
+  it("accepts ergonomic alternates — 'yes' / 'no' / '1' / '0' / 'on' / 'off' / 'y' / 'n'", () => {
+    expect(wrapped.parse('yes')).toBe(true);
+    expect(wrapped.parse('YES')).toBe(true);
+    expect(wrapped.parse('y')).toBe(true);
+    expect(wrapped.parse('1')).toBe(true);
+    expect(wrapped.parse('on')).toBe(true);
+    expect(wrapped.parse('no')).toBe(false);
+    expect(wrapped.parse('n')).toBe(false);
+    expect(wrapped.parse('0')).toBe(false);
+    expect(wrapped.parse('off')).toBe(false);
+  });
+
+  it('rejects garbage strings via the inner schema (no silent coercion to truthy)', () => {
+    const r = wrapped.safeParse('definitely');
+    expect(r.success).toBe(false);
+    const r2 = wrapped.safeParse('truthy');
+    expect(r2.success).toBe(false);
+  });
+
+  it('rejects non-boolean non-string values (numbers, objects, arrays)', () => {
+    expect(wrapped.safeParse(0).success).toBe(false);
+    expect(wrapped.safeParse(1).success).toBe(false);
+    expect(wrapped.safeParse({}).success).toBe(false);
+    expect(wrapped.safeParse([]).success).toBe(false);
+  });
+
+  it('treats empty / whitespace-only strings as not supplied (optional pattern)', () => {
+    // When `.optional()` is applied to the inner schema, the empty form-field
+    // value `""` shipped by Claude Desktop should not surface as a Zod
+    // validation error — it should be treated as "field not filled."
+    const innerOptional = booleanFromWire(z.boolean().optional());
+    expect(innerOptional.safeParse('').success).toBe(true);
+    expect(innerOptional.safeParse('   ').success).toBe(true);
+    expect(innerOptional.safeParse('true').success).toBe(true);
+    expect(innerOptional.safeParse(true).success).toBe(true);
+    // Confirm the resolved value for the empty case is undefined (not false).
+    const r = innerOptional.safeParse('');
+    if (r.success) expect(r.data).toBeUndefined();
+  });
+
+  it("BL-082 regression: requireVerbatimBody='TRUE' from slash-command form parses to boolean true", () => {
+    // The specific failure case from the 2026-06-07 operator incident:
+    // Claude Desktop shipped {"requireVerbatimBody": "TRUE"} and the server
+    // rejected with "expected boolean, received string". This pins the fix.
+    const schema = booleanFromWire(z.boolean().optional());
+    expect(schema.parse('true')).toBe(true);
+    expect(schema.parse('TRUE')).toBe(true);
+    expect(schema.parse('false')).toBe(false);
+    expect(schema.parse('FALSE')).toBe(false);
   });
 });

--- a/mcp-server/tests/unit/scripts/extract-irl-markdown-cli-smoke.test.ts
+++ b/mcp-server/tests/unit/scripts/extract-irl-markdown-cli-smoke.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Real-Node CLI smoke test for `extract-irl-markdown.mjs`.
+ *
+ * Pre-existing round-trip tests in `extract-irl-markdown.test.ts` import the
+ * library function directly under vitest. That harness uses Vite's module
+ * resolver, which normalizes CommonJS interop differently than raw Node 22's
+ * ESM resolver. A subtle bug surfaced in production (2026-06-07):
+ *
+ *   import * as XLSX from 'xlsx-js-style';
+ *   // ...
+ *   XLSX.read(buf)  // ← undefined under raw Node, works under vitest
+ *
+ * The library-level tests passed; the actual CLI invocation (`npm run
+ * irl:extract`) blew up with `XLSX.read is not a function`. This test
+ * closes that gap: it spawns the SAME node executable that operators run,
+ * against the SAME .mjs script file, against a real .xlsx buffer, and
+ * asserts the canonical markdown shape comes out. Catches any future
+ * CJS/ESM interop drift OR any node-builtin path that Vite's resolver
+ * silently shims.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateIrlXlsxBuffer } from '../../../../src/utils/irl/generate-xlsx';
+import type { IRLArticle } from '../../../../src/utils/irl/types';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = resolve(__dirname, '../../../scripts/extract-irl-markdown.mjs');
+
+const SAMPLE_ARTICLE: IRLArticle = {
+  title: 'Information Request List',
+  intro: 'Below is information useful to size and execute a client engagement.',
+  sections: [
+    {
+      number: '00',
+      title: 'Basics',
+      bullets: [{ text: 'Company name' }, { text: 'Annual recurring revenue' }],
+    },
+  ],
+  footer: '_Last updated: 2026-06-07._',
+};
+
+let tempDir: string;
+let xlsxPath: string;
+
+beforeAll(() => {
+  // Generate a real workbook buffer, write to a temp .xlsx file the CLI
+  // can open. Using the actual generator keeps the test honest — if a future
+  // generator change breaks the workbook shape, this smoke test catches it.
+  tempDir = mkdtempSync(join(tmpdir(), 'extract-irl-cli-smoke-'));
+  xlsxPath = join(tempDir, 'sample.xlsx');
+  const buf = generateIrlXlsxBuffer(SAMPLE_ARTICLE, {
+    targetName: 'CLI Smoke Co',
+    transactionContext: 'value-creation',
+    generatedAt: new Date('2026-06-07T12:00:00.000Z'),
+    canonicalUrl: 'https://example.test/canonical',
+  });
+  writeFileSync(xlsxPath, Buffer.from(buf));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('extract-irl-markdown.mjs — real-Node CLI smoke', () => {
+  it('runs end-to-end via raw node, emits canonical markdown to stdout', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, xlsxPath], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    if (result.status !== 0) {
+      // Echo stdout AND stderr so the assertion message reveals the actual
+      // failure (CJS/ESM interop bugs surface with `XLSX.read is not a
+      // function` in stderr; library-level tests can't see this).
+      throw new Error(
+        `CLI exited with status ${result.status}\n` +
+          `stdout:\n${result.stdout}\n` +
+          `stderr:\n${result.stderr}`
+      );
+    }
+    expect(result.stdout).toContain('# Information Request List — CLI Smoke Co (filled)');
+    expect(result.stdout).toContain('- 0-01 Company name');
+    expect(result.stdout).toContain('- 0-02 Annual recurring revenue');
+    // stderr should carry the summary line.
+    expect(result.stderr).toMatch(/Extracted \d+ bullets/);
+  });
+
+  it('writes to --out path when supplied', () => {
+    const outPath = join(tempDir, 'out.md');
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, xlsxPath, '--out', outPath], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    const written = readFileSync(outPath, 'utf8');
+    expect(written).toContain('# Information Request List — CLI Smoke Co (filled)');
+  });
+
+  it('exits non-zero with usage on --help', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, '--help'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('extract-irl-markdown');
+    expect(result.stderr).toContain('--out');
+  });
+
+  it('exits non-zero with a usage-style stderr when no path is supplied', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Usage:');
+  });
+});

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -3880,6 +3880,27 @@ The bug is operator-visible (block carries the fabricated list) but not partner-
 
 ---
 
+### BL-082: `booleanFromWire` for slash-command form interop ✅ CLOSED 2026-06-07 (shipped at mcp-server 0.30.4)
+
+**Problem**: per the MCP wire protocol, prompt `arguments` are typed as `Record<string, string>` — every value the client sends is a string regardless of the conceptual type. Claude Desktop's slash-command form renders boolean fields as plain text inputs and ships `"true"` / `"TRUE"` / `"false"` rather than the JSON boolean. The `gst_irl_ingestion` prompt's `requireVerbatimBody: z.boolean().optional()` field rejected every string form with `expected boolean, received string`, blocking the operator's first BL-076 + extract-irl-markdown partner-paste exercise on 2026-06-07.
+
+**Scope**: add a `booleanFromWire` Zod preprocess to [`mcp-server/src/prompts/wire-shape.ts`] following the design of the existing `arrayFromWire` / `numberFromWire` / `enumFromWire` adapters. Apply to `requireVerbatimBody` in `gst_irl_ingestion` argsSchema. Bundle the `forceTools` array field through `arrayFromWire` while there — same root-cause bug class, just hadn't been exercised empirically.
+
+**Surface impact**: `mcp-server` 0.30.3 → 0.30.4 (patch). No public contract change (additive — typed booleans still parse identically). No prompt-body change, no schema change, no manifest hash drift.
+
+**Acceptance** (in-session):
+
+- 8 new `booleanFromWire` unit tests + 5 new BL-082 regression tests at the irl-ingestion argsSchema level covering the exact failing operator payload (`requireVerbatimBody: 'TRUE'`).
+- 1489 mcp-server tests green; tsc clean.
+
+**Operator unblock**: deploy 0.30.4 to staging; retry `/gst_irl_ingestion` with `requireVerbatimBody: TRUE`. The schema now accepts the string form the slash-command UI ships.
+
+**Related**: BL-076 + BL-077c (the body-by-hash + namespace fix that made partner-paste reachable), PR #248 (extract-irl-markdown script + runbook that made partner-paste actionable), BL-079 (reserved — server-side body delivery via prompt-arg, the structural follow-on).
+
+**Lesson for future prompt-arg additions**: the BL-031.75 / BL-045 prompt registration discipline did not mandate wire-shape coverage for non-string types. Any future `z.boolean()` / `z.number()` / `z.array(...)` / `z.enum(...)` arg added to a registered prompt without going through the matching `*FromWire` adapter is a latent slash-command-UI failure waiting to surface. Worth a lint rule or pre-commit hook in a future ticket (reserve as **BL-083**: add ESLint rule rejecting `z.boolean()` / `z.array(...)` / etc. directly inside a `GstPrompt.argsSchema` literal without a wire-shape adapter wrapper).
+
+---
+
 ### BL-079: Server-side body delivery via prompt-arg + body-by-hash on `validate_irl_provenance` ⏳ OPEN 2026-06-07
 
 **Problem**: post-BL-076 / BL-077c, the body-by-hash mechanism works end-to-end on small (5-10KB) bodies but fails on production-realistic ones. The 2026-06-07 staging exercise on a 77,743-byte body showed the model's tool-call args emission truncated at ~1,753 bytes (2.3%). `prepare_irl_body` cached a partial body; the model self-detected the hash mismatch and halted the run. Same emission ceiling affects `validate_irl_provenance` — its `filledIrl` arg requires the model to emit the full body for citation substring-matching.


### PR DESCRIPTION
## Summary

Operator-blocking bug surfaced on the first BL-076 + extract-irl-markdown partner-paste live exercise on 2026-06-07. Claude Desktop's slash-command form shipped:

```json
{"method":"prompts/get","params":{"name":"gst_irl_ingestion","arguments":{
  "requireVerbatimBody":"TRUE", "filledIrl":"..."
}}}
```

Server rejected:

```
expected: 'boolean', code: 'invalid_type', path: ['requireVerbatimBody'],
message: 'Invalid input: expected boolean, received string'
```

Per the MCP wire protocol, prompt `arguments` are typed as `Record<string, string>` — every value the client sends is a string regardless of the conceptual type. The `arrayFromWire` / `numberFromWire` / `enumFromWire` adapters already existed at [`mcp-server/src/prompts/wire-shape.ts`](mcp-server/src/prompts/wire-shape.ts) for the array / number / enum cases; the boolean case was missing.

## Surface impact

- **NEW** `booleanFromWire` exported from [`wire-shape.ts`](mcp-server/src/prompts/wire-shape.ts). Mirrors the existing adapter design:
  - Accepts typed booleans (forward-compat)
  - Case-insensitive `'true'` / `'false'`
  - Ergonomic alternates: `'yes'` / `'no'` / `'y'` / `'n'` / `'1'` / `'0'` / `'on'` / `'off'`
  - Empty / whitespace-only strings normalize to `undefined` (unfilled-form-field convention)
  - Garbage strings fall through to Zod for structured rejection
- **UPDATED** `gst_irl_ingestion` argsSchema:
  - `requireVerbatimBody`: `z.boolean().optional()` → `booleanFromWire(z.boolean().optional())`
  - `forceTools`: `z.array(z.enum(ORCHESTRATED_TOOLS)).optional()` → `arrayFromWire(z.array(z.enum(ORCHESTRATED_TOOLS)).optional())` (same root-cause bug class; latent, not yet empirically hit)
- **No public contract change.** Typed booleans still parse identically; the schema now ALSO accepts the string forms the wire protocol actually delivers.
- **No prompt body change, no schema change, no manifest hash drift, no body hash rebaseline.**

This PR also includes a cherry-pick of `ac2864b` (extract-irl-markdown CJS interop fix + remove shebang + real-Node CLI tests) which was on PR #248's branch but did NOT make it into master via the squash-merge. The shebang triggered `SyntaxError` under vitest's Vite parser, and the namespace import broke the raw-Node CLI invocation. Without this, `npm run irl:extract` is broken on master.

## Acceptance (in-session)

- **8 new `booleanFromWire` unit tests** at [`tests/unit/prompts/wire-shape.test.ts`](mcp-server/tests/unit/prompts/wire-shape.test.ts): forward-compat boolean pass-through; canonical `'true'`/`'false'`; case-insensitive; whitespace trimming; ergonomic alternates; garbage rejection; non-string rejection; empty-as-undefined.
- **5 new BL-082 regression tests** at [`tests/unit/prompts/irl-ingestion.test.ts`](mcp-server/tests/unit/prompts/irl-ingestion.test.ts) covering the exact failing operator payload: `requireVerbatimBody: 'true'`, `'TRUE'`, `'false'`, `''` (empty), `'definitely'` (garbage).
- **1489 mcp-server tests green**; tsc clean.

## Test plan

- [x] `cd mcp-server && npx tsc --noEmit` — clean
- [x] `cd mcp-server && npx vitest run` — 1489 / 1489 pass
- [ ] **Post-merge operator unblock**: deploy 0.30.4 to staging; retry `/gst_irl_ingestion` with `requireVerbatimBody: TRUE` from the slash-command form. Expected: no `expected boolean, received string` error; workflow proceeds.

## Reserved: BL-083 — ESLint rule

The BL-031.75 / BL-045 prompt registration discipline did not mandate wire-shape coverage for non-string types. Any future `z.boolean()` / `z.number()` / `z.array(...)` / `z.enum(...)` arg added to a registered prompt without going through the matching `*FromWire` adapter is a latent slash-command-UI failure waiting to surface. Reserved as **BL-083**: add ESLint rule (or pre-commit hook) rejecting bare non-string Zod types directly inside a `GstPrompt.argsSchema` literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)