### PR TITLE
ci: trigger required CI on Dependabot rebases (add dependabot/** to push)

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -22,10 +22,13 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    # Branch list harmonized with test.yml, test-mcp-server.yml,
-    # deploy-mcp-staging.yml, and deploy-mcp-production.yml. All five
-    # workflows share `[master, dev, 'feat/**', 'fix/**', 'feature/**']`.
-    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
+    # CI-validation branch list. Shares `[master, dev, 'feat/**', 'fix/**',
+    # 'feature/**']` with test.yml and test-mcp-server.yml, PLUS 'dependabot/**'
+    # so Dependabot rebases (which arrive as `synchronize`, not opened/reopened)
+    # still run this required audit on the new head commit. The deploy workflows
+    # (deploy-mcp-staging.yml, deploy-mcp-production.yml) deliberately OMIT
+    # 'dependabot/**' — dependency bumps must be validated but never auto-deployed.
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**', 'dependabot/**']
     paths:
       - 'package-lock.json'
       - 'mcp-server/package-lock.json'

--- a/.github/workflows/test-mcp-server.yml
+++ b/.github/workflows/test-mcp-server.yml
@@ -15,7 +15,12 @@ permissions:
 
 on:
   push:
-    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
+    # Includes 'dependabot/**' (like test.yml / npm-audit.yml, unlike the deploy
+    # workflows) so Dependabot rebases — which arrive as `synchronize`, not
+    # opened/reopened — still validate the MCP surface on the new head commit.
+    # deploy-mcp-staging.yml / deploy-mcp-production.yml gate on their own branch
+    # list (no 'dependabot/**'), so dependency bumps are tested but never auto-deployed.
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**', 'dependabot/**']
     paths:
       - 'mcp-server/**'
       - '!mcp-server/**/*.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,16 @@ permissions:
 
 on:
   push:
-    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']
+    # 'dependabot/**' is included here (unlike the deploy workflows) so that
+    # Dependabot rebases/recreates — which force-push to the dependabot branch
+    # and arrive as `synchronize`, NOT `opened`/`reopened` — still trigger the
+    # required Test Suite on the new head commit. Without it, a rebased
+    # Dependabot PR keeps its stale (or absent) required checks and is
+    # permanently BLOCKED. `synchronize` is still intentionally omitted from
+    # pull_request below to avoid double-firing on feat/fix/feature PRs (push
+    # already covers those); the push trigger is the single source of per-commit
+    # validation for all branch families.
+    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**', 'dependabot/**']
   pull_request:
     branches: [master]
     # Deliberately NOT listening to `synchronize` — push covers every commit

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -88,7 +88,9 @@ git commit -m "..."
 
 **Important**: the hook runs **before** the commit is recorded. A file you staged with double-quotes and 4-space indent may end up in the commit with single-quotes and 2-space indent — that's Prettier doing its job between the stash and the record. If you see your commit look different than your working tree expected, that's why.
 
-### On every push to `master`, `dev`, `feat/**`, `fix/**`, `feature/**` and PRs to `master`
+### On every push to `master`, `dev`, `feat/**`, `fix/**`, `feature/**`, `dependabot/**` and PRs to `master`
+
+> **Why `dependabot/**` is in the push list.** The required CI workflows (`test.yml`, `npm-audit.yml`, `test-mcp-server.yml`) use `pull_request: types: [opened, reopened]` — deliberately **not** `synchronize` — and rely on the `push` trigger to validate each new commit on a PR branch. Dependabot **rebases/recreates** force-push to a `dependabot/**` branch, which arrives as a `synchronize` event (ignored) on a branch that was historically absent from the push list. The result: a rebased Dependabot PR kept its stale/absent required checks and was **permanently BLOCKED** — and `@dependabot rebase` could never fix it (the rebase is the very event that doesn't trigger CI). Adding `dependabot/**` to the **push** branch list of those three CI workflows gives Dependabot branches the same per-commit validation as `feat/**`/`fix/**`, without re-introducing the duplicate-run problem `synchronize` would cause. The **deploy** workflows (`deploy-mcp-staging.yml`, `deploy-mcp-production.yml`) intentionally **omit** `dependabot/**` so dependency bumps are validated but never auto-deployed. If a Dependabot PR is stuck BLOCKED on a commit that predates this fix, close+reopen it (fires `reopened`) to re-run the required suite.
 
 The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workflows/test.yml) runs a 3-job parallel-then-gate pipeline:
 


### PR DESCRIPTION
## Problem

Dependabot PRs become **permanently BLOCKED** after a rebase/recreate, and `@dependabot rebase` cannot fix them. Observed on #215, #216, #217, #271 — on the rebased head commit, only `lighthouse` ran; the required **Test Suite** and **npm audit** checks never ran, so branch protection kept them BLOCKED.

## Root cause

The required CI workflows (`test.yml`, `npm-audit.yml`, `test-mcp-server.yml`) are configured as:

```yaml
on:
  push:
    branches: [master, dev, 'feat/**', 'fix/**', 'feature/**']   # excludes dependabot/**
  pull_request:
    branches: [master]
    types: [opened, reopened]   # intentionally NOT synchronize
```

They deliberately omit `synchronize` (to avoid double-firing on feat/fix PRs, where `push` already validates each commit) and rely on `push` for per-commit validation. But Dependabot **rebases/recreates** force-push to a `dependabot/**` branch — a `synchronize` event (ignored) on a branch **absent from the push list**. So neither trigger fires, the new head commit gets no required checks, and the PR is stuck. `@dependabot rebase` is itself the event that doesn't trigger CI, so it can never unblock.

`lighthouse.yml` kept running because it uses the **default** `pull_request` types (which include `synchronize`).

## Fix

Add `'dependabot/**'` to the **push** branch list of the three CI-validation workflows. Dependabot branches now get the same per-commit validation as `feat/**`/`fix/**` — including on rebases — **without** re-introducing the duplicate-run problem `synchronize` would cause on feat/fix/feature PRs.

The **deploy** workflows (`deploy-mcp-staging.yml`, `deploy-mcp-production.yml`) deliberately keep their narrower branch list, so dependency bumps are **validated but never auto-deployed** from a dependabot branch.

Documented in `DEVELOPER_TOOLING.md` per the tooling-change policy.

## Scope / follow-up

- This prevents **recurrence**. Already-open PRs stuck on a pre-fix commit (#215/#216/#217) still need a one-time **close + reopen** (fires `reopened`) to re-run — or, once this merges, a fresh `@dependabot rebase` will trigger CI correctly.
- All three workflow YAMLs validated as well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
