### PR TITLE
test(mcp-server): warm worker in beforeAll to fix ratelimit cold-start flake

### DIFF
--- a/mcp-server/tests/integration/ratelimit.test.ts
+++ b/mcp-server/tests/integration/ratelimit.test.ts
@@ -37,6 +37,15 @@ beforeAll(async () => {
       MCP_KEY_RP: TEST_KEY,
     },
   });
+
+  // Warm the worker before any test runs. `unstable_dev` resolves once the
+  // workerd process is spawned, but the FIRST `worker.fetch()` still pays a
+  // ~3s cold start (JIT-compiling + instantiating the module graph). Left
+  // unwarmed, that cost is billed to the first `it()` under vitest's 5000ms
+  // default test timeout — which intermittently times out under full-suite
+  // CPU contention. Paying it here, inside the 60s beforeAll budget, keeps
+  // every test's fetch on the warm (~10-90ms) path.
+  await worker.fetch('/health');
 }, 60_000);
 
 afterAll(async () => {


### PR DESCRIPTION
## Context

`mcp-server/tests/integration/ratelimit.test.ts` intermittently failed with `Error: Test timed out in 5000ms` at the first `worker.fetch('/mcp')` call. Investigated with two impartial agents + direct verification.

## Root cause

`beforeAll` boots a **real workerd** via `unstable_dev` under a 60s hook budget — but `unstable_dev` resolves when the process *spawns*, **before the worker is warm**. The first `worker.fetch('/mcp')` then pays a **~3.1s cold start** (JIT + module-graph eval), which vitest bills to the **first `it()`** under the default **5000ms** test timeout. That leaves only ~1.8s of headroom — enough to intermittently time out under full-suite CPU contention.

Verified empirically: within one boot the three tests clocked **3152ms / 88ms / 10ms** — the first is ~35× slower purely from cold start. This is a **test-harness fragility, not a product bug** (the `/mcp` path is unrelated to any recent product change).

## Fix

Add a warm-up `worker.fetch('/health')` at the end of `beforeAll`, so the cold start is paid inside the generous 60s hook budget instead of against a test's 5s timeout.

**Effect (measured):** first test drops from **~3150ms → ~35ms**; every fetch now runs on the warm (~10–90ms) path. Headroom against the 5s timeout goes from ~1.8s to ~4.9s — the flake surface is eliminated at its root rather than by widening the timeout.

## Files
- `mcp-server/tests/integration/ratelimit.test.ts` — one warm-up fetch (+9 lines)

## Verification
- Test passes across repeated isolation runs; per-test durations confirmed 33/37ms for the previously-slow first test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)