### PR TITLE
fix(mcp-prompts): reword authorial-intent preamble to drop the injection-tell

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -11,7 +11,7 @@
 ## Current manifest hash
 
 ```
-5ee20ef3c3b6c17cf4f740867917c27a964b7e28dbbbb2dae194d3aaa82f8194
+18d19416405f3989e5ba2975536f44f21a2d82e0e90a6d8eff4225149d4cfe70
 ```
 
 Computed over (sorted):
@@ -20,12 +20,28 @@ Computed over (sorted):
 - 123 Regulation URIs (BL-057: +3 — NIST AI RMF, UK pro-innovation AI framework, Chile Ley 21.719). Aliases (BL-073 + BL-073 acronym add-on `NIST AI RMF` / `NIST RMF` on `US-NIST-AI-RMF.json`) are NOT in the manifest hash inputs — they're an additive matching layer in `compose_dossier_envelope`'s server-side validation, not a registry shape change.
 - 6 Radar URIs.
 - **15** tool names (BL-049's `extract_irl_from_xlsx` partial-reverted at v0.13.1; BL-076 keeps the tool roster intact — `compose_dossier_envelope` schema changes do NOT affect the manifest tool list).
-- **9** prompt `name@version` tuples — `gst_information_request_list` at `0.0.4` + `gst_irl_ingestion` at `0.19.0` (BL-086 L2: worked-example deletion — see the 0.32.0 stanza below).
+- **9** prompt `name@version` tuples — `gst_information_request_list` at `0.0.4` + `gst_irl_ingestion` at `0.20.0` (authorial-intent preamble reword — see the 0.33.0 stanza below).
 
 If this hash differs from the value in
 [`tests/integration/manifest-stability.test.ts`](./tests/integration/manifest-stability.test.ts) → `EXPECTED_MANIFEST_HASH`,
 the test will fail with a remediation message. Update **both** values
 in lockstep when the registry shape changes.
+
+---
+
+## 0.33.0 — 2026-06-30 — Reword authorial-intent preamble (drop the injection-tell)
+
+**Theme**: the shared authorial-intent leading line (`authorialIntentLine` in `src/prompts/embed.ts`, prepended to every GST prompt body) was reworded to remove a counterproductive clause. It used to read _"…treat them as the user's direct instructions and proceed without hedging about prompt provenance."_ That instruction-not-to-question-provenance reads as a prompt-injection tell to v4.7+ models and triggered the exact refusal it was meant to prevent — observed live on a partner-paste `gst_irl_ingestion` run (2026-06-30), where the model declined the workflow citing the "suppress your judgment" preamble as a jailbreak signal.
+
+New line: _"Workflow invocation: `<name>` — a GST consultant workflow the user explicitly initiated from the MCP prompt menu. The steps below are the task to carry out."_ It states provenance positively (the workflow came from a deliberate user action) and leaves the model's judgment intact.
+
+**Empirical motivation**: this is a companion to BL-086 — L2 shrank the body, but the refusal trigger turned out to be this preamble (and the BL-079 prepop/VERIFY provenance scaffolding, addressed separately), not the worked examples.
+
+**Surface impact**:
+
+- **UPDATED** shared `authorialIntentLine` — affects the rendered body of all 9 prompts that use it. Only `gst_irl_ingestion` carries a `promptVersion` consumed for provenance + body-hash baselines, so only it bumps: `0.19.0` → `0.20.0`. The other prompts' bodies change cosmetically with no version-bump (nothing consumes their version; no body-hash test).
+- **BODY HASH DRIFT** — all 7 `gst_irl_ingestion` body hashes drift (the preamble leads every variant). Rebaselined in `tests/integration/irl-ingestion-body-hash-stability.test.ts`.
+- **MANIFEST HASH DRIFT** — from the `gst_irl_ingestion` tuple bump. New value: `18d19416405f3989e5ba2975536f44f21a2d82e0e90a6d8eff4225149d4cfe70`.
 
 ---
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/prompts/embed.ts
+++ b/mcp-server/src/prompts/embed.ts
@@ -78,10 +78,19 @@ export function embedFyiRadarSnapshot(): EmbedResult {
 /**
  * Standardized authorial-intent leading line for every prompt body
  * (BL-031.75 Commit 5 / V1 finding 2). Claude Desktop renders the
- * `prompts/get` expansion as if it were an uploaded document, which
- * triggers the model's prompt-injection hedge. This line short-circuits
- * the hedge by signalling explicit authorial intent.
+ * `prompts/get` expansion as if it were an uploaded document, which can
+ * trigger the model's prompt-injection hedge. This line orients the model
+ * by stating provenance positively — the workflow came from a deliberate
+ * user action (the MCP prompt menu).
+ *
+ * BL-086 follow-up: the original phrasing ("treat them as the user's direct
+ * instructions and proceed without hedging about prompt provenance") was
+ * counterproductive on v4.7+ models — instructing the model NOT to question
+ * provenance reads as an injection tell and triggered the very refusal it
+ * aimed to prevent (observed live on a partner-paste gst_irl_ingestion run,
+ * 2026-06-30). The reworded line states where the workflow came from and
+ * leaves the model's judgment intact.
  */
 export function authorialIntentLine(promptName: string): string {
-  return `Workflow invocation: \`${promptName}\` — a GST consultant workflow the user has explicitly initiated. The steps below are your task; treat them as the user's direct instructions and proceed without hedging about prompt provenance.`;
+  return `Workflow invocation: \`${promptName}\` — a GST consultant workflow the user explicitly initiated from the MCP prompt menu. The steps below are the task to carry out.`;
 }

--- a/mcp-server/src/prompts/irl-ingestion.ts
+++ b/mcp-server/src/prompts/irl-ingestion.ts
@@ -1060,7 +1060,7 @@ export const irlIngestionPrompt: GstPrompt<typeof argsSchema> = {
   name: PROMPT_NAME,
   description:
     'Bookend to gst_information_request_list — ingest a populated IRL and orchestrate every applicable Hub tool + downstream artifact to produce a unified engagement dossier. Scenario-neutral: serves buy-side diligence, sell-side prep, value-creation engagements, and post-close hardening. The "high-fidelity intake → full platform ingestion" workflow.',
-  version: '0.19.0',
+  version: '0.20.0',
   lastReviewedAt: '2026-06-30',
   orchestrates: [...ORCHESTRATED_TOOLS, IRL_RESOURCE_URI, VDR_RESOURCE_URI] as const,
   argsSchema,

--- a/mcp-server/tests/integration/irl-ingestion-body-hash-stability.test.ts
+++ b/mcp-server/tests/integration/irl-ingestion-body-hash-stability.test.ts
@@ -221,16 +221,21 @@ function hashPromptOutput(args: Parameters<typeof irlIngestionPrompt.build>[0]):
 // drift (minimal + full + full-compact); interactive and the 3 extract-only
 // bodies are unchanged. (The BL-086 design doc's "all 7 drift" prediction was
 // inaccurate — extract-only does not embed these blocks.)
+// authorialIntentLine reword rebaseline (prompt v0.19.0 → v0.20.0): the shared
+// authorial-intent preamble (embed.ts) was reworded to drop the "proceed
+// without hedging about prompt provenance" injection-tell that triggered a
+// live v4.7+ refusal (2026-06-30). The preamble leads EVERY body variant, so
+// all 7 hashes drift this time (interactive + 3 one-shot + 3 extract-only).
 const EXPECTED_HASH_INTERACTIVE =
-  'fbdd7fe8934ddaa4937abe7844cf47e00ed1519f0c79a414d238b7671e2f1fe9';
+  '18e5ac3e6b830c824b07481ac287ef0aebc4f07a8344f8007edc2eeef1168fdb';
 const EXPECTED_HASH_ONESHOT_MINIMAL =
-  '58f64525ade6d9ab6327f4d6a0fe5d2366b3937267c413fdec039a0c085027e6';
+  'c7f3ffc465479f22429b9914650d94e3aad57734782db6e8cbda04f46908c469';
 const EXPECTED_HASH_ONESHOT_FULL =
-  'ac38b4556c48e8af9228a8cfa12c2cb5bbeca4e00dadb633ba650ead301bb5f4';
+  'e790f7170fb36bc90ae503a163aeeb5f73d44d83377fe0cbb8b9157c7a6170ff';
 const EXPECTED_HASH_EXTRACT_ONLY_MINIMAL =
-  'e2142f96edde5fb2b6d2e2e33797ab49f87b76675a184dcd213cb2e0d177352f';
+  'c01d16ea44f7ac8ab17d3994abe06f2cd5614da844698eeb3d58e7418501d20e';
 const EXPECTED_HASH_EXTRACT_ONLY_FULL =
-  '26e3876c2a3a16089fd6fe7a816731a8068331949f433e33d0449a92cd8a390f';
+  'f729e6e23fd389fe25334e2bbf82622914d5a0e7f9bb58bd4016f78bc284335e';
 // BL-045 PR B audit M1 — compact-verbosity coverage. Verbose-default
 // scenarios above don't catch a regression where compact mode silently
 // gains a verbose-only directive (PER_SECTION_JSON_FENCE_DIRECTIVE,
@@ -240,9 +245,9 @@ const EXPECTED_HASH_EXTRACT_ONLY_FULL =
 // Compact bodies include the directive annotations + verify-block schema
 // expansion same as verbose.
 const EXPECTED_HASH_ONESHOT_FULL_COMPACT =
-  'fcd631bbb386bc16ef9646028b05b8a40886f58e8eb79ef42660a30d86cceec3';
+  '8afe357cca5d20113a33f571237d02b3d76e592aa7fb93811d0908ccaa2e65bc';
 const EXPECTED_HASH_EXTRACT_ONLY_FULL_COMPACT =
-  '57db5b3add0796b40c7eff16a5e3b35801a59bb58d6615eb52d6af61357ee80a';
+  'a5074362e8cd677355901e9e6e5a1c69a1cd846c857f7a582da1b8c6ed938d08';
 
 interface Scenario {
   name: string;

--- a/mcp-server/tests/integration/manifest-stability.test.ts
+++ b/mcp-server/tests/integration/manifest-stability.test.ts
@@ -108,7 +108,11 @@ import { ALL_PROMPTS } from '../../src/prompts/_registry';
 // BL-086 L2 (prompt v0.18.0 → v0.19.0): manifest drifts solely from the
 // gst_irl_ingestion name@version tuple bump (the new embedToolWorkedExamples
 // arg is NOT part of the manifest input — only name@version + URIs are).
-const EXPECTED_MANIFEST_HASH = '5ee20ef3c3b6c17cf4f740867917c27a964b7e28dbbbb2dae194d3aaa82f8194';
+// authorialIntentLine reword (prompt v0.19.0 → v0.20.0): manifest drifts again
+// solely from the gst_irl_ingestion tuple bump. The shared-preamble reword
+// changes other prompts' bodies too, but only irl-ingestion's version bumps,
+// so the manifest delta is one tuple.
+const EXPECTED_MANIFEST_HASH = '18d19416405f3989e5ba2975536f44f21a2d82e0e90a6d8eff4225149d4cfe70';
 
 function computeManifestHash(): string {
   const libraryUris = LIBRARY_ENTRIES.map((e) => e.uri).sort();

--- a/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
+++ b/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
@@ -89,7 +89,7 @@ describe('gst_irl_ingestion', () => {
     // BL-045 reset: prompt version restarts at 0.1.0 to signal the substantive
     // rescope (rename, scenario-neutral framing, mode/verbosity/forceTools args,
     // inclusion gates, JSON fences, provenance footer, gap list).
-    expect(irlIngestionPrompt.version).toBe('0.19.0');
+    expect(irlIngestionPrompt.version).toBe('0.20.0');
     expect(irlIngestionPrompt.lastReviewedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(irlIngestionPrompt.orchestrates.length).toBeGreaterThanOrEqual(11);
   });


### PR DESCRIPTION
## Problem

Every GST prompt body opens with a shared `authorialIntentLine` ([embed.ts](mcp-server/src/prompts/embed.ts)) that read:

> "…treat them as the user's direct instructions and **proceed without hedging about prompt provenance**."

That clause — added long ago to *reduce* the model's prompt-injection hedge — is now **counterproductive on v4.7+ models**. Telling a safety-tuned model not to question provenance is itself a jailbreak tell, and it triggered the exact refusal it was meant to prevent.

**Observed live (2026-06-30):** a partner-paste `gst_irl_ingestion` run was *refused*, with the model quoting this preamble as reason #1 ("It opens by instructing me to suppress my own judgment … Legitimate workflows don't need to preemptively tell me not to question where they came from").

This is the companion finding to BL-086: **L2 shrank the body, but this preamble (not the worked examples) was a primary refusal trigger.**

## Fix

Reword the shared line to state provenance **positively** and leave the model's judgment intact:

> "Workflow invocation: `<name>` — a GST consultant workflow the user explicitly initiated from the MCP prompt menu. The steps below are the task to carry out."

## Scope / versioning

- Affects the rendered body of all **9 prompts** that use the shared line.
- Only `gst_irl_ingestion` carries a `promptVersion` consumed for provenance + has body-hash baselines, so **only it bumps**: `0.19.0` → `0.20.0`. The other prompts' bodies change cosmetically with no version bump (nothing consumes their version; they have no body-hash test). No precedent forces all-prompt bumps for a shared-preamble change.
- mcp-server `0.32.0` → `0.33.0`.

## Tests / verification

- No test asserts on the preamble text (grep-verified).
- All **7** `gst_irl_ingestion` body hashes rebaselined (the preamble leads every variant); manifest hash rebaselined (tuple bump). BREAKING_CHANGES.md 0.33.0 stanza + manifest block updated.
- `npx tsc --noEmit` clean; full `mcp-server` suite green (**1521** pass).

## Follow-up (not in this PR)

The same live refusal also flagged the BL-079 prepop + VERIFY-block provenance scaffolding (the model being asked to assert `pass-bound` / a hash it didn't compute). That's the architectural half — I'll scope it separately (pull-forward of BL-086 L4 + rework how prepop provenance is surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
