### PR TITLE
fix(tech-debt-calculator): faithfully restore shared deeplinks (auto-expand + clamp-and-warn)

### DIFF
--- a/mcp-server/tests/unit/deeplinks/tech-debt-deeplink.test.ts
+++ b/mcp-server/tests/unit/deeplinks/tech-debt-deeplink.test.ts
@@ -39,18 +39,20 @@ describe('Tech Debt deep-link', () => {
     const decoded = decodeState(encoded!);
     const expected = rawToState(SAMPLE_INPUT);
 
-    // decodeState returns Partial<CalcState>; every field we populated should round-trip
+    // decodeState returns { state, adjusted }; in-range inputs round-trip
+    // verbatim with no clamping recorded.
     expect(decoded).not.toBeNull();
-    expect(decoded!.teamSize).toBe(expected.teamSize);
-    expect(decoded!.salary).toBe(expected.salary);
-    expect(decoded!.maintPct).toBe(expected.maintPct);
-    expect(decoded!.deployIdx).toBe(expected.deployIdx);
-    expect(decoded!.incidents).toBe(expected.incidents);
-    expect(decoded!.mttr).toBe(expected.mttr);
-    expect(decoded!.remediationBudget).toBe(expected.remediationBudget);
-    expect(decoded!.arr).toBe(expected.arr);
-    expect(decoded!.remediationPct).toBe(expected.remediationPct);
-    expect(decoded!.contextSwitchOn).toBe(expected.contextSwitchOn);
+    expect(decoded!.adjusted).toEqual([]);
+    expect(decoded!.state.teamSize).toBe(expected.teamSize);
+    expect(decoded!.state.salary).toBe(expected.salary);
+    expect(decoded!.state.maintPct).toBe(expected.maintPct);
+    expect(decoded!.state.deployIdx).toBe(expected.deployIdx);
+    expect(decoded!.state.incidents).toBe(expected.incidents);
+    expect(decoded!.state.mttr).toBe(expected.mttr);
+    expect(decoded!.state.remediationBudget).toBe(expected.remediationBudget);
+    expect(decoded!.state.arr).toBe(expected.arr);
+    expect(decoded!.state.remediationPct).toBe(expected.remediationPct);
+    expect(decoded!.state.contextSwitchOn).toBe(expected.contextSwitchOn);
   });
 
   it('preserves granular ARR precision in the deeplink (no slider-quantization loss)', () => {
@@ -66,9 +68,9 @@ describe('Tech Debt deep-link', () => {
     const url = buildTechDebtDeeplink(granular);
     const encoded = new URL(url).searchParams.get('s')!;
     const decoded = decodeState(encoded)!;
-    expect(decoded.arr).toBe(237_500_000);
-    expect(decoded.remediationBudget).toBe(1_750_000);
-    expect(decoded.salary).toBe(187_500);
+    expect(decoded.state.arr).toBe(237_500_000);
+    expect(decoded.state.remediationBudget).toBe(1_750_000);
+    expect(decoded.state.salary).toBe(187_500);
   });
 
   it('throws on unknown deployFrequency rather than emitting a malformed URL', () => {

--- a/src/pages/hub/tools/tech-debt-calculator/index.astro
+++ b/src/pages/hub/tools/tech-debt-calculator/index.astro
@@ -1659,10 +1659,34 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
 
   // ─── Event wiring ─────────────────────────────────────────────────────────────
 
+  // Advanced-tier inputs live behind the collapsible panel. A shared link may
+  // carry non-default values for any of them (MCP-generated deeplinks always
+  // encode `a:0` regardless of the advanced fields they populate). If we honor
+  // `advancedOpen:false` blindly, the recipient lands on a collapsed panel whose
+  // advanced results breakdown is never rendered — the inputs are silently
+  // applied to the primary figure but invisible. Auto-expand when any advanced
+  // field diverges from its default so the full analysis is surfaced on arrival.
+  const ADVANCED_KEYS = [
+    'deployIdx',
+    'incidents',
+    'mttr',
+    'remediationBudget',
+    'arr',
+    'remediationPct',
+    'contextSwitchOn',
+  ] as const;
+
+  function hasNonDefaultAdvanced(s: CalcState): boolean {
+    return ADVANCED_KEYS.some((k) => s[k] !== DEFAULT_STATE[k]);
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     // Apply URL-encoded state before initialising sliders so DOM positions match
     const urlState = readUrlState();
-    if (urlState) Object.assign(state, urlState);
+    if (urlState) {
+      Object.assign(state, urlState);
+      if (hasNonDefaultAdvanced(state)) state.advancedOpen = true;
+    }
 
     initSliders();
     render();

--- a/src/pages/hub/tools/tech-debt-calculator/index.astro
+++ b/src/pages/hub/tools/tech-debt-calculator/index.astro
@@ -67,6 +67,9 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
           Methodology built from 100+ PE technology diligence engagements
         </p>
 
+        <!-- Shared-link range-adjustment notice (populated by decodeState on load) -->
+        <p class="tdc-shared-notice" data-shared-notice role="status" aria-live="polite" hidden></p>
+
         <!-- ── Core inputs ─────────────────────────────────────────── -->
         <div class="inputs-section">
           <div class="brutal-tool-shell__section-label section-label">Team & Cost</div>
@@ -632,6 +635,22 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
   /* ── Authority line ────────────────────────────────────────────────────── */
   .tdc-authority {
     padding: var(--spacing-sm) var(--spacing-2xl);
+  }
+
+  /* ── Shared-link range-adjustment notice ───────────────────────────────── */
+  .tdc-shared-notice {
+    margin: 0 var(--spacing-2xl) var(--spacing-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-left: 3px solid var(--color-secondary);
+    background: color-mix(in srgb, var(--color-secondary) 8%, transparent);
+    font-family: var(--font-family-mono);
+    font-size: var(--text-xs);
+    line-height: 1.5;
+    color: var(--text-primary);
+  }
+
+  .tdc-shared-notice[hidden] {
+    display: none;
   }
 
   /* ── Shared section padding ───────────────────────────────────────────── */
@@ -1400,9 +1419,23 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
     history.replaceState(null, '', '?' + params.toString());
   }
 
-  function readUrlState(): Partial<CalcState> | null {
+  function readUrlState(): ReturnType<typeof decodeState> {
     const s = new URLSearchParams(window.location.search).get('s');
     return s ? decodeState(s) : null;
+  }
+
+  // Surface a visible notice when a shared link carried values outside the
+  // calculator's supported range (see decodeState's producer/consumer note).
+  // Without this, a clamped value looks indistinguishable from one the reader
+  // chose — the same silent-misreport failure mode this guard set out to fix.
+  function showSharedStateNotice(adjustedLabels: string[]): void {
+    const noticeEl = document.querySelector('[data-shared-notice]') as HTMLElement | null;
+    if (!noticeEl || adjustedLabels.length === 0) return;
+    noticeEl.textContent =
+      `Some values in this shared link were outside the calculator's supported range and have ` +
+      `been adjusted to the nearest limit: ${adjustedLabels.join(', ')}. Results reflect the ` +
+      `adjusted values.`;
+    noticeEl.hidden = false;
   }
 
   // ─── Currency ─────────────────────────────────────────────────────────────────
@@ -1684,8 +1717,9 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
     // Apply URL-encoded state before initialising sliders so DOM positions match
     const urlState = readUrlState();
     if (urlState) {
-      Object.assign(state, urlState);
+      Object.assign(state, urlState.state);
       if (hasNonDefaultAdvanced(state)) state.advancedOpen = true;
+      showSharedStateNotice(urlState.adjusted);
     }
 
     initSliders();

--- a/src/utils/tech-debt-engine.ts
+++ b/src/utils/tech-debt-engine.ts
@@ -197,6 +197,16 @@ export const fmtPayback = (months: number): string => {
 // (previous slider-position format quantized to 100 buckets and was lossy
 // at high ARR values). 'in' is a JS reserved word in some contexts — always
 // access as raw['in'].
+//
+// Producer/consumer domain note: the MCP `estimate_tech_debt_cost` tool
+// accepts a WIDER numeric domain than this calculator's sliders (e.g.
+// remediationBudget/arr `>= 0`, mttrHours `>= 0` including 0 as an "elided /
+// unknown" sentinel). A deeplink built from those inputs can therefore carry
+// values outside a slider's [min,max]. Rather than silently dropping such a
+// field back to an unrelated default — which makes a shared link misreport the
+// analysis it was built to convey — `decodeState` clamps each out-of-range
+// value to the nearest supported bound and records the field in `adjusted[]`
+// so the page can surface a visible "values were adjusted" notice.
 
 export function encodeState(state: CalcState): string {
   const compact = {
@@ -215,28 +225,64 @@ export function encodeState(state: CalcState): string {
   return btoa(JSON.stringify(compact));
 }
 
-export function decodeState(encoded: string): Partial<CalcState> | null {
+export interface DecodedState {
+  /** Fields present in the payload and usable — either verbatim (in range) or clamped to a bound. */
+  state: Partial<CalcState>;
+  /**
+   * Human-readable labels for fields that were present but had to be coerced:
+   * clamped to the nearest bound (out of range) or dropped (non-numeric). Empty
+   * when every shared value was honored exactly. The page renders these in a
+   * notice so a link built from the wider MCP input domain never silently
+   * decodes to an unrelated default without telling the reader.
+   */
+  adjusted: string[];
+}
+
+export function decodeState(encoded: string): DecodedState | null {
   try {
     const raw = JSON.parse(atob(encoded));
     if (typeof raw !== 'object' || raw === null) return null;
 
-    const out: Partial<CalcState> = {};
-    const isNum = (v: unknown, min: number, max: number): v is number =>
-      typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+    const state: Partial<CalcState> = {};
+    const adjusted: string[] = [];
 
-    if (raw.a === 0 || raw.a === 1) out.advancedOpen = raw.a === 1;
-    if (isNum(raw.ts, 1, 500)) out.teamSize = raw.ts;
-    if (isNum(raw.sa, 60000, 1000000)) out.salary = raw.sa;
-    if (Number.isInteger(raw.mp) && raw.mp >= 0 && raw.mp <= 100) out.maintPct = raw.mp;
-    if (Number.isInteger(raw.di) && raw.di >= 0 && raw.di <= 8) out.deployIdx = raw.di;
-    if (Number.isInteger(raw['in']) && raw['in'] >= 0 && raw['in'] <= 20) out.incidents = raw['in'];
-    if (Number.isInteger(raw.mttr) && raw.mttr >= 1 && raw.mttr <= 48) out.mttr = raw.mttr;
-    if (isNum(raw.bg, 10000, 50000000)) out.remediationBudget = raw.bg;
-    if (isNum(raw.ar, 100000, 1000000000)) out.arr = raw.ar;
-    if (Number.isInteger(raw.re) && raw.re >= 0 && raw.re <= 100) out.remediationPct = raw.re;
-    if (raw.cs === 0 || raw.cs === 1) out.contextSwitchOn = raw.cs === 1;
+    // Clamp a present numeric field into [min,max] and assign it via `set`. An
+    // out-of-range value is coerced to the nearest bound; a non-numeric present
+    // value is dropped. Either coercion records `label` in `adjusted`. Absent
+    // fields are skipped silently (partial links are normal). Integer fields are
+    // rounded so the stored value stays representable on the slider control.
+    const clampNum = (
+      value: unknown,
+      min: number,
+      max: number,
+      label: string,
+      set: (v: number) => void,
+      isInt = false
+    ): void => {
+      if (value === undefined) return;
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        adjusted.push(label);
+        return;
+      }
+      const rounded = isInt ? Math.round(value) : value;
+      const clamped = Math.min(max, Math.max(min, rounded));
+      if (clamped !== value) adjusted.push(label);
+      set(clamped);
+    };
 
-    return out;
+    if (raw.a === 0 || raw.a === 1) state.advancedOpen = raw.a === 1;
+    clampNum(raw.ts, 1, 500, 'Team Size', (v) => (state.teamSize = v), true);
+    clampNum(raw.sa, 60000, 1000000, 'Avg. Salary', (v) => (state.salary = v));
+    clampNum(raw.mp, 0, 100, 'Maintenance Burden', (v) => (state.maintPct = v), true);
+    clampNum(raw.di, 0, 8, 'Deployment Frequency', (v) => (state.deployIdx = v), true);
+    clampNum(raw['in'], 0, 20, 'Incidents / Mo', (v) => (state.incidents = v), true);
+    clampNum(raw.mttr, 1, 48, 'Avg. Time to Resolve', (v) => (state.mttr = v), true);
+    clampNum(raw.bg, 10000, 50000000, 'Remediation Budget', (v) => (state.remediationBudget = v));
+    clampNum(raw.ar, 100000, 1000000000, 'Annual Recurring Revenue', (v) => (state.arr = v));
+    clampNum(raw.re, 0, 100, 'Remediation Efficiency', (v) => (state.remediationPct = v), true);
+    if (raw.cs === 0 || raw.cs === 1) state.contextSwitchOn = raw.cs === 1;
+
+    return { state, adjusted };
   } catch {
     return null;
   }

--- a/tests/e2e/tech-debt-calculator.test.ts
+++ b/tests/e2e/tech-debt-calculator.test.ts
@@ -317,6 +317,68 @@ test.describe('Tech Debt Calculator', () => {
       expect(paramCost).not.toBe(defaultCost);
     });
 
+    // Regression: MCP-generated deeplinks encode `a:0` even when they populate
+    // advanced fields (deploy frequency, context-switch, custom ARR, etc.).
+    // Honoring a:0 blindly left the advanced panel collapsed and its results
+    // breakdown unrendered until the user manually toggled it open. The page
+    // must auto-expand when the incoming state carries non-default advanced values.
+    test('deeplink with non-default advanced fields auto-expands the advanced panel', async ({
+      page,
+    }) => {
+      // a:0 (panel flagged closed) but di:6 (Quarterly+), cs:1 (context-switch on),
+      // ar:$50M — all diverge from defaults. Mirrors an MCP-generated share link.
+      const advancedState = btoa(
+        JSON.stringify({
+          a: 0,
+          ts: 42,
+          sa: 108_000,
+          mp: 30,
+          di: 6,
+          in: 5,
+          mttr: 8,
+          bg: 1_000_000,
+          ar: 50_000_000,
+          re: 30,
+          cs: 1,
+        })
+      );
+
+      await gotoCalcWithParams(page, advancedState);
+
+      // Panel and results breakdown are open on arrival — no manual toggle needed
+      await expect(page.locator('[data-advanced-panel]')).not.toHaveClass(/is-hidden/);
+      await expect(page.locator('[data-adv-results]')).not.toHaveClass(/is-hidden/);
+      await expect(page.locator('[data-advanced-toggle]')).toHaveAttribute('aria-expanded', 'true');
+      await expect(page.locator('[data-toggle-label]')).toHaveText('Hide Advanced Inputs');
+
+      // Advanced results reflect the deeplinked inputs (not em-dash placeholders)
+      expect(await getMetric(page, 'direct-labor')).not.toBe('—');
+      expect(await getMetric(page, 'velocity')).not.toBe('—');
+      expect(await getMetric(page, 'debt-pct-arr')).not.toBe('—');
+
+      // Context-switch was on in the link → its line item is visible with a value
+      await expect(page.locator('#ctx-switch-stat')).toBeVisible();
+      expect(await getMetric(page, 'context-switch')).not.toBe('—');
+    });
+
+    test('deeplink with only core (non-advanced) fields keeps the panel collapsed', async ({
+      page,
+    }) => {
+      // Only team-size/salary/maint differ; every advanced field is at default →
+      // nothing advanced to surface, so the panel should stay collapsed.
+      const coreOnlyState = btoa(
+        JSON.stringify({ a: 0, ts: 40, sa: 200_000, mp: 45, di: 3, in: 3, mttr: 4 })
+      );
+
+      await gotoCalcWithParams(page, coreOnlyState);
+
+      await expect(page.locator('[data-advanced-panel]')).toHaveClass(/is-hidden/);
+      await expect(page.locator('[data-advanced-toggle]')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
+
     test('slider changes update the URL ?s= param', async ({ page }) => {
       await gotoCalc(page);
 

--- a/tests/e2e/tech-debt-calculator.test.ts
+++ b/tests/e2e/tech-debt-calculator.test.ts
@@ -361,6 +361,32 @@ test.describe('Tech Debt Calculator', () => {
       expect(await getMetric(page, 'context-switch')).not.toBe('—');
     });
 
+    test('the reported repro link surfaces a range-adjustment notice for out-of-range values', async ({
+      page,
+    }) => {
+      // The exact ?s= payload from the bug report. It encodes bg:0 and mttr:0
+      // (MCP "unknown / elided" sentinels) which sit below the calculator's
+      // supported floors. The decoder must clamp them and the page must tell
+      // the reader — not silently swap in the $500K / 4h defaults.
+      const REPRO_STATE =
+        'eyJhIjowLCJ0cyI6NDIsInNhIjoxMDgwMDAsIm1wIjozMCwiZGkiOjYsImluIjowLCJtdHRyIjowLCJiZyI6MCwiYXIiOjMxNjgwMDAwLCJyZSI6MzAsImNzIjoxfQ==';
+
+      await gotoCalcWithParams(page, REPRO_STATE);
+
+      const notice = page.locator('[data-shared-notice]');
+      await expect(notice).toBeVisible();
+      await expect(notice).toContainText('Remediation Budget');
+      await expect(notice).toContainText('Avg. Time to Resolve');
+    });
+
+    test('an all-in-range deeplink shows no range-adjustment notice', async ({ page }) => {
+      const inRange = btoa(
+        JSON.stringify({ a: 0, ts: 40, sa: 200_000, mp: 45, di: 3, in: 3, mttr: 4, bg: 1_000_000 })
+      );
+      await gotoCalcWithParams(page, inRange);
+      await expect(page.locator('[data-shared-notice]')).toBeHidden();
+    });
+
     test('deeplink with only core (non-advanced) fields keeps the panel collapsed', async ({
       page,
     }) => {

--- a/tests/unit/tech-debt-engine.test.ts
+++ b/tests/unit/tech-debt-engine.test.ts
@@ -587,17 +587,19 @@ describe('decodeState', () => {
   it('round-trips DEFAULT_STATE through encode → decode with full field equality', () => {
     const decoded = decodeState(encodeState(DEFAULT_STATE));
     expect(decoded).not.toBeNull();
-    expect(decoded!.advancedOpen).toBe(DEFAULT_STATE.advancedOpen);
-    expect(decoded!.teamSize).toBe(DEFAULT_STATE.teamSize);
-    expect(decoded!.salary).toBe(DEFAULT_STATE.salary);
-    expect(decoded!.maintPct).toBe(DEFAULT_STATE.maintPct);
-    expect(decoded!.deployIdx).toBe(DEFAULT_STATE.deployIdx);
-    expect(decoded!.incidents).toBe(DEFAULT_STATE.incidents);
-    expect(decoded!.mttr).toBe(DEFAULT_STATE.mttr);
-    expect(decoded!.remediationBudget).toBe(DEFAULT_STATE.remediationBudget);
-    expect(decoded!.arr).toBe(DEFAULT_STATE.arr);
-    expect(decoded!.remediationPct).toBe(DEFAULT_STATE.remediationPct);
-    expect(decoded!.contextSwitchOn).toBe(DEFAULT_STATE.contextSwitchOn);
+    expect(decoded!.adjusted).toEqual([]);
+    const s = decoded!.state;
+    expect(s.advancedOpen).toBe(DEFAULT_STATE.advancedOpen);
+    expect(s.teamSize).toBe(DEFAULT_STATE.teamSize);
+    expect(s.salary).toBe(DEFAULT_STATE.salary);
+    expect(s.maintPct).toBe(DEFAULT_STATE.maintPct);
+    expect(s.deployIdx).toBe(DEFAULT_STATE.deployIdx);
+    expect(s.incidents).toBe(DEFAULT_STATE.incidents);
+    expect(s.mttr).toBe(DEFAULT_STATE.mttr);
+    expect(s.remediationBudget).toBe(DEFAULT_STATE.remediationBudget);
+    expect(s.arr).toBe(DEFAULT_STATE.arr);
+    expect(s.remediationPct).toBe(DEFAULT_STATE.remediationPct);
+    expect(s.contextSwitchOn).toBe(DEFAULT_STATE.contextSwitchOn);
   });
 
   it('returns null for an empty string', () => {
@@ -613,43 +615,69 @@ describe('decodeState', () => {
   });
 
   it('returns an empty partial (not null) for valid JSON with no known keys', () => {
-    const encoded = btoa(JSON.stringify({ unknown: 99 }));
-    const result = decodeState(encoded);
+    const result = decodeState(btoa(JSON.stringify({ unknown: 99 })));
     expect(result).not.toBeNull();
-    expect(Object.keys(result!)).toHaveLength(0);
+    expect(Object.keys(result!.state)).toHaveLength(0);
+    expect(result!.adjusted).toEqual([]);
   });
 
   it('returns partial result when only some fields are present — valid fields included', () => {
-    const encoded = btoa(JSON.stringify({ mp: 60 }));
-    const result = decodeState(encoded);
+    const result = decodeState(btoa(JSON.stringify({ mp: 60 })));
     expect(result).not.toBeNull();
-    expect(result!.maintPct).toBe(60);
-    expect(result!.teamSize).toBeUndefined();
+    expect(result!.state.maintPct).toBe(60);
+    expect(result!.state.teamSize).toBeUndefined();
+    expect(result!.adjusted).toEqual([]);
   });
 
-  it('rejects teamSize > 500', () => {
-    expect(decodeState(btoa(JSON.stringify({ ts: 501 })))!.teamSize).toBeUndefined();
+  // ── Out-of-range values clamp to the nearest supported bound and are
+  //    reported in `adjusted`, rather than being silently dropped to an
+  //    unrelated default. The MCP `estimate_tech_debt_cost` tool accepts a
+  //    wider numeric domain than these sliders, so a valid deeplink can carry
+  //    values outside a slider's [min,max]; clamp-and-report keeps the shared
+  //    link honest instead of misreporting the analysis. ──
+
+  it('clamps teamSize > 500 down to 500 and records the adjustment', () => {
+    const r = decodeState(btoa(JSON.stringify({ ts: 501 })))!;
+    expect(r.state.teamSize).toBe(500);
+    expect(r.adjusted).toContain('Team Size');
   });
 
-  it('rejects teamSize < 1', () => {
-    expect(decodeState(btoa(JSON.stringify({ ts: 0 })))!.teamSize).toBeUndefined();
+  it('clamps teamSize < 1 up to 1 and records the adjustment', () => {
+    const r = decodeState(btoa(JSON.stringify({ ts: 0 })))!;
+    expect(r.state.teamSize).toBe(1);
+    expect(r.adjusted).toContain('Team Size');
   });
 
-  it('rejects out-of-range salary (< 60K or > 1M)', () => {
-    expect(decodeState(btoa(JSON.stringify({ sa: 50000 })))!.salary).toBeUndefined();
-    expect(decodeState(btoa(JSON.stringify({ sa: 1_500_000 })))!.salary).toBeUndefined();
+  it('clamps out-of-range salary to the 60K–1M bounds', () => {
+    expect(decodeState(btoa(JSON.stringify({ sa: 50000 })))!.state.salary).toBe(60000);
+    expect(decodeState(btoa(JSON.stringify({ sa: 1_500_000 })))!.state.salary).toBe(1_000_000);
   });
 
-  it('rejects out-of-range arr (< 100K or > 1B)', () => {
-    expect(decodeState(btoa(JSON.stringify({ ar: 50000 })))!.arr).toBeUndefined();
-    expect(decodeState(btoa(JSON.stringify({ ar: 2_000_000_000 })))!.arr).toBeUndefined();
+  it('clamps out-of-range arr to the 100K–1B bounds', () => {
+    expect(decodeState(btoa(JSON.stringify({ ar: 50000 })))!.state.arr).toBe(100000);
+    expect(decodeState(btoa(JSON.stringify({ ar: 2_000_000_000 })))!.state.arr).toBe(1_000_000_000);
   });
 
-  it('rejects out-of-range remediationBudget (< 10K or > 50M)', () => {
-    expect(decodeState(btoa(JSON.stringify({ bg: 5000 })))!.remediationBudget).toBeUndefined();
-    expect(
-      decodeState(btoa(JSON.stringify({ bg: 100_000_000 })))!.remediationBudget
-    ).toBeUndefined();
+  it('clamps out-of-range remediationBudget to the 10K–50M bounds', () => {
+    expect(decodeState(btoa(JSON.stringify({ bg: 5000 })))!.state.remediationBudget).toBe(10000);
+    expect(decodeState(btoa(JSON.stringify({ bg: 100_000_000 })))!.state.remediationBudget).toBe(
+      50_000_000
+    );
+  });
+
+  it('clamps remediationBudget = 0 (MCP "unknown" sentinel) up to the 10K floor and flags it', () => {
+    // Direct repro for the reported bug: MCP deeplinks encode bg:0 for an
+    // unknown budget. The old decoder dropped it → the page silently showed
+    // the $500K default and a wrong payback period.
+    const r = decodeState(btoa(JSON.stringify({ bg: 0 })))!;
+    expect(r.state.remediationBudget).toBe(10000);
+    expect(r.adjusted).toContain('Remediation Budget');
+  });
+
+  it('clamps mttr = 0 (MCP "elided" sentinel) up to the 1h floor and flags it', () => {
+    const r = decodeState(btoa(JSON.stringify({ mttr: 0 })))!;
+    expect(r.state.mttr).toBe(1);
+    expect(r.adjusted).toContain('Avg. Time to Resolve');
   });
 
   it('preserves typed-input precision through URL round-trip (no quantization)', () => {
@@ -658,122 +686,126 @@ describe('decodeState', () => {
     // raw dollars and must round-trip exactly.
     const granular = makeState({ arr: 237_500, salary: 187_500, remediationBudget: 423_000 });
     const decoded = decodeState(encodeState(granular))!;
-    expect(decoded.arr).toBe(237_500);
-    expect(decoded.salary).toBe(187_500);
-    expect(decoded.remediationBudget).toBe(423_000);
+    expect(decoded.state.arr).toBe(237_500);
+    expect(decoded.state.salary).toBe(187_500);
+    expect(decoded.state.remediationBudget).toBe(423_000);
+    expect(decoded.adjusted).toEqual([]);
   });
 
-  it('rejects deployIdx > 8', () => {
-    expect(decodeState(btoa(JSON.stringify({ di: 9 })))!.deployIdx).toBeUndefined();
+  it('clamps deployIdx > 8 to 8', () => {
+    expect(decodeState(btoa(JSON.stringify({ di: 9 })))!.state.deployIdx).toBe(8);
   });
 
-  it('rejects deployIdx < 0', () => {
-    expect(decodeState(btoa(JSON.stringify({ di: -1 })))!.deployIdx).toBeUndefined();
+  it('clamps deployIdx < 0 to 0', () => {
+    expect(decodeState(btoa(JSON.stringify({ di: -1 })))!.state.deployIdx).toBe(0);
   });
 
-  it('rejects maintPct < 0', () => {
-    expect(decodeState(btoa(JSON.stringify({ mp: -1 })))!.maintPct).toBeUndefined();
+  it('clamps maintPct < 0 to 0', () => {
+    const r = decodeState(btoa(JSON.stringify({ mp: -1 })))!;
+    expect(r.state.maintPct).toBe(0);
+    expect(r.adjusted).toContain('Maintenance Burden');
   });
 
-  it('accepts maintPct of 0', () => {
-    expect(decodeState(btoa(JSON.stringify({ mp: 0 })))!.maintPct).toBe(0);
+  it('accepts maintPct of 0 without flagging', () => {
+    const r = decodeState(btoa(JSON.stringify({ mp: 0 })))!;
+    expect(r.state.maintPct).toBe(0);
+    expect(r.adjusted).toEqual([]);
   });
 
-  it('rejects maintPct > 100', () => {
-    expect(decodeState(btoa(JSON.stringify({ mp: 101 })))!.maintPct).toBeUndefined();
+  it('clamps maintPct > 100 to 100', () => {
+    expect(decodeState(btoa(JSON.stringify({ mp: 101 })))!.state.maintPct).toBe(100);
   });
 
-  it('rejects mttr < 1', () => {
-    expect(decodeState(btoa(JSON.stringify({ mttr: 0 })))!.mttr).toBeUndefined();
+  it('clamps mttr > 48 to 48', () => {
+    expect(decodeState(btoa(JSON.stringify({ mttr: 49 })))!.state.mttr).toBe(48);
   });
 
-  it('rejects mttr > 48', () => {
-    expect(decodeState(btoa(JSON.stringify({ mttr: 49 })))!.mttr).toBeUndefined();
+  it('clamps incidents < 0 to 0', () => {
+    expect(decodeState(btoa(JSON.stringify({ in: -1 })))!.state.incidents).toBe(0);
   });
 
-  it('rejects incidents < 0', () => {
-    expect(decodeState(btoa(JSON.stringify({ in: -1 })))!.incidents).toBeUndefined();
+  it('clamps incidents > 20 to 20', () => {
+    expect(decodeState(btoa(JSON.stringify({ in: 21 })))!.state.incidents).toBe(20);
   });
 
-  it('rejects incidents > 20', () => {
-    expect(decodeState(btoa(JSON.stringify({ in: 21 })))!.incidents).toBeUndefined();
-  });
-
-  it('rejects float values for integer fields (e.g. deployIdx: 3.5)', () => {
-    expect(decodeState(btoa(JSON.stringify({ di: 3.5 })))!.deployIdx).toBeUndefined();
+  it('rounds float values for integer fields and flags the coercion (e.g. deployIdx: 3.5)', () => {
+    const r = decodeState(btoa(JSON.stringify({ di: 3.5 })))!;
+    expect(r.state.deployIdx).toBe(4);
+    expect(r.adjusted).toContain('Deployment Frequency');
   });
 
   it('rejects advancedOpen values that are not 0 or 1 (e.g. 2)', () => {
-    expect(decodeState(btoa(JSON.stringify({ a: 2 })))!.advancedOpen).toBeUndefined();
+    expect(decodeState(btoa(JSON.stringify({ a: 2 })))!.state.advancedOpen).toBeUndefined();
   });
 
   it('accepts advancedOpen: 1 and maps it to boolean true', () => {
-    expect(decodeState(btoa(JSON.stringify({ a: 1 })))!.advancedOpen).toBe(true);
+    expect(decodeState(btoa(JSON.stringify({ a: 1 })))!.state.advancedOpen).toBe(true);
   });
 
   it('accepts advancedOpen: 0 and maps it to boolean false', () => {
-    expect(decodeState(btoa(JSON.stringify({ a: 0 })))!.advancedOpen).toBe(false);
+    expect(decodeState(btoa(JSON.stringify({ a: 0 })))!.state.advancedOpen).toBe(false);
   });
 
   it('ignores unknown keys — returns only known fields', () => {
-    const encoded = btoa(JSON.stringify({ mp: 50, future_field: 'x', another: 99 }));
-    const result = decodeState(encoded)!;
-    expect(result.maintPct).toBe(50);
-    expect((result as any).future_field).toBeUndefined();
-    expect((result as any).another).toBeUndefined();
+    const result = decodeState(btoa(JSON.stringify({ mp: 50, future_field: 'x', another: 99 })))!;
+    expect(result.state.maintPct).toBe(50);
+    expect((result.state as any).future_field).toBeUndefined();
+    expect((result.state as any).another).toBeUndefined();
   });
 
   // ── remediationPct (re) ──
 
   it('round-trips remediationPct through encode/decode', () => {
-    const state = makeState({ remediationPct: 42 });
-    const decoded = decodeState(encodeState(state))!;
-    expect(decoded.remediationPct).toBe(42);
+    const decoded = decodeState(encodeState(makeState({ remediationPct: 42 })))!;
+    expect(decoded.state.remediationPct).toBe(42);
   });
 
-  it('rejects out-of-range remediationPct (> 100)', () => {
-    expect(decodeState(btoa(JSON.stringify({ re: 101 })))!.remediationPct).toBeUndefined();
+  it('clamps out-of-range remediationPct (> 100) to 100', () => {
+    expect(decodeState(btoa(JSON.stringify({ re: 101 })))!.state.remediationPct).toBe(100);
   });
 
-  it('rejects negative remediationPct', () => {
-    expect(decodeState(btoa(JSON.stringify({ re: -1 })))!.remediationPct).toBeUndefined();
+  it('clamps negative remediationPct to 0', () => {
+    expect(decodeState(btoa(JSON.stringify({ re: -1 })))!.state.remediationPct).toBe(0);
   });
 
-  it('rejects float remediationPct', () => {
-    expect(decodeState(btoa(JSON.stringify({ re: 50.5 })))!.remediationPct).toBeUndefined();
+  it('rounds float remediationPct and flags the coercion', () => {
+    const r = decodeState(btoa(JSON.stringify({ re: 50.5 })))!;
+    expect(r.state.remediationPct).toBe(51);
+    expect(r.adjusted).toContain('Remediation Efficiency');
   });
 
   // ── contextSwitchOn (cs) ──
 
   it('round-trips contextSwitchOn through encode/decode', () => {
-    const stateOn = makeState({ contextSwitchOn: true });
-    expect(decodeState(encodeState(stateOn))!.contextSwitchOn).toBe(true);
-    const stateOff = makeState({ contextSwitchOn: false });
-    expect(decodeState(encodeState(stateOff))!.contextSwitchOn).toBe(false);
+    expect(
+      decodeState(encodeState(makeState({ contextSwitchOn: true })))!.state.contextSwitchOn
+    ).toBe(true);
+    expect(
+      decodeState(encodeState(makeState({ contextSwitchOn: false })))!.state.contextSwitchOn
+    ).toBe(false);
   });
 
   it('rejects contextSwitchOn values that are not 0 or 1', () => {
-    expect(decodeState(btoa(JSON.stringify({ cs: 2 })))!.contextSwitchOn).toBeUndefined();
+    expect(decodeState(btoa(JSON.stringify({ cs: 2 })))!.state.contextSwitchOn).toBeUndefined();
   });
 
   it('backward compatibility: URLs missing re/cs still decode the rest', () => {
-    const partialEncoded = btoa(JSON.stringify({ mp: 25, ts: 50 }));
-    const result = decodeState(partialEncoded)!;
-    expect(result.maintPct).toBe(25);
-    expect(result.teamSize).toBe(50);
-    expect(result.remediationPct).toBeUndefined();
-    expect(result.contextSwitchOn).toBeUndefined();
+    const result = decodeState(btoa(JSON.stringify({ mp: 25, ts: 50 })))!;
+    expect(result.state.maintPct).toBe(25);
+    expect(result.state.teamSize).toBe(50);
+    expect(result.state.remediationPct).toBeUndefined();
+    expect(result.state.contextSwitchOn).toBeUndefined();
   });
 
   // Pre-2026-05 URLs encoded slider-position integers under the old keys
   // (sp, bp, ap). The new decoder ignores them — accepted breakage per
   // the BL-032.8-adjacent precision-thrash fix (2026-05-21).
   it('ignores legacy slider-position keys (sp, bp, ap)', () => {
-    const legacyEncoded = btoa(JSON.stringify({ sp: 50, bp: 50, ap: 50 }));
-    const result = decodeState(legacyEncoded)!;
-    expect(result.salary).toBeUndefined();
-    expect(result.remediationBudget).toBeUndefined();
-    expect(result.arr).toBeUndefined();
+    const result = decodeState(btoa(JSON.stringify({ sp: 50, bp: 50, ap: 50 })))!;
+    expect(result.state.salary).toBeUndefined();
+    expect(result.state.remediationBudget).toBeUndefined();
+    expect(result.state.arr).toBeUndefined();
+    expect(result.adjusted).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem

Following a Tech Debt Calculator share link with populated advanced fields was broken in two compounding ways, reported via this repro:

```
/hub/tools/tech-debt-calculator/?s=eyJhIjowLCJ0cyI6NDIsInNhIjoxMDgwMDAsIm1wIjozMCwiZGkiOjYsImluIjowLCJtdHRyIjowLCJiZyI6MCwiYXIiOjMxNjgwMDAwLCJyZSI6MzAsImNzIjoxfQ==
```

1. **Advanced panel stayed collapsed.** The MCP `estimate_tech_debt_cost` deeplink builder hardcodes `advancedOpen: false`, so every shared link encodes `a:0` even though it always carries populated advanced fields (deploy frequency, incidents, ARR, context-switch…). The page honored `a:0`, leaving the advanced **results** breakdown (Direct Labor, Velocity, Debt % of ARR, Payback, Context-Switch cost) as em-dashes until the user manually toggled the panel open.

2. **Out-of-range values silently became defaults.** The MCP tool accepts a **wider** numeric domain than the calculator's sliders (`remediationBudget`/`arr` `>= 0`, `mttrHours >= 0` with `0` as an "unknown / elided" sentinel). `decodeState` validated against the *slider* bounds and **dropped** anything out of range, so the page fell back to an unrelated default. The repro link's `bg:0` / `mttr:0` silently rendered a **\$500K budget / 4h MTTR** and a **7-month payback** — when the tool computed a \$0 budget and "< 1 mo." A shared link misrepresented its own analysis with no signal to the reader.

## Fix

Both fixes land at the **consumer** (page load / decoder), so they repair links **already shared in the wild**, not just future ones.

**1. Auto-expand advanced panel** — when incoming URL state diverges from default on any advanced-tier field, open the panel on arrival so the full analysis (inputs + results breakdown) is visible. Core-only links (team size / salary / maintenance) stay collapsed.

**2. Clamp-and-warn instead of silent default** — `decodeState` now returns `{ state, adjusted }`:
- Present-but-out-of-range numeric values are **clamped to the nearest supported bound** (`bg:0 → $10K`, `mttr:0 → 1h`) rather than dropped; integer fields round to stay slider-representable. Clamping to a bound is inherently faithful and far closer to intent than an arbitrary default (`bg:0` now yields "< 1 mo", matching the tool).
- Each coercion records a human-readable label in `adjusted[]`; the page shows a visible notice ("Some values in this shared link were outside the calculator's supported range and have been adjusted to the nearest limit: …") so a clamped value is never indistinguishable from one the reader chose.

## Tests

- **Unit** (`tests/unit/tech-debt-engine.test.ts`): rewrote the `decodeState` suite to the `{ state, adjusted }` contract with clamp assertions, incl. direct repro cases for `bg:0` / `mttr:0`.
- **MCP round-trip** (`mcp-server/.../tech-debt-deeplink.test.ts`): updated to the new shape; in-range inputs round-trip verbatim with `adjusted: []`.
- **E2E** (`tests/e2e/tech-debt-calculator.test.ts`): the exact repro `?s=` link auto-expands + surfaces a notice naming Remediation Budget + Avg. Time to Resolve; an all-in-range link shows none; a core-only link stays collapsed.

Verification: `astro check` clean · eslint + stylelint clean · full unit suite **1112 passed** · TDC E2E **47 passed** (chromium).

## Scope note

Investigated the sibling **ICG** tool for the same bug class: its producer/consumer answer-value domains (`-1..3`) and `companyStage` enum **match exactly** (round-trip is byte-identical), so the clamp bug does **not** exist there — deliberately left untouched. The only ICG gap is a low-severity, scoring-safe "fail loud" opportunity (surfacing `unknownAnswerKeys` on the page for stale/typo'd keys), noted for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)