### PR TITLE
chore(deps): drop @opentelemetry/* overrides now resolved by Sentry 10.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,6 @@
     "fast-uri": "3.1.2",
     "esbuild": "0.28.1",
     "vite": "7.3.5",
-    "@opentelemetry/core": "2.8.0",
-    "@opentelemetry/instrumentation-http": "0.219.0",
     "@modelcontextprotocol/sdk": {
       "hono": "4.12.25",
       "express-rate-limit": "8.5.1"


### PR DESCRIPTION
## What

Removes the `@opentelemetry/core` and `@opentelemetry/instrumentation-http` entries from the `overrides` block in `package.json`.

## Why

These overrides were added in #262 as a band-aid to clear `GHSA-8988-4f7v-96qf` (and the `@sentry/node` / `@sentry/astro` advisories that chained off it) while the Sentry packages still pinned vulnerable OpenTelemetry versions.

#216 and #215 bumped `@sentry/astro` and `@sentry/cloudflare` to **10.62.0**, which depend on patched OpenTelemetry transitively — making the overrides redundant.

## Verification

- `npm audit --audit-level=moderate --omit=dev` → **0 vulnerabilities** (prod advisories remain at 0).
- `@opentelemetry/core` still resolves to **2.8.0** naturally via Sentry 10.62.0 — the `package-lock.json` is byte-identical with or without the override, confirming full redundancy (this PR is a 2-line `package.json` change, no lockfile diff).
- `npm run build` clean; **1111** unit/integration tests pass.

The unrelated `vite` / `esbuild` / `hono` overrides (separate advisories) are intentionally left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
