### PR TITLE
feat(radar): time-limit FYI (curated) item pinning

### DIFF
--- a/mcp-server/src/content/radar-live-store.ts
+++ b/mcp-server/src/content/radar-live-store.ts
@@ -33,7 +33,7 @@ import {
   recordInoreaderStatus,
   type InoreaderObservedSource,
 } from '../observability/inoreader-status';
-import { toSnapshotItem, type SnapshotItem } from './radar-transform';
+import { filterFreshFyi, toSnapshotItem, type SnapshotItem } from './radar-transform';
 import type { Env } from '../worker';
 
 const CACHE_TTL_SECONDS = 6 * 60 * 60; // 6h, matches website ISR window
@@ -181,6 +181,16 @@ export async function readWireLive(
  * On cache miss, calls Inoreader's annotated-stream endpoint via
  * `fetchAnnotatedItems`. Items are tagged `tier: 'fyi'`.
  *
+ * **Curated-item freshness**: returned items pass through `filterFreshFyi`
+ * (age cap `FYI_MAX_AGE_DAYS` + count cap `FYI_MAX_COUNT`). The filter runs
+ * at READ time on both the cache-hit and fresh-fetch paths — the Upstash
+ * cache stores the RAW items (unfiltered), so age is re-evaluated against
+ * the current clock on every read. An item therefore ages out the moment it
+ * crosses the cutoff, without waiting for the 6h TTL. Every live Worker
+ * consumer (website `/radar/snapshot`, `search_radar`, `get_latest_insights`,
+ * the `gst://radar/fyi` Resource, the hourly cron) routes through here, so
+ * this is the single enforcement point.
+ *
  * `opts.forceRefresh`: skip the cache lookup and always fetch from Inoreader.
  * Used by the BL-032.5 Phase 4 Worker Cron.
  *
@@ -196,9 +206,12 @@ export async function readFyiLive(
   if (cache && !opts.forceRefresh) {
     const cached = await cache.get<CachedTier>(CACHE_KEY_FYI);
     if (cached) {
-      // Limit cached items to the requested count (cache stores up to 30,
-      // callers may request fewer; just slice rather than re-fetching).
-      const items = cached.items.slice(0, count);
+      // Apply the freshness gate against the current clock (cache holds RAW
+      // items), then honor the caller's `count` upper bound. The trailing
+      // slice is a no-op in production — every caller passes count >= 30 and
+      // FYI_MAX_COUNT already caps lower — but preserves the "caller may
+      // request fewer" contract.
+      const items = filterFreshFyi(cached.items).slice(0, count);
       return { ok: true, tier: 'fyi', items, fetchedAt: cached.fetchedAt, cacheHit: true };
     }
   }
@@ -218,13 +231,21 @@ export async function readFyiLive(
   const fetchedAt = new Date().toISOString();
 
   if (cache) {
+    // Cache the RAW items (unfiltered) so the read-time freshness gate is
+    // always evaluated against the current clock — see docstring.
     await cache.set<CachedTier>(
       CACHE_KEY_FYI,
       { tier: 'fyi', items, fetchedAt },
       CACHE_TTL_SECONDS
     );
   }
-  return { ok: true, tier: 'fyi', items, fetchedAt, cacheHit: false };
+  return {
+    ok: true,
+    tier: 'fyi',
+    items: filterFreshFyi(items).slice(0, count),
+    fetchedAt,
+    cacheHit: false,
+  };
 }
 
 /** Map an InoreaderResult failure to the LiveTierResult failure shape. */

--- a/mcp-server/src/content/radar-snapshot.ts
+++ b/mcp-server/src/content/radar-snapshot.ts
@@ -15,6 +15,15 @@
  * We replicate the minimal cache-key + JSON-read logic locally rather
  * than reusing the website's `cache.ts` to keep the dependency surface
  * small (no Sentry import) and the budget-protection invariant explicit.
+ *
+ * FYI freshness gate is INTENTIONALLY NOT applied here. The live path
+ * (`radar-live-store.ts` `readFyiLive`) runs `filterFreshFyi` to age curated
+ * items out after 30 days. This offline reader deliberately does NOT — the
+ * seeded snapshot uses static fixture timestamps for deterministic, budget-
+ * free CI/dev, and age-filtering would make `search_radar_offline` and the
+ * embedded brief spontaneously empty once a committed fixture ages past the
+ * cutoff. The offline tier is a stand-in, not the source of truth; retention
+ * is enforced Worker-side only. See RADAR.md § FYI Content Retention.
  */
 
 import { createHash } from 'node:crypto';

--- a/mcp-server/src/content/radar-transform.ts
+++ b/mcp-server/src/content/radar-transform.ts
@@ -118,6 +118,58 @@ export function oldestItemDaysAgo(
 }
 
 /**
+ * Curated-item freshness caps (BL — Radar FYI time-limited pinning).
+ *
+ * FYI ("curated") items are Inoreader-annotated articles. Historically they
+ * had NO time-based expiry: an item stayed visible until 30 *newer*
+ * annotations pushed it out of the fetch window, so a curated take could
+ * float in the feed for months. These constants bound that: a curated item
+ * ages out `FYI_MAX_AGE_DAYS` after its annotation, and at most
+ * `FYI_MAX_COUNT` FYI items ever render. Applied via `filterFreshFyi` in
+ * `readFyiLive` (every live Worker consumer routes through it). The offline
+ * snapshot tier is intentionally exempt — see `radar-snapshot.ts`.
+ */
+export const FYI_MAX_AGE_DAYS = 30;
+export const FYI_MAX_COUNT = 15;
+
+/**
+ * Curated (FYI) freshness gate. Age is measured from `annotatedAt` (fallback
+ * `publishedAt`) — the product rule is "expire 30 days after *annotation*",
+ * not publication. Drops items older than `maxAgeDays` OR carrying an
+ * unparseable date (a retention filter must not leak items it cannot prove
+ * are fresh — the opposite defensiveness from `oldestItemDaysAgo`, which
+ * skips malformed dates when *measuring* age), then keeps the newest
+ * `maxCount` by annotation date.
+ *
+ * Boundary compares milliseconds directly (`now - ts <= maxAgeMs`): an item
+ * annotated exactly `maxAgeDays` ago is kept; `maxAgeDays` + 1ms is dropped.
+ * Future-dated annotations pass (negative age) and sort first, matching the
+ * future-clamp philosophy in `oldestItemDaysAgo`.
+ *
+ * Pure: pass `now` to make tests deterministic.
+ */
+export function filterFreshFyi(
+  items: readonly SnapshotItem[],
+  opts: { maxAgeDays: number; maxCount: number } = {
+    maxAgeDays: FYI_MAX_AGE_DAYS,
+    maxCount: FYI_MAX_COUNT,
+  },
+  now: number = Date.now()
+): SnapshotItem[] {
+  const maxAgeMs = opts.maxAgeDays * 86_400_000;
+  const keyMs = (it: SnapshotItem): number => Date.parse(it.annotatedAt ?? it.publishedAt);
+  return items
+    .filter((it) => {
+      const ts = keyMs(it);
+      if (!Number.isFinite(ts)) return false; // drop undate-able curated items
+      return now - ts <= maxAgeMs;
+    })
+    .slice()
+    .sort((a, b) => keyMs(b) - keyMs(a)) // newest-first BY annotation date
+    .slice(0, opts.maxCount);
+}
+
+/**
  * Transform an Inoreader API item into the SnapshotItem shape both the
  * offline tool and the live tools return. The `tier` parameter is the
  * caller's signal of which feed produced this item — FYI items carry

--- a/mcp-server/src/tools/radar-live.ts
+++ b/mcp-server/src/tools/radar-live.ts
@@ -248,7 +248,10 @@ export async function handleGetLatestInsights(
   if (breakerCheck) return breakerCheck;
 
   const limit = input.limit ?? 10;
-  const fyiResult = await readFyiLive(env, Math.max(limit, 30), { keyOwner }); // fetch 30 always so cache shared with search_radar
+  // Fetch 30 always so the Upstash cache is shared with search_radar. Note:
+  // readFyiLive caps FYI output at FYI_MAX_COUNT (15) via the freshness gate,
+  // so `limit` (schema max 30) can never actually yield more than 15 items.
+  const fyiResult = await readFyiLive(env, Math.max(limit, 30), { keyOwner });
   if (!fyiResult.ok) return failureResponse(env, fyiResult, 'live-get-latest-insights');
 
   const filtered = fyiResult.items

--- a/mcp-server/tests/integration/radar-live.test.ts
+++ b/mcp-server/tests/integration/radar-live.test.ts
@@ -105,21 +105,31 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
   });
 }
 
+// Anchor fixture timestamps to a recent, always-fresh base so the FYI
+// freshness gate (filterFreshFyi: drops annotations > 30 days old) never
+// removes them. The `published` argument is a small relative-recency rank
+// (higher = newer); we offset it from a base ~1 day ago, preserving the
+// ordering the sort-assertions rely on while keeping every item well inside
+// the 30-day window. Mirrors the `Date.now()`-anchoring in
+// tests/fixtures/radar-mock-data.ts.
+const RECENT_BASE_S = Math.floor(Date.now() / 1000) - 100_000;
+
 function makeInoreaderItem(
   id: string,
   published: number,
   category: 'GST-PE-MA' | 'GST-Enterprise-Tech' | 'GST-AI-Automation' | 'GST-Security',
   hasAnnotation = false
 ) {
+  const publishedTs = RECENT_BASE_S + published;
   return {
     id,
     title: `Title ${id}`,
-    published,
+    published: publishedTs,
     origin: { streamId: 's', title: 'Source', htmlUrl: 'https://example.com' },
     canonical: [{ href: `https://example.com/${id}` }],
     categories: [`user/-/label/${category}`],
     annotations: hasAnnotation
-      ? [{ id: 1, start: 0, end: 10, added_on: published, text: 'highlight', note: 'GST take' }]
+      ? [{ id: 1, start: 0, end: 10, added_on: publishedTs, text: 'highlight', note: 'GST take' }]
       : undefined,
   };
 }
@@ -232,6 +242,9 @@ describe('search_radar — happy path', () => {
 
 describe('search_radar — cache hit path', () => {
   it('returns cached items without invoking Inoreader fetch', async () => {
+    // Fresh annotatedAt so the read-time freshness gate keeps the cached
+    // item (cache holds raw items; filterFreshFyi runs on read).
+    const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const cachedFyi = {
       tier: 'fyi',
       items: [
@@ -241,13 +254,14 @@ describe('search_radar — cache hit path', () => {
           url: 'https://example.com/cached',
           source: 'CachedSrc',
           category: 'pe-ma',
-          publishedAt: '2026-05-01T00:00:00.000Z',
+          publishedAt: recentIso,
+          annotatedAt: recentIso,
           annotation: { highlightedText: 'h', gstTake: 't' },
         },
       ],
-      fetchedAt: '2026-05-01T00:00:00.000Z',
+      fetchedAt: recentIso,
     };
-    const cachedWire = { tier: 'wire', items: [], fetchedAt: '2026-05-01T00:00:00.000Z' };
+    const cachedWire = { tier: 'wire', items: [], fetchedAt: recentIso };
 
     redisGet.mockImplementation(async (key: string) => {
       if (key === 'mcp:radar:cache:wire') return { storedAt: Date.now(), data: cachedWire };

--- a/mcp-server/tests/unit/content/radar-transform-fresh-fyi.test.ts
+++ b/mcp-server/tests/unit/content/radar-transform-fresh-fyi.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for `filterFreshFyi` (Radar FYI time-limited pinning).
+ *
+ * Pinned behavior:
+ *   - empty input → []
+ *   - all fresh → passthrough, capped at maxCount (newest by annotatedAt)
+ *   - all stale → [] (curated tier may legitimately render empty)
+ *   - mixed → drops only the stale items
+ *   - > maxCount fresh → keeps the newest maxCount BY annotatedAt
+ *   - unparseable annotatedAt/publishedAt → dropped (expiry filter must not
+ *     leak items it cannot prove are fresh)
+ *   - future-dated annotation → kept and sorts first
+ *   - boundary: exactly maxAgeDays ago is KEPT; maxAgeDays + 1ms is DROPPED
+ *   - annotatedAt missing → falls back to publishedAt for the age/sort axis
+ *   - exported constants are the agreed values (30 / 15)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  filterFreshFyi,
+  FYI_MAX_AGE_DAYS,
+  FYI_MAX_COUNT,
+  type SnapshotItem,
+} from '../../../src/content/radar-transform';
+
+const NOW = new Date('2026-07-01T12:00:00.000Z').getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Build an FYI-shaped SnapshotItem annotated `daysAgo` days before NOW.
+ * Pass `overrides` to exercise the publishedAt-fallback / unparseable cases.
+ */
+function fyi(id: string, daysAgo: number, overrides: Partial<SnapshotItem> = {}): SnapshotItem {
+  return {
+    id,
+    title: `Item ${id}`,
+    url: `https://example.com/${id}`,
+    source: 'Example',
+    category: 'enterprise-tech',
+    publishedAt: new Date(NOW - daysAgo * DAY).toISOString(),
+    annotatedAt: new Date(NOW - daysAgo * DAY).toISOString(),
+    annotation: { gstTake: 'take' },
+    ...overrides,
+  };
+}
+
+const DEFAULT_OPTS = { maxAgeDays: FYI_MAX_AGE_DAYS, maxCount: FYI_MAX_COUNT };
+
+describe('filterFreshFyi', () => {
+  it('returns [] for empty input', () => {
+    expect(filterFreshFyi([], DEFAULT_OPTS, NOW)).toEqual([]);
+  });
+
+  it('passes through fresh items (newest-first by annotatedAt)', () => {
+    const items = [fyi('a', 10), fyi('b', 1), fyi('c', 20)];
+    const result = filterFreshFyi(items, DEFAULT_OPTS, NOW);
+    expect(result.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('returns [] when every item is stale (curated tier may be empty)', () => {
+    const items = [fyi('a', 31), fyi('b', 45), fyi('c', 400)];
+    expect(filterFreshFyi(items, DEFAULT_OPTS, NOW)).toEqual([]);
+  });
+
+  it('drops only the stale items in a mixed feed', () => {
+    const items = [fyi('fresh', 5), fyi('stale', 60), fyi('edge', 29)];
+    const result = filterFreshFyi(items, DEFAULT_OPTS, NOW);
+    expect(result.map((i) => i.id)).toEqual(['fresh', 'edge']);
+  });
+
+  it('keeps only the newest maxCount when more than maxCount are fresh', () => {
+    // 20 items, all fresh, annotated 0..19 days ago.
+    const items = Array.from({ length: 20 }, (_, i) => fyi(`i${i}`, i));
+    const result = filterFreshFyi(items, DEFAULT_OPTS, NOW);
+    expect(result).toHaveLength(FYI_MAX_COUNT);
+    // Newest 15 by annotation date → i0..i14.
+    expect(result.map((i) => i.id)).toEqual(
+      Array.from({ length: FYI_MAX_COUNT }, (_, i) => `i${i}`)
+    );
+  });
+
+  it('drops items with an unparseable date', () => {
+    const items = [
+      fyi('good', 3),
+      fyi('bad', 3, { annotatedAt: 'not-a-date', publishedAt: 'also-bad' }),
+    ];
+    const result = filterFreshFyi(items, DEFAULT_OPTS, NOW);
+    expect(result.map((i) => i.id)).toEqual(['good']);
+  });
+
+  it('keeps a future-dated annotation and sorts it first', () => {
+    const future = fyi('future', -5); // annotated 5 days in the future
+    const items = [fyi('now', 0), future, fyi('old', 10)];
+    const result = filterFreshFyi(items, DEFAULT_OPTS, NOW);
+    expect(result.map((i) => i.id)).toEqual(['future', 'now', 'old']);
+  });
+
+  it('keeps an item annotated exactly maxAgeDays ago (inclusive boundary)', () => {
+    const exactly = fyi('boundary', 0, {
+      annotatedAt: new Date(NOW - FYI_MAX_AGE_DAYS * DAY).toISOString(),
+    });
+    expect(filterFreshFyi([exactly], DEFAULT_OPTS, NOW).map((i) => i.id)).toEqual(['boundary']);
+  });
+
+  it('drops an item annotated maxAgeDays + 1ms ago (exclusive past the boundary)', () => {
+    const justPast = fyi('past', 0, {
+      annotatedAt: new Date(NOW - FYI_MAX_AGE_DAYS * DAY - 1).toISOString(),
+    });
+    expect(filterFreshFyi([justPast], DEFAULT_OPTS, NOW)).toEqual([]);
+  });
+
+  it('falls back to publishedAt when annotatedAt is absent', () => {
+    const noAnnotatedAt = fyi('pubonly', 0, {
+      annotatedAt: undefined,
+      publishedAt: new Date(NOW - 2 * DAY).toISOString(),
+    });
+    const stalePub = fyi('pubstale', 0, {
+      annotatedAt: undefined,
+      publishedAt: new Date(NOW - 90 * DAY).toISOString(),
+    });
+    const result = filterFreshFyi([noAnnotatedAt, stalePub], DEFAULT_OPTS, NOW);
+    expect(result.map((i) => i.id)).toEqual(['pubonly']);
+  });
+
+  it('defaults now to Date.now() when omitted', () => {
+    const recent = fyi('recent', 0, {
+      annotatedAt: new Date(Date.now() - 2 * DAY).toISOString(),
+    });
+    const ancient = fyi('ancient', 0, {
+      annotatedAt: new Date(Date.now() - 200 * DAY).toISOString(),
+    });
+    const result = filterFreshFyi([recent, ancient]);
+    expect(result.map((i) => i.id)).toEqual(['recent']);
+  });
+
+  it('exposes the agreed cap constants', () => {
+    expect(FYI_MAX_AGE_DAYS).toBe(30);
+    expect(FYI_MAX_COUNT).toBe(15);
+  });
+});

--- a/src/docs/hub/RADAR.md
+++ b/src/docs/hub/RADAR.md
@@ -100,12 +100,17 @@ Create folders in Inoreader prefixed with `GST-`:
 
 ### FYI Content Retention
 
-FYI items have no time-based expiry on the GST side. Visibility is determined by a **most-recent-N window**:
+FYI (curated) items age out under a **dual cap** enforced Worker-side, so a curated take no longer pins indefinitely:
 
-- The Radar fetches the **30 most recent** annotated items from Inoreader each ISR cycle
-- An item remains visible until it falls outside that top-30 window (i.e., 30+ newer annotations push it off)
-- Removing annotations (highlights/notes) in Inoreader also removes the item
-- There is up to a **6-hour stale window** between an item leaving the API and disappearing from the page (due to ISR cache)
+- **Age cap** — `FYI_MAX_AGE_DAYS = 30`: an item is dropped once its **annotation** (`annotatedAt`) is more than 30 days old. Age is measured from the annotation date, not the article's publish date.
+- **Count cap** — `FYI_MAX_COUNT = 15`: at most the **newest 15** surviving items (by annotation date) render.
+- Both caps are applied by `filterFreshFyi` (`mcp-server/src/content/radar-transform.ts`) inside `readFyiLive` (`radar-live-store.ts`) — the single choke point every live consumer routes through (website `/radar/snapshot`, `search_radar`, `get_latest_insights`, the `gst://radar/fyi` Resource, the hourly cron).
+- The filter runs at **read time** against the current clock; the Upstash cache stores the **raw** annotated items, so an item ages out the moment it crosses 30 days — the 6h cache no longer delays expiry.
+- **The FYI tier may render empty** if every annotation is older than 30 days. That is the intended consequence of the age cap — there is no "keep newest N even if stale" fallback.
+- Removing annotations (highlights/notes) in Inoreader still removes the item on the next refresh.
+- Constants live in `radar-transform.ts` — tune both in one place.
+
+> **Offline tier is exempt (by design).** The seeded offline snapshot (`npm run radar:seed`, the `search_radar_offline` tool, the `gst_radar_brief_today` prompt embed) uses static fixture timestamps for deterministic, budget-free CI/dev. `filterFreshFyi` is **not** applied there — see the header note in `mcp-server/src/content/radar-snapshot.ts`.
 
 ## Page UX Features
 


### PR DESCRIPTION
## Context

Curated **FYI** items on `/hub/radar` previously **pinned indefinitely**. They come from Inoreader's `annotated` stream (`n=30`) with **no time-based expiry** anywhere in the pipeline — an item stayed visible until 30 *newer* annotations pushed it out. With sparse curation (~30 per 6 months), a take could float in the feed for months.

## What changed

A **dual cap**, enforced **Worker-side** at the single choke point every live consumer routes through (`readFyiLive`):

- **Age cap** — `FYI_MAX_AGE_DAYS = 30`: drop items whose annotation (`annotatedAt`) is older than 30 days.
- **Count cap** — `FYI_MAX_COUNT = 15`: keep at most the newest 15 by annotation date.

New pure `filterFreshFyi` in `radar-transform.ts` (mirrors the existing `oldestItemDaysAgo` idiom) owns the logic. It runs at **read time** on both the cache-hit and fresh-fetch paths, while the Upstash cache still stores **raw** items — so age is re-evaluated against the current clock on every read and an item ages out the moment it crosses 30 days, not delayed by the 6h TTL.

Because every live consumer funnels through `readFyiLive`, the website `/hub/radar`, `search_radar`, `get_latest_insights`, and the `gst://radar/fyi` Resource all inherit the behavior consistently.

### Behavior notes
- **The FYI tier may now render empty** if every annotation is >30 days old — the intended consequence of an age cap. No "keep newest N even if stale" fallback (it would silently defeat the cap).
- **Offline/seed snapshot tier is intentionally exempt** (static fixture timestamps → age-filtering would make dev/CI surfaces spontaneously empty). Documented in `radar-snapshot.ts` and `RADAR.md`.

## Files
- `mcp-server/src/content/radar-transform.ts` — `filterFreshFyi` + `FYI_MAX_AGE_DAYS`/`FYI_MAX_COUNT`
- `mcp-server/src/content/radar-live-store.ts` — apply filter at read time in both `readFyiLive` branches
- `mcp-server/src/tools/radar-live.ts` — clarifying comment
- `mcp-server/src/content/radar-snapshot.ts` — header note (offline exemption)
- `src/docs/hub/RADAR.md` — rewrote §FYI Content Retention
- Tests: new `radar-transform-fresh-fyi.test.ts`; `radar-live.test.ts` fixtures re-anchored to relative timestamps

## Verification
- New unit + updated integration tests pass; full mcp-server suite **1532 passing**; `tsc --noEmit` clean; ESLint clean on changed files.
- To tune: change the two constants in `radar-transform.ts`.

## Observability heads-up (no code change)
- Cron `fyiItems` count now reports ≤15 (was ≤30).
- Any alert keyed on "oldest FYI item" age shifts, since FYI age is now capped at 30d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)