### PR TITLE
fix(techpar): restore branded input styling on the Costs tab

### DIFF
--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -1480,9 +1480,19 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
   }
 
   /* TechPar inputs inherit brutal-field__input base styles via scoped selector.
-     Default padding-left accommodates the $ prefix on most fields. */
-  .brutal-tool-shell--fluid input[type='number'],
-  .brutal-tool-shell--fluid input[data-arr-display] {
+     Default padding-left accommodates the $ prefix on most fields.
+
+     The input matchers are :global() for the same reason as the .tp-arr-chip
+     block below: the Costs-tab inputs are rendered by <PresetInput>
+     (src/components/techpar/PresetInput.astro), which carries its own Astro
+     scope hash. Without :global() on the input, Astro appends index.astro's
+     hash and the component-rendered inputs fall back to unstyled native number
+     fields (black border + spin buttons) — visible regression on the Costs tab.
+     The container (.brutal-tool-shell--fluid, in-file at the top of this page)
+     stays scoped, so the rule is still confined to this tool's shell. The
+     in-file ARR input (input[data-arr-display]) matches either way. */
+  .brutal-tool-shell--fluid :global(input[type='number']),
+  .brutal-tool-shell--fluid :global(input[data-arr-display]) {
     width: 100%;
     background: transparent;
     border: 2px dashed light-dark(var(--border-light), var(--border-dark-default));
@@ -1498,12 +1508,12 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
     border-radius: 0;
   }
 
-  .brutal-tool-shell--fluid input[type='number']::-webkit-inner-spin-button {
+  .brutal-tool-shell--fluid :global(input[type='number']::-webkit-inner-spin-button) {
     appearance: none;
   }
 
-  .brutal-tool-shell--fluid input[type='number']:focus,
-  .brutal-tool-shell--fluid input[data-arr-display]:focus {
+  .brutal-tool-shell--fluid :global(input[type='number']:focus),
+  .brutal-tool-shell--fluid :global(input[data-arr-display]:focus) {
     border-color: var(--color-primary);
     border-style: solid;
   }


### PR DESCRIPTION
## Problem

On the TechPar **Costs** tab, the input fields (Monthly Cloud Spend, Infrastructure Personnel, R&D OpEx, etc.) rendered with native browser styling — black border + number spin buttons — instead of the branded dashed-border / mono / `$`-prefix style used by the **Profile** tab's ARR input.

## Root cause

TechPar applies its input base styling through a **scoped element selector** (`.brutal-tool-shell--fluid input[type='number']`) rather than a class. BL-042 extracted the Costs-tab inputs into `PresetInput.astro`, so those inputs took on the **component's** Astro scope hash — and index.astro's scoped selector stopped matching them, dropping all styling. The Profile ARR input is still hand-written *in* index.astro, so it kept its hash and stayed styled.

This is the same scoping trap already documented and fixed for the `.tp-arr-chip` chips in this file — the fix had simply never been extended to the input selectors.

## Fix

Wrap the input matchers in `:global()` so they reach the component-rendered inputs, while keeping the `.brutal-tool-shell--fluid` container **scoped** so the rule stays confined to this page (no leak to other hub tools using the same shell class). CSS-only — no markup, class, or behavior changes, so existing selectors / E2E are untouched.

## Verification

- Compiled CSS confirms the intended shape: container keeps its scope hash (`.brutal-tool-shell--fluid[data-astro-cid-…]`), input matcher is un-hashed → now matches the `PresetInput`-rendered Costs-tab inputs.
- `npm run build`, `npm run lint:css`, and `npx astro check` (0 errors) all clean.
- Visually verified by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
