### PR TITLE
feat(mcp): BL-079 Part A — validate_irl_provenance body-by-hash (v0.30.5)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -29,6 +29,35 @@ in lockstep when the registry shape changes.
 
 ---
 
+## 0.30.5 — 2026-06-07 — BL-079 Part A: `validate_irl_provenance` body-by-hash
+
+**Theme**: closes the precheck-loop emission damage observed on the 2026-06-07 night staging exercise. Operator paste of a ~50KB IRL body produced `provenanceVerification: { total: 19, verified: 14, unverified: 5, tierMismatches: 1, tierFabrications: 3 }` because `validate_irl_provenance` required the model to re-emit the full body alongside the citations on every precheck iteration — the model's output stream silently dropped ~12% of bytes, and the citation substring matcher then ran against the lossy reconstruction. Part A lets the model pass the canonical 16-hex `irlBodyHash` instead; the server re-hydrates the operator-supplied bytes from the shared `IrlBodyCache` (BL-076 substrate, BL-077c namespace) for matching. The model emits the body to `prepare_irl_body` ONCE per session instead of once per precheck iteration.
+
+Independently fixes the precheck-iteration emission damage — Part B (prompt-render cache pre-pop) is the larger sequel that takes the body off the emission path entirely. See `src/docs/development/MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md` for the full design.
+
+**Surface impact**:
+
+- **UPDATED** `validate_irl_provenance` input schema at [`mcp-server/src/schemas/validate-irl-provenance.ts`]:
+  - `filledIrl`: now **optional** (`z.string().min(200).optional()`). Legacy callers that pass it directly continue to work unchanged.
+  - **NEW** `irlBodyHash`: optional 16-hex hash field (same format as `compose_dossier_envelope.irlBodyHash`). When supplied, the server re-hydrates from `metrics.irlBodyCache` for citation matching.
+  - **NEW** cross-field `.refine` rule: at least one of `filledIrl` / `irlBodyHash` MUST be supplied. The MCP SDK validates only the per-field shape, so the handler enforces this invariant explicitly via a structured `isError: true` response.
+- **UPDATED** handler signature: `handleValidateIrlProvenanceTool(payload, metrics?)`. `metrics` defaults to `NOOP_METRICS_CONTEXT` — existing call sites that pass only the payload continue to work unchanged.
+- **UPDATED** `registerValidateIrlProvenanceTool` now threads its `metrics` argument into the handler so the registered tool can resolve `irlBodyHash` against the shared `IrlBodyCache`. The `MetricsContext.irlBodyCache` plumbing (added in 0.30.0 / BL-076) is the same surface — no new wiring.
+- **NEW** export `RunIrlProvenanceCheckInput` — the engine-internal input type with `filledIrl: string` (required). Distinct from the public `ValidateIrlProvenanceInput` (where `filledIrl` is optional). The handler is the single resolution point: schema parses, handler resolves the body from either source, engine consumes the resolved string.
+- **NEW** export `ValidateIrlProvenanceInputObject` — the underlying ZodObject (no `.refine`) used by `registerTool` for `.shape` exposure. The full schema with `.refine` is still exported as `ValidateIrlProvenanceInputSchema` for explicit parsing in tests.
+- **No prompt-body change**, no manifest hash drift, no body hash rebaseline. Part A is a tool-schema additive expansion only; the prompt directive update lands in Part B (0.31.0).
+- **No public contract removal**. Every legacy `{ filledIrl, citations }` call shape continues to parse + execute identically.
+
+**Acceptance** (in-session):
+
+- 13 new BL-079 schema unit tests at [`tests/unit/schemas/validate-irl-provenance-bl079.test.ts`]: refine rule (all 5 cases per design doc), regex shape (3 cases), per-field optionality on `.shape`, handler cache-hit / cache-miss / both-fields precedence / neither-field defense-in-depth, `Bl076BodyCacheMissError` instanceof contract.
+- 6 new integration tests at [`tests/integration/bl-079-validate-body-by-hash.test.ts`] exercising the `prepare_irl_body → validate_irl_provenance` chain end-to-end: cache write-then-resolve, precheck iteration re-use of the same cached body, cache-miss surfacing `Bl076BodyCacheMissError`, legacy path backward-compat, R-8 compose internal-call seam regression, hash format invariant.
+- 1511 mcp-server tests green; `npx tsc --noEmit` clean.
+
+**What Part B will add** (separate PR, 0.31.0): prompt-render-time cache pre-population (wrapper calls `handlePrepareIrlBodyTool` synchronously from `_registry.ts` when the operator supplied `filledIrl` as a prompt arg), `partner-paste-verbatim-prepop` runScenario taxonomy, BL-070 gate dual-accept, prompt directive surgery instructing the model to skip `prepare_irl_body` entirely when it sees the `**Body-binding hash:**` directive. The model will emit the body ZERO times across the entire partner-paste workflow once Part B ships.
+
+---
+
 ## 0.30.4 — 2026-06-07 — BL-082 `booleanFromWire` for slash-command form interop
 
 **Theme**: closes a structural bug in prompt-argument validation. Per the MCP wire protocol, prompt `arguments` are typed as `Record<string, string>` — every value the client sends is a string regardless of the conceptual type. Claude Desktop's slash-command form renders boolean fields as plain text inputs and ships `"true"` / `"TRUE"` / `"false"` rather than the JSON boolean. Pre-0.30.4, the `gst_irl_ingestion` prompt's `requireVerbatimBody: z.boolean().optional()` field rejected every string form with `expected boolean, received string`. The `arrayFromWire` / `numberFromWire` / `enumFromWire` adapters already existed at [`mcp-server/src/prompts/wire-shape.ts`] for the array / number / enum cases; the boolean case was missing.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/schemas/validate-irl-provenance.ts
