### PR TITLE
fix(mcp): BL-082 follow-up — chain .optional() outside wire-shape wrappers

### DIFF
--- a/mcp-server/src/prompts/irl-ingestion.ts
+++ b/mcp-server/src/prompts/irl-ingestion.ts
@@ -127,12 +127,22 @@ const argsSchema = z.object({
     .describe(
       "Output verbosity. Defaults to 'verbose' (emits per-field provenance footers + schema-validated JSON-fence self-check directives). 'compact' elides both — useful when piping the dossier JSON downstream to automation that does not need the audit prose."
     ),
-  forceTools: arrayFromWire(z.array(z.enum(ORCHESTRATED_TOOLS)).optional()).describe(
-    "Escape hatch — explicit override that bypasses inclusion gates for the listed tool names. Defaults to `[]` (gates fully apply). Use when (a) the partner wants a tool output despite sparse IRL signal, or (b) the partner is refining a single section. Strict enum — accepted values are derived from the prompt's orchestrates array at build time, so an unknown tool name is rejected at parse time."
-  ),
-  requireVerbatimBody: booleanFromWire(z.boolean().optional()).describe(
-    'BL-070 — accuracy-critical run gate. Set TRUE for high-stakes engagements (regulatory deliverable, M&A close, post-mortem) where BL-049 hash-bind authority MUST hold over the partner-supplied source — not the model-reconstructed body. When set, the `compose_dossier_envelope` tool REFUSES any `irlSource !== "partner-paste-verbatim"` with a structured error directing the operator to re-invoke with the IRL pasted as markdown into the `filledIrl` arg. Default unset (false) — drafting / exploration mode where the BL-072 (J) gap-list disclosure is sufficient.'
-  ),
+  // BL-082 follow-up: `.optional()` chained on BOTH the inner schema (so the
+  // wrapper's empty-string-as-undefined path is accepted) AND the outer
+  // ZodEffects wrapper (so Claude Desktop's form-introspection sees a
+  // top-level `ZodOptional` and marks the field as optional in the slash-
+  // command UI — without the outer `.optional()` the form shows it as
+  // required even though Zod's runtime accepts it missing).
+  forceTools: arrayFromWire(z.array(z.enum(ORCHESTRATED_TOOLS)).optional())
+    .optional()
+    .describe(
+      "Escape hatch — explicit override that bypasses inclusion gates for the listed tool names. Defaults to `[]` (gates fully apply). Use when (a) the partner wants a tool output despite sparse IRL signal, or (b) the partner is refining a single section. Strict enum — accepted values are derived from the prompt's orchestrates array at build time, so an unknown tool name is rejected at parse time."
+    ),
+  requireVerbatimBody: booleanFromWire(z.boolean().optional())
+    .optional()
+    .describe(
+      'BL-070 — accuracy-critical run gate. Set TRUE for high-stakes engagements (regulatory deliverable, M&A close, post-mortem) where BL-049 hash-bind authority MUST hold over the partner-supplied source — not the model-reconstructed body. When set, the `compose_dossier_envelope` tool REFUSES any `irlSource !== "partner-paste-verbatim"` with a structured error directing the operator to re-invoke with the IRL pasted as markdown into the `filledIrl` arg. Default unset (false) — drafting / exploration mode where the BL-072 (J) gap-list disclosure is sufficient.'
+    ),
 });
 
 const PROMPT_NAME = 'gst_irl_ingestion';

--- a/mcp-server/src/prompts/wire-shape.ts
+++ b/mcp-server/src/prompts/wire-shape.ts
@@ -146,10 +146,20 @@ function unwrapToEnumOptions(schema: z.ZodTypeAny): readonly string[] {
  * native diagnostic ("Invalid input: expected boolean") still surfaces with
  * an actionable error message.
  *
- * `.optional()` / `.default(...)` MUST be applied to the inner schema —
- * `booleanFromWire(z.boolean().optional())`, NOT
- * `booleanFromWire(z.boolean()).optional()` — for the empty-string path to
- * take effect (the latter sees `""` before the preprocess and mis-rejects).
+ * **Optional fields require `.optional()` chained on BOTH sides** — the
+ * inner schema (so the wrapper's empty-string→undefined path is accepted by
+ * the inner type) AND the outer `ZodEffects` wrapper (so `ZodObject`'s
+ * field-optionality introspection sees a top-level `ZodOptional`, which is
+ * how Claude Desktop's slash-command form decides whether to mark the
+ * field "required" in the UI). The pattern is:
+ *
+ *   field: booleanFromWire(z.boolean().optional()).optional()
+ *
+ * NOT either form alone. Inner-only: object-level "field required" UI
+ * marker stays on (BL-082 follow-up empirically observed 2026-06-07).
+ * Outer-only: the wrapper's `""` → undefined path is rejected by the inner
+ * non-optional schema. Same convention applies to `arrayFromWire` /
+ * `numberFromWire` / `enumFromWire`.
  */
 const TRUE_FORMS = new Set(['true', '1', 'yes', 'y', 'on']);
 const FALSE_FORMS = new Set(['false', '0', 'no', 'n', 'off']);

--- a/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
+++ b/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
@@ -692,6 +692,31 @@ describe('gst_irl_ingestion', () => {
       const r = irlIngestionPrompt.argsSchema.safeParse({ requireVerbatimBody: 'definitely' });
       expect(r.success).toBe(false);
     });
+
+    // BL-082 follow-up: the schema must mark requireVerbatimBody + forceTools
+    // as OPTIONAL at the ZodObject seam so Claude Desktop's slash-command form
+    // doesn't render them as required fields. ZodObject inspects whether each
+    // field's schema is ZodOptional at the TOP level — `booleanFromWire(...)`
+    // returns ZodEffects, not ZodOptional, so the outer `.optional()` chain
+    // is load-bearing for the UI introspection. Without it, the form blocks
+    // the operator from submitting before they fill the field.
+    it('BL-082 follow-up: argsSchema marks requireVerbatimBody as optional at the ZodObject layer (UI introspection)', () => {
+      const shape = irlIngestionPrompt.argsSchema.shape;
+      expect(shape.requireVerbatimBody.isOptional()).toBe(true);
+    });
+
+    it('BL-082 follow-up: argsSchema marks forceTools as optional at the ZodObject layer (UI introspection)', () => {
+      const shape = irlIngestionPrompt.argsSchema.shape;
+      expect(shape.forceTools.isOptional()).toBe(true);
+    });
+
+    it('BL-082 follow-up: argsSchema accepts an entirely empty object (no requireVerbatimBody, no forceTools)', () => {
+      // Regression guard: the original schema (z.boolean().optional() and
+      // z.array(...).optional()) accepted {} cleanly. After the BL-082 wire-
+      // shape wrapping, the {} case MUST remain accepted — otherwise the
+      // slash-command form blocks submission before any fields are filled.
+      expect(irlIngestionPrompt.argsSchema.safeParse({}).success).toBe(true);
+    });
   });
 
   describe('BL-071 — serverToolCallCounts + precheck-derivation directive', () => {


### PR DESCRIPTION
## Summary

Follow-up that was supposed to ship with PR #249 but got pushed AFTER you merged it — sat on the remote branch unmerged. Opening as a separate PR so it's reviewable.

After PR #249, `requireVerbatimBody` and `forceTools` accept the slash-command form's string values correctly (`"TRUE"` parses to `true`, etc.) — but the form UI still shows both fields as **required** because `ZodObject` introspects the field schema's top-level type to determine optionality. `booleanFromWire(z.boolean().optional())` returns `ZodEffects` wrapping `ZodOptional` — Zod's runtime accepts `{}` (so the existing `argsSchema.safeParse({}).success` test passed), but the UI walks `.shape` and sees `ZodEffects`, marks the field "required."

## Fix

Chain `.optional()` on **both** sides:

```ts
forceTools: arrayFromWire(z.array(z.enum(...)).optional()).optional()
requireVerbatimBody: booleanFromWire(z.boolean().optional()).optional()
```

- **Inner** `.optional()`: so the wrapper's empty-string→`undefined` path is accepted by the inner schema
- **Outer** `.optional()`: so `ZodObject.shape.<field>.isOptional()` returns `true` and the UI marks the field as optional

## Acceptance

- **3 new regression tests** at [`tests/unit/prompts/irl-ingestion.test.ts`](mcp-server/tests/unit/prompts/irl-ingestion.test.ts) pinning the contract:
  - `argsSchema.shape.requireVerbatimBody.isOptional() === true`
  - `argsSchema.shape.forceTools.isOptional() === true`
  - `argsSchema.safeParse({}).success === true` (regression guard)
- Updated `booleanFromWire` docstring at [`wire-shape.ts`](mcp-server/src/prompts/wire-shape.ts) to document the both-sides pattern explicitly
- 1492 mcp-server tests green; tsc clean

## Test plan

- [x] `cd mcp-server && npx tsc --noEmit` — clean
- [x] `cd mcp-server && npx vitest run` — 1492 / 1492 pass
- [ ] **Post-merge operator verify**: re-open the `/gst_irl_ingestion` slash-command form in Claude Desktop. Both `requireVerbatimBody` and `forceTools` should now show as optional fields (no required-asterisk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)