### PR TITLE
fix(stylelint): disable no-invalid-position-declaration for .astro files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -78,6 +78,7 @@
         "at-rule-no-unknown": [true, { "ignoreAtRules": ["import", "layer"] }],
         "no-descending-specificity": [true, { "severity": "warning" }],
         "selector-max-specificity": ["0,4,1", { "severity": "warning" }],
+        "no-invalid-position-declaration": null,
         "max-nesting-depth": [3, { "ignoreAtRules": ["media", "supports", "container"] }],
         "selector-max-compound-selectors": 4,
         "declaration-block-no-shorthand-property-overrides": true,

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -328,6 +328,10 @@ The override block in `.stylelintrc.json`:
 
 The base rules are duplicated inside the `.astro` override because stylelint's `extends` + `overrides` interaction does not inherit rules from the parent config. Keep the two rule sets in sync when editing.
 
+#### `no-invalid-position-declaration` disabled in the `.astro` override only
+
+The `.astro` override sets `"no-invalid-position-declaration": null`, while the base config (plain `.css`) leaves it enabled. As of stylelint 17.13.0 this rule fires false positives on HTML **inline `style="…"` attributes** in `.astro` markup (an inline style is declaration-only, so "declaration after a nested rule" is nonsensical there) — it flagged 983 such attributes across 17 components with zero real `.css` violations, and `--fix` cannot resolve them. This surfaced as a hard `lint:css` failure on every Dependabot dev-dependency bump that pulled stylelint ≥17.13 (e.g. PRs #263, #267). Suppressing it for `.astro` unblocks those bumps while keeping the rule active for real stylesheets. Re-enable once the upstream inline-style false positive is fixed.
+
 ### Running stylelint
 
 ```bash


### PR DESCRIPTION
## Problem

Every Dependabot dev-dependency bump that pulls **stylelint ≥ 17.13.0** fails CI's `Lint & Type Check` job on `npm run lint:css` — blocking PRs **#263** and **#267** (both the dev-dependencies group).

## Root cause

stylelint 17.13.0's `no-invalid-position-declaration` rule fires **false positives on HTML inline `style="…"` attributes** in `.astro` markup. An inline style is declaration-only, so "declaration in an invalid position (after a nested rule)" is nonsensical there.

Evidence (reproduced against PR #267's exact 17.13 dependency set):
- **983 violations across 17 `.astro` files**, e.g. `FyiItem.astro:49` → `style="color: var(--cat-color);"`, `techpar/index.astro:655` → `style="display:none"`.
- **Zero** violations in any real `src/styles/**/*.css` file.
- `stylelint --fix` does **not** resolve them (the rule isn't auto-fixable).

So it's an upstream inline-style false positive, not a real CSS problem in our code.

## Fix

Disable `no-invalid-position-declaration` in the **`.astro` override only**. The base config (plain `.css`) keeps it enabled, so real-stylesheet coverage is retained.

Verified against PR #267's installed 17.13 deps: `lint:css` drops from **983 errors → 0**. Also valid/clean on current master deps.

Documented in `DEVELOPER_TOOLING.md` per the tooling-change policy. Re-enable once the upstream inline-style false positive is fixed.

## After merge

Once this lands on `master`, the open dev-dependency bump (#267) needs a rebase to inherit the config — `@dependabot rebase` — after which it should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