+++ b/mcp-server/src/schemas/validate-irl-provenance.ts
@@ -63,12 +63,41 @@ const citationEntrySchema = z.object({
 
 export { citationFieldSchema };
 
-export const ValidateIrlProvenanceInputSchema = z.object({
+/**
+ * BL-079 — body reference may arrive as the verbatim body OR as the 16-hex
+ * canonical hash that re-hydrates from the shared `IrlBodyCache`. Exactly the
+ * same shape as `compose_dossier_envelope.irlBodyHash` (see
+ * `src/schemas/compose-dossier-envelope.ts:57`); duplicated locally to avoid
+ * a circular import between the two schemas.
+ */
+const IRL_BODY_HASH_REGEX = /^[a-f0-9]{16}$/;
+
+/**
+ * Underlying ZodObject (no `.refine`) — exposed so `registerTool` can read
+ * `.shape` for the MCP inputSchema. The `.refine` cross-field rule lives on
+ * `ValidateIrlProvenanceInputSchema` below; the handler explicitly enforces
+ * "at least one of filledIrl / irlBodyHash" since `registerTool` only sees
+ * the per-field shape.
+ */
+export const ValidateIrlProvenanceInputObject = z.object({
   filledIrl: z
     .string()
     .min(200)
+    .optional()
     .describe(
-      'The populated IRL body (markdown), same shape as the gst_irl_ingestion prompt arg. Used as the haystack for excerpt verification.'
+      'The verbatim IRL body (markdown), same shape as the gst_irl_ingestion prompt arg. Used as the haystack for excerpt verification. ' +
+        'BL-079 — now optional. If `irlBodyHash` is supplied AND populated in the server-side IRL body cache (via a prior `prepare_irl_body` call, or BL-079 Part B prompt-render pre-pop), the server re-hydrates the body from cache and `filledIrl` may be omitted. ' +
+        'For interactive / xlsx-reconstruction mode where the cache is not pre-populated, this remains the canonical path. ' +
+        '`filledIrl` takes precedence when both fields are supplied (legacy compatibility for callers that emit both).'
+    ),
+  irlBodyHash: z
+    .string()
+    .regex(IRL_BODY_HASH_REGEX, 'irlBodyHash must be exactly 16 lowercase hex characters')
+    .optional()
+    .describe(
+      'BL-079 — body-by-hash mode. When the operator supplies `filledIrl` as a `gst_irl_ingestion` prompt arg (Part B), the prompt-build wrapper pre-populates the IRL body cache. The model copies the `**Body-binding hash:**` directive verbatim into this field and omits `filledIrl`. ' +
+        'Under Part A (this PR) the model can also pass the hash returned by `prepare_irl_body` to skip emitting the full body twice in the precheck loop. ' +
+        'Server re-hydrates from cache for citation matching. Falls back to `Bl076BodyCacheMissError` if the cache write did not land (operator should retry, or call `prepare_irl_body` to re-seed). For interactive / xlsx-reconstruction mode where the cache is not pre-populated, omit this field and supply `filledIrl` instead.'
     ),
   citations: z
     .array(citationEntrySchema)
@@ -78,7 +107,37 @@ export const ValidateIrlProvenanceInputSchema = z.object({
     ),
 });
 
-export type ValidateIrlProvenanceInput = z.infer<typeof ValidateIrlProvenanceInputSchema>;
+/**
+ * Full input schema with the BL-079 cross-field rule. Use this for explicit
+ * parsing in tests and at any handler boundary that needs the refine
+ * enforced. The MCP SDK consumes `ValidateIrlProvenanceInputObject.shape` at
+ * `registerTool` time, which does NOT carry refine — the handler enforces
+ * the "at least one of filledIrl / irlBodyHash" invariant explicitly.
+ */
+export const ValidateIrlProvenanceInputSchema = ValidateIrlProvenanceInputObject.refine(
+  (input) => Boolean(input.filledIrl) || Boolean(input.irlBodyHash),
+  {
+    message:
+      'BL-079 — at least one of `filledIrl` / `irlBodyHash` MUST be supplied. ' +
+      'Body-by-hash path: pass `irlBodyHash` alone (server re-hydrates from the IrlBodyCache populated by `prepare_irl_body` or the BL-079 prompt-render pre-pop). ' +
+      'Legacy interactive / xlsx-reconstruction path: pass `filledIrl` alone. ' +
+      'Both allowed — `filledIrl` takes precedence when present (legacy callers).',
+  }
+);
+
+export type ValidateIrlProvenanceInput = z.infer<typeof ValidateIrlProvenanceInputObject>;
+
+/**
+ * BL-079 — engine-internal input shape. The public schema makes `filledIrl`
+ * optional (the handler may resolve it from the IRL body cache via
+ * `irlBodyHash`); the pure-function engine still requires the body as a
+ * non-empty string. The handler is the single resolution point between the
+ * two — schema parses, handler resolves, engine matches.
+ */
+export interface RunIrlProvenanceCheckInput {
+  filledIrl: string;
+  citations: ValidateIrlProvenanceInput['citations'];
+}
 
 export interface ValidateIrlProvenanceVerdict {
   path: string;
@@ -297,7 +356,7 @@ function aggregateArrayVerdict(
  * verdicts to its emitted citation structure unchanged.
  */
 export function runIrlProvenanceCheck(
-  input: ValidateIrlProvenanceInput
+  input: RunIrlProvenanceCheckInput
 ): ValidateIrlProvenanceResult {
   const haystackNorm = normalizeForMatching(input.filledIrl);
   const haystackWords = haystackNorm.split(' ').filter((w) => w.length > 0);

--- a/mcp-server/src/tools/validate-irl-provenance.ts
+++ b/mcp-server/src/tools/validate-irl-provenance.ts
@@ -9,25 +9,38 @@
  * verdict array the model uses to populate (J) gap list entries for
  * unverified claims.
  *
+ * BL-079 Part A — the handler now accepts either `filledIrl` directly OR
+ * an `irlBodyHash` that resolves against the shared `IrlBodyCache` (the
+ * same cache `prepare_irl_body` writes to and `compose_dossier_envelope`
+ * reads from). When only the hash is supplied, the server re-hydrates the
+ * body from cache for citation matching — closing the precheck-loop
+ * emission damage observed on the 2026-06-07 night exercise (50KB body
+ * emitted to validate twice per iteration, losing ~12% of bytes each
+ * time, producing 5/19 unverified citations against the lossy bytes).
+ *
  * See: src/schemas/validate-irl-provenance.ts for the matching engine.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { NOOP_METRICS_CONTEXT, withToolMetrics, type MetricsContext } from '../metrics/_index';
 import {
-  ValidateIrlProvenanceInputSchema,
+  ValidateIrlProvenanceInputObject,
   runIrlProvenanceCheck,
   type ValidateIrlProvenanceInput,
 } from '../schemas/validate-irl-provenance';
+import { Bl076BodyCacheMissError } from '../schemas/compose-dossier-envelope';
 
 const TOOL_DESCRIPTION = `Verify that citations the model emitted (in \`_audit\` blocks, the (K) provenance footer, etc.) actually appear in the supplied filled IRL.
 
 **Why call this**: the BL-045 calibration audit refines structural shape but cannot verify excerpt truthfulness — a model that obeys every audit rule can still fabricate the excerpt itself. This tool closes that gap by substring-matching every cited excerpt against the IRL body.
 
-**Inputs**:
+**Inputs** (BL-079 — \`filledIrl\` is now optional; supply EITHER):
 
-- \`filledIrl\` — the populated IRL body, same shape as the \`gst_irl_ingestion\` prompt arg.
+- \`filledIrl\` — the populated IRL body, same shape as the \`gst_irl_ingestion\` prompt arg. Legacy path; still works.
+- \`irlBodyHash\` — the 16-hex \`sha256(body).slice(0,16)\` value (same shape as \`compose_dossier_envelope.irlBodyHash\`). When supplied alone, the server re-hydrates the body from the shared IRL body cache (populated by \`prepare_irl_body\` or BL-079 Part B prompt-render pre-pop). Use this path to avoid emitting the full body twice in the precheck loop — material wall-clock savings on bodies > ~10KB.
 - \`citations\` — array of \`{ path, citation }\` pairs. \`path\` identifies the claim site in your dossier (e.g., \`_audit.revenueRange.citation\`, \`section-C.headline\`); \`citation\` is the string you emitted (e.g., \`"Section 00 row 10 — Recurring revenue $2.64M CAD/mo Apr-2026"\`).
+
+At least one of \`filledIrl\` / \`irlBodyHash\` MUST be supplied. \`filledIrl\` takes precedence when both are present (legacy compatibility).
 
 **Outputs**: per-citation verdict in one of four buckets:
 
@@ -41,16 +54,64 @@ The tool is pure (no engine call, no Hub URLs). Call it during your (K) provenan
 /**
  * Handler exported so integration tests can exercise the full pipeline
  * without going through the MCP transport.
+ *
+ * BL-079 Part A — accepts a `metrics` argument so the handler can resolve
+ * `irlBodyHash` against `metrics.irlBodyCache`. Defaults to
+ * `NOOP_METRICS_CONTEXT` so the existing call sites + unit tests that pass
+ * `filledIrl` directly continue to work unchanged.
  */
-export async function handleValidateIrlProvenanceTool(payload: ValidateIrlProvenanceInput) {
+export async function handleValidateIrlProvenanceTool(
+  payload: ValidateIrlProvenanceInput,
+  metrics: MetricsContext = NOOP_METRICS_CONTEXT
+) {
   try {
-    const result = runIrlProvenanceCheck(payload);
+    // BL-079 Part A — resolve the body. `filledIrl` takes precedence when
+    // present (legacy callers that emit both fields); otherwise re-hydrate
+    // from the shared IrlBodyCache via `irlBodyHash`. The schema's `.refine`
+    // rule guarantees at least one of the two is set, so the final else
+    // branch is unreachable in practice — but we narrow defensively so the
+    // engine never receives `undefined`.
+    let filledIrl: string;
+    if (payload.filledIrl) {
+      filledIrl = payload.filledIrl;
+    } else if (payload.irlBodyHash) {
+      const cached = await metrics.irlBodyCache?.get(payload.irlBodyHash);
+      if (!cached) {
+        throw new Bl076BodyCacheMissError(payload.irlBodyHash);
+      }
+      filledIrl = cached;
+    } else {
+      // BL-079 — the MCP SDK validates the per-field shape but not the
+      // cross-field refine rule (it consumes `inputSchema.shape`, not the
+      // refined schema). Enforce "at least one of filledIrl / irlBodyHash"
+      // here so the engine never receives `undefined`.
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              'validate_irl_provenance: at least one of `filledIrl` / `irlBodyHash` MUST be supplied. ' +
+              'Body-by-hash path (BL-079): pass `irlBodyHash` alone after `prepare_irl_body` has seeded the cache. ' +
+              'Legacy path: pass `filledIrl` directly.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const result = runIrlProvenanceCheck({ filledIrl, citations: payload.citations });
     const text = JSON.stringify(result, null, 2);
     return {
       content: [{ type: 'text' as const, text }],
       structuredContent: result as unknown as Record<string, unknown>,
     };
   } catch (error) {
+    if (error instanceof Bl076BodyCacheMissError) {
+      return {
+        content: [{ type: 'text' as const, text: error.message }],
+        isError: true,
+      };
+    }
     const message = error instanceof Error ? error.message : String(error);
     return {
       content: [{ type: 'text' as const, text: `Failed to validate IRL provenance: ${message}` }],
@@ -68,8 +129,10 @@ export function registerValidateIrlProvenanceTool(
     {
       title: 'Validate IRL provenance',
       description: TOOL_DESCRIPTION,
-      inputSchema: ValidateIrlProvenanceInputSchema.shape,
+      inputSchema: ValidateIrlProvenanceInputObject.shape,
     },
-    withToolMetrics('validate_irl_provenance', metrics, handleValidateIrlProvenanceTool)
+    withToolMetrics('validate_irl_provenance', metrics, (payload: ValidateIrlProvenanceInput) =>
+      handleValidateIrlProvenanceTool(payload, metrics)
+    )
   );
 }

--- a/mcp-server/tests/integration/bl-079-validate-body-by-hash.test.ts
+++ b/mcp-server/tests/integration/bl-079-validate-body-by-hash.test.ts
@@ -1,0 +1,161 @@
+/**
+ * BL-079 Part A — `prepare_irl_body` → `validate_irl_provenance` body-by-hash
+ * integration test.
+ *
+ * Exercises the end-to-end flow the model uses in production once Part A
+ * ships: the model emits the IRL body to `prepare_irl_body` ONCE, receives
+ * the canonical 16-hex hash, and then passes only the hash to subsequent
+ * `validate_irl_provenance` calls in the precheck loop. The server re-
+ * hydrates the operator-supplied bytes from the shared `IrlBodyCache` and
+ * runs citation matching against them — closing the 2026-06-07 night
+ * exercise's 5/19 unverified citations + tier-mismatches damage.
+ *
+ * Tests assert:
+ *   1. `prepare_irl_body` writes to the cache.
+ *   2. `validate_irl_provenance({ irlBodyHash, citations })` resolves to a
+ *      successful verdict using the cached body.
+ *   3. The same cache + hash can be re-used across multiple validate calls
+ *      (the precheck iteration pattern — model retries with refined
+ *      citations after each verdict).
+ *   4. A cache miss (TTL expiry / eviction) surfaces `Bl076BodyCacheMissError`
+ *      so the model can fall back to re-calling `prepare_irl_body`.
+ *   5. Backward-compat: the same handler still accepts `{ filledIrl, citations }`
+ *      directly (no cache wiring needed for the legacy path).
+ *   6. R-8 — `compose_dossier_envelope`'s internal `runIrlProvenanceCheck`
+ *      call still validates under the BL-079 schema expansion (engine takes
+ *      `{filledIrl, citations}` directly; not affected by the public-input
+ *      schema's optionality).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { handlePrepareIrlBodyTool } from '../../src/tools/prepare-irl-body';
+import { handleValidateIrlProvenanceTool } from '../../src/tools/validate-irl-provenance';
+import { InMemoryIrlBodyCache } from '../../src/cache/irl-body-cache';
+import { runIrlProvenanceCheck } from '../../src/schemas/validate-irl-provenance';
+import { computeIrlBodyHash } from '../../src/schemas/compose-dossier-envelope';
+import type { MetricsContext } from '../../src/metrics/_index';
+
+const SAMPLE_IRL = `# Information Request List — Acme (returned, 2026-06-03)
+
+## 00 — Basics
+
+- Annual recurring revenue: $45.2M Q1-FY26 annualized; $31.4M trailing 12 months
+- Geographies: US (East Coast, Texas, California), EU (Germany, France, Netherlands)
+- Total headcount: 187 today; 121 twelve months ago
+- Year-over-year growth rate: Revenue 62% YoY; headcount 55% YoY
+
+## 02 — Software Architecture
+
+- Engineering FTE count: 58 total — 38 product, 8 SRE, 3 security, 7 data, 2 platform
+- Stack: TypeScript Node 22, Python 3.12, Aurora Postgres 15, Redshift on AWS
+`;
+
+const CITATIONS = [
+  { path: 'sec-A.headline', citation: 'Section 00 — Annual recurring revenue: $45.2M' },
+  { path: 'sec-B.headline', citation: 'Section 02 — Engineering FTE count: 58 total' },
+];
+
+function metricsWith(cache: InMemoryIrlBodyCache): MetricsContext {
+  return {
+    sink: { write: () => undefined },
+    irlBodyCache: cache,
+  };
+}
+
+describe('BL-079 Part A — prepare → validate body-by-hash chain', () => {
+  it('prepare_irl_body writes the body to cache; validate_irl_provenance re-hydrates via irlBodyHash', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    const metrics = metricsWith(cache);
+
+    // Step 1 — model calls prepare_irl_body with the full body.
+    const prepareResult = await handlePrepareIrlBodyTool({ filledIrl: SAMPLE_IRL }, metrics);
+    expect(prepareResult.isError).toBeUndefined();
+    const prepared = prepareResult.structuredContent as { irlBodyHash: string; byteLength: number };
+    expect(prepared.irlBodyHash).toMatch(/^[a-f0-9]{16}$/);
+
+    // The cache MUST now contain the body keyed by the canonical hash.
+    expect(cache.size()).toBe(1);
+
+    // Step 2 — model calls validate with ONLY the hash. Server re-hydrates.
+    const validateResult = await handleValidateIrlProvenanceTool(
+      { irlBodyHash: prepared.irlBodyHash, citations: CITATIONS },
+      metrics
+    );
+    expect(validateResult.isError).toBeUndefined();
+    const verdict = validateResult.structuredContent as Record<string, unknown> & {
+      total: number;
+      verified: number;
+    };
+    expect(verdict.total).toBe(2);
+    expect(verdict.verified).toBe(2);
+  });
+
+  it('multiple validate calls with the same hash re-use the cached body (precheck iteration pattern)', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    const metrics = metricsWith(cache);
+    const prepared = await handlePrepareIrlBodyTool({ filledIrl: SAMPLE_IRL }, metrics);
+    const hash = (prepared.structuredContent as { irlBodyHash: string }).irlBodyHash;
+
+    // Three rounds of validate, simulating the precheck iteration loop.
+    for (let i = 0; i < 3; i++) {
+      const result = await handleValidateIrlProvenanceTool(
+        { irlBodyHash: hash, citations: CITATIONS },
+        metrics
+      );
+      expect(result.isError).toBeUndefined();
+      const v = result.structuredContent as { verified: number };
+      expect(v.verified).toBe(2);
+    }
+  });
+
+  it('cache miss surfaces Bl076BodyCacheMissError so the model can re-call prepare_irl_body', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    const metrics = metricsWith(cache);
+    // Operator-supplied hash but cache was never seeded (simulates TTL
+    // expiry or eviction).
+    const orphanHash = computeIrlBodyHash(SAMPLE_IRL);
+
+    const result = await handleValidateIrlProvenanceTool(
+      { irlBodyHash: orphanHash, citations: CITATIONS },
+      metrics
+    );
+    expect(result.isError).toBe(true);
+    const text = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+    expect(text).toMatch(/BL-076 body-cache miss/);
+    expect(text).toMatch(/prepare_irl_body/);
+  });
+
+  it('legacy path: handler still accepts { filledIrl, citations } directly with no cache wiring', async () => {
+    // No irlBodyCache in metrics — proves the legacy path doesn't depend on it.
+    const result = await handleValidateIrlProvenanceTool({
+      filledIrl: SAMPLE_IRL,
+      citations: CITATIONS,
+    });
+    expect(result.isError).toBeUndefined();
+    const v = result.structuredContent as { verified: number };
+    expect(v.verified).toBe(2);
+  });
+
+  it('R-8 — compose internal-call seam: runIrlProvenanceCheck engine input still validates with {filledIrl, citations}', () => {
+    // The compose handler's internal call site at compose-dossier-envelope.ts
+    // builds `{ filledIrl, citations }` and calls runIrlProvenanceCheck. The
+    // engine type is now `RunIrlProvenanceCheckInput` (filledIrl REQUIRED)
+    // — distinct from the public schema where filledIrl is optional. Assert
+    // the engine accepts the shape the compose seam emits unchanged.
+    const verdict = runIrlProvenanceCheck({
+      filledIrl: SAMPLE_IRL,
+      citations: CITATIONS,
+    });
+    expect(verdict.total).toBe(2);
+    expect(verdict.verified).toBe(2);
+  });
+
+  it('hash format invariant: computeIrlBodyHash yields canonical 16-hex lowercase', () => {
+    // The same hash function powers `prepare_irl_body` (writer) and the
+    // validate body-by-hash lookup. Asserting the format invariant guards
+    // against a future hash-function drift that would silently miss the
+    // cache.
+    const h = computeIrlBodyHash(SAMPLE_IRL);
+    expect(h).toMatch(/^[a-f0-9]{16}$/);
+  });
+});

--- a/mcp-server/tests/unit/schemas/validate-irl-provenance-bl079.test.ts
+++ b/mcp-server/tests/unit/schemas/validate-irl-provenance-bl079.test.ts
@@ -1,0 +1,193 @@
+/**
+ * BL-079 Part A — `validate_irl_provenance` body-by-hash schema tests.
+ *
+ * Covers the cross-field rule + the `irlBodyHash` shape + the handler-side
+ * cache-resolution path. These tests are the contract that closes the
+ * 2026-06-07 night exercise's precheck-loop emission damage: the model can
+ * pass only the 16-hex hash; the server re-hydrates the operator-supplied
+ * bytes for citation matching.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  ValidateIrlProvenanceInputObject,
+  ValidateIrlProvenanceInputSchema,
+} from '../../../src/schemas/validate-irl-provenance';
+import { handleValidateIrlProvenanceTool } from '../../../src/tools/validate-irl-provenance';
+import { InMemoryIrlBodyCache } from '../../../src/cache/irl-body-cache';
+import { Bl076BodyCacheMissError } from '../../../src/schemas/compose-dossier-envelope';
+import type { MetricsContext } from '../../../src/metrics/_index';
+
+const SAMPLE_IRL = `# Information Request List — Acme (returned, 2026-06-03)
+
+## 00 — Basics
+
+- Annual recurring revenue: $45.2M Q1-FY26 annualized; $31.4M trailing 12 months
+- Geographies: US (East Coast, Texas, California), EU (Germany, France, Netherlands)
+- Total headcount: 187 today; 121 twelve months ago
+
+## 02 — Software Architecture
+
+- Engineering FTE count: 58 total — 38 product, 8 SRE, 3 security, 7 data, 2 platform
+- Stack: TypeScript Node 22, Python 3.12, Aurora Postgres 15, Redshift on AWS
+`;
+
+const SAMPLE_HASH = createHash('sha256').update(SAMPLE_IRL).digest('hex').slice(0, 16);
+
+const SAMPLE_CITATIONS = [
+  { path: 'sec-A.headline', citation: 'Section 00 — Annual recurring revenue: $45.2M' },
+];
+
+function noopMetrics(cache?: InMemoryIrlBodyCache): MetricsContext {
+  return {
+    sink: { write: () => undefined },
+    ...(cache ? { irlBodyCache: cache } : {}),
+  };
+}
+
+describe('BL-079 — ValidateIrlProvenanceInputSchema cross-field rule', () => {
+  it('accepts `{ irlBodyHash, citations }` alone (body-by-hash mode)', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      irlBodyHash: SAMPLE_HASH,
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts `{ filledIrl, citations }` alone (legacy mode)', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      filledIrl: SAMPLE_IRL,
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts both fields (legacy + body-by-hash; filledIrl precedence)', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      filledIrl: SAMPLE_IRL,
+      irlBodyHash: SAMPLE_HASH,
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when neither filledIrl nor irlBodyHash is supplied', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/at least one of/i);
+    }
+  });
+
+  it('rejects irlBodyHash that does not match the 16-hex regex', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      irlBodyHash: 'not-a-hash',
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects irlBodyHash with wrong length (too long)', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      irlBodyHash: 'a'.repeat(17),
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects irlBodyHash with uppercase hex (canonical lowercase only)', () => {
+    const result = ValidateIrlProvenanceInputSchema.safeParse({
+      irlBodyHash: SAMPLE_HASH.toUpperCase(),
+      citations: SAMPLE_CITATIONS,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('BL-079 — ValidateIrlProvenanceInputObject `.shape` exposure', () => {
+  it('exposes both filledIrl and irlBodyHash as optional fields for MCP registerTool', () => {
+    // The underlying ZodObject's `.shape` is what `registerTool` consumes
+    // for the published inputSchema. Both fields MUST be present and
+    // optional so the slash-command form does not mark them required.
+    const shape = ValidateIrlProvenanceInputObject.shape;
+    expect(shape.filledIrl.isOptional()).toBe(true);
+    expect(shape.irlBodyHash.isOptional()).toBe(true);
+    // `citations` stays required.
+    expect(shape.citations.isOptional()).toBe(false);
+  });
+});
+
+describe('BL-079 — handleValidateIrlProvenanceTool cache-resolution path', () => {
+  it('resolves irlBodyHash via cache and runs citation matching against re-hydrated body', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    await cache.set(SAMPLE_HASH, SAMPLE_IRL);
+    const result = await handleValidateIrlProvenanceTool(
+      {
+        irlBodyHash: SAMPLE_HASH,
+        citations: SAMPLE_CITATIONS,
+      },
+      noopMetrics(cache)
+    );
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as Record<string, unknown>;
+    expect(structured.total).toBe(1);
+    expect(structured.verified).toBe(1);
+  });
+
+  it('returns Bl076BodyCacheMissError isError when irlBodyHash supplied but cache misses', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    // Note: cache is empty — hash will miss.
+    const result = await handleValidateIrlProvenanceTool(
+      {
+        irlBodyHash: SAMPLE_HASH,
+        citations: SAMPLE_CITATIONS,
+      },
+      noopMetrics(cache)
+    );
+    expect(result.isError).toBe(true);
+    const text = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+    expect(text).toMatch(/BL-076 body-cache miss/);
+    expect(text).toMatch(SAMPLE_HASH);
+  });
+
+  it('prefers filledIrl when both fields are supplied (legacy precedence)', async () => {
+    const cache = new InMemoryIrlBodyCache();
+    // Seed cache with DIFFERENT bytes than filledIrl, then assert the
+    // verdict matches filledIrl's body — proving filledIrl was used, not
+    // the cache.
+    await cache.set(SAMPLE_HASH, '# DIFFERENT BODY — citation should NOT match here.');
+    const result = await handleValidateIrlProvenanceTool(
+      {
+        filledIrl: SAMPLE_IRL,
+        irlBodyHash: SAMPLE_HASH,
+        citations: SAMPLE_CITATIONS,
+      },
+      noopMetrics(cache)
+    );
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as Record<string, unknown>;
+    expect(structured.verified).toBe(1);
+  });
+
+  it('returns structured isError when neither field is supplied (defense-in-depth past the SDK shape check)', async () => {
+    const result = await handleValidateIrlProvenanceTool(
+      // Bypass the schema refine — simulate the SDK letting through a
+      // payload that only matches the per-field shape (which has both
+      // fields optional). Handler must catch this and return isError.
+      { citations: SAMPLE_CITATIONS } as Parameters<typeof handleValidateIrlProvenanceTool>[0],
+      noopMetrics()
+    );
+    expect(result.isError).toBe(true);
+    const text = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+    expect(text).toMatch(/at least one of/i);
+  });
+
+  it('Bl076BodyCacheMissError is the canonical class — instanceof check holds', () => {
+    const err = new Bl076BodyCacheMissError(SAMPLE_HASH);
+    expect(err).toBeInstanceOf(Bl076BodyCacheMissError);
+    expect(err.irlBodyHash).toBe(SAMPLE_HASH);
+  });
+});

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -3901,7 +3901,7 @@ The bug is operator-visible (block carries the fabricated list) but not partner-
 
 ---
 
-### BL-079: Server-side body delivery via prompt-arg + body-by-hash on `validate_irl_provenance` ⏳ OPEN — design audit-passed 2026-06-07
+### BL-079: Server-side body delivery via prompt-arg + body-by-hash on `validate_irl_provenance` 🔧 IN PROGRESS — Part A shipping 2026-06-07 (0.30.5); Part B pending operator verification
 
 **Design doc**: [MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md](MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md) — full architecture, schema diffs, capability-preservation matrix, audit-folded revisions, split-PR plan. Ready for operator approval to start Part A implementation.
 
@@ -3909,7 +3909,7 @@ The bug is operator-visible (block carries the fabricated list) but not partner-
 
 **Ship cadence** (per audit): split into two PRs with operator-verification checkpoint between them.
 
-- **Part A** (next, ~1 day): `validate_irl_provenance` schema expansion + handler re-hydration. Independently fixes the precheck-loop emission damage (the 5 unverified + 1 tier-mismatch + 3 tier-fabrications observed tonight stop being possible). Operator can manually orchestrate prepare → validate-by-hash. Ships as patch 0.30.5.
+- **Part A** ✅ shipped 0.30.5 (2026-06-07): `validate_irl_provenance` schema expansion (`filledIrl` now optional, `irlBodyHash` added as 16-hex optional field, cross-field `.refine` rule) + handler re-hydration via `metrics.irlBodyCache.get(irlBodyHash)`. Engine signature split: public `ValidateIrlProvenanceInput` allows omitted `filledIrl`; new internal `RunIrlProvenanceCheckInput` keeps the engine pure. Backward-compat preserved — every legacy `{filledIrl, citations}` caller continues to work unchanged. 13 schema unit tests + 6 integration tests (prepare → validate body-by-hash chain, precheck-iteration cache reuse, cache-miss surfaces `Bl076BodyCacheMissError`, R-8 compose internal-call seam regression). Independently fixes the precheck-loop emission damage — under Part A alone, the operator manually orchestrates `prepare_irl_body` then `validate_irl_provenance({irlBodyHash, citations})` and the 5 unverified + 1 tier-mismatch + 3 tier-fabrications observed tonight stop being possible.
 - **Part B** (after A merges + operator validates, ~1.5–2 days): prompt-render-time cache pre-pop via sync await + `handlePrepareIrlBodyTool` reuse (Alt-D pattern — free BL-077a/b/c diagnostics) + prompt directive surgery + `runScenario: partner-paste-verbatim-prepop` + BL-070 gate dual-accept + `serverCachedBodyBytes` field for VERIFY `filledIrl.bytes` semantic correctness. Ships as minor 0.31.0 with manifest + 3 body hash rebaselines.
 
 **Problem**: post-BL-076 / BL-077c, the body-by-hash mechanism works end-to-end on small (5-10KB) bodies but fails on production-realistic ones. The 2026-06-07 staging exercise on a 77,743-byte body showed the model's tool-call args emission truncated at ~1,753 bytes (2.3%). `prepare_irl_body` cached a partial body; the model self-detected the hash mismatch and halted the run. Same emission ceiling affects `validate_irl_provenance` — its `filledIrl` arg requires the model to emit the full body for citation substring-matching.


### PR DESCRIPTION
## Summary

- `validate_irl_provenance` now accepts the canonical 16-hex `irlBodyHash` instead of (or alongside) `filledIrl`. Server re-hydrates the body from the shared `IrlBodyCache` (BL-076 substrate, BL-077c namespace) for citation matching.
- Closes the precheck-loop emission damage observed on the 2026-06-07 night exercise: 50KB paste produced `provenanceVerification: { unverified: 5, tierMismatches: 1, tierFabrications: 3 }` because the model re-emitted the body on every precheck iteration and shed ~12% of bytes each time. Under Part A, the model emits the body ONCE to `prepare_irl_body`, then passes only the hash to validate.
- Part A is shippable on its own — operator manually orchestrates prepare → validate-by-hash. Part B (prompt-render cache pre-pop) ships separately as 0.31.0 with the prompt-directive surgery + `partner-paste-verbatim-prepop` runScenario.

## Design

See [`src/docs/development/MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md`](src/docs/development/MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md) — audit-passed, all 10 audit revisions folded in. Ship cadence section (Part A / Part B split + per-part scope) matches this PR's contents exactly.

## Schema changes

- `filledIrl`: now **optional** on `ValidateIrlProvenanceInputSchema`. Legacy callers passing it directly continue to work unchanged.
- **NEW** `irlBodyHash`: optional 16-hex hash field, same shape as `compose_dossier_envelope.irlBodyHash`.
- **NEW** cross-field `.refine` rule: at least one of `{filledIrl, irlBodyHash}` MUST be supplied. The MCP SDK validates per-field shape only — the handler enforces the cross-field invariant explicitly and returns structured `isError: true` if neither was supplied.
- **NEW** export `ValidateIrlProvenanceInputObject` (ZodObject sans refine) for `registerTool.shape` consumption.
- **NEW** export `RunIrlProvenanceCheckInput` (engine-internal type, `filledIrl: string` required) — keeps the pure engine's invariant unchanged while the public schema relaxes.

## Handler changes

- `handleValidateIrlProvenanceTool(payload, metrics?)` — `metrics` defaults to `NOOP_METRICS_CONTEXT`. Backward-compatible for the BL-071 test surface that passes the handler as a bare function reference.
- Resolves `irlBodyHash` via `metrics.irlBodyCache?.get(...)`; cache miss throws `Bl076BodyCacheMissError` (reused class, not renamed — backward-compat win).
- `filledIrl` takes precedence when both fields are supplied (legacy callers emitting both).

## Tests

- **13** new schema unit tests at [`tests/unit/schemas/validate-irl-provenance-bl079.test.ts`](mcp-server/tests/unit/schemas/validate-irl-provenance-bl079.test.ts) — refine rule (5 cases per design doc), regex shape (3 cases incl. uppercase/length), `.shape` per-field optionality, cache hit/miss/precedence, defense-in-depth neither-field path.
- **6** new integration tests at [`tests/integration/bl-079-validate-body-by-hash.test.ts`](mcp-server/tests/integration/bl-079-validate-body-by-hash.test.ts) — `prepare_irl_body → validate_irl_provenance` chain end-to-end, multi-call precheck-iteration cache reuse, cache-miss `Bl076BodyCacheMissError`, legacy `{filledIrl, citations}` backward-compat, **R-8** compose internal-call seam regression, hash format invariant.
- **1511** mcp-server tests green; `npx tsc --noEmit` clean.

## What ships in Part B (next PR, 0.31.0)

- `_registry.ts` wrapper sync-await pre-pop via `handlePrepareIrlBodyTool` reuse (Alt-D pattern — inherits BL-077a/b/c diagnostics)
- Prompt directive surgery at both invocation sites — "skip `prepare_irl_body` when you see the `**Body-binding hash:**` directive"
- VERIFY taxonomy: `runScenario: partner-paste-verbatim-prepop`
- BL-070 gate dual-accept (`partner-paste-verbatim` OR `partner-paste-verbatim-prepop`)
- `serverCachedBodyBytes` field on compose output for `filledIrl.bytes` semantic correctness
- Manifest + 3 body hash rebaselines

## Backward compatibility

- No public contract removal — every legacy `{filledIrl, citations}` call parses + executes identically.
- No prompt-body change.
- No manifest hash drift.
- No body hash rebaseline.
- Tool-schema additive expansion only.

## Test plan

- [ ] Merge to master → staging auto-deploys to `gst-mcp-staging`
- [ ] Operator manually exercises: call `prepare_irl_body` with a >10KB body → call `validate_irl_provenance({ irlBodyHash, citations })` with hash alone → verify `verified` count matches what the legacy path produced
- [ ] Verify `Bl076BodyCacheMissError` surfaces correctly when the operator passes an orphan hash (no prior prepare)
- [ ] Spot-check: legacy `{filledIrl, citations}` call still works against staging
- [ ] After Part A operator-verification clean → start Part B implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)