### PR TITLE
feat(bimi): BIMI logo asset + content-type header (BL-005)

### DIFF
--- a/public/branding/logo-bimi.svg
+++ b/public/branding/logo-bimi.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <title>Global Strategic Technologies</title>
+  <desc>GST delta icon — dark triangle outline on a solid teal background.</desc>
+  <rect width="512" height="512" fill="#00D9B5"/>
+  <path d="M256 96 L416 416 L96 416 Z" fill="none" stroke="#0a0a0a" stroke-width="48" stroke-linejoin="miter"/>
+</svg>

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -86,9 +86,9 @@ Consolidated backlog of open development initiatives for the GST website. Each i
 
 #### Acceptance Criteria
 
-- [ ] `public/branding/logo-bimi.svg` created in SVG Tiny PS profile (1:1 square, `version="1.2"`, `baseProfile="tiny-ps"`, no `<script>`/`<style>`, under 32KB)
-- [ ] `vercel.json` updated with `Content-Type: image/svg+xml` header for `/branding/logo-bimi.svg`
-- [ ] `curl -I https://globalstrategic.tech/branding/logo-bimi.svg` returns HTTP 200 with correct Content-Type, no redirects
+- [x] `public/branding/logo-bimi.svg` created in SVG Tiny PS profile (1:1 square, `version="1.2"`, `baseProfile="tiny-ps"`, no `<script>`/`<style>`, under 32KB) — 457 bytes, conformance-checked
+- [x] `vercel.json` updated with `Content-Type: image/svg+xml` header for `/branding/logo-bimi.svg`
+- [ ] `curl -I https://globalstrategic.tech/branding/logo-bimi.svg` returns HTTP 200 with correct Content-Type, no redirects — _pending merge to `master` + Vercel deploy_
 - [ ] BIMI TXT record added in Cloudflare: `default._bimi` -> `v=BIMI1; l=https://globalstrategic.tech/branding/logo-bimi.svg; a=;`
 - [ ] BIMI Inspector validation passes
 - [ ] Test email to Gmail shows logo in inbox

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,15 @@
       ]
     },
     {
+      "source": "/branding/logo-bimi.svg",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "image/svg+xml"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary

Implements the code portion of **BL-005: BIMI Logo Deployment** — the GST delta avatar that Gmail/Apple Mail/Yahoo display next to advisory emails once DNS is in place.

- Adds `public/branding/logo-bimi.svg` authored to the **SVG Tiny Portable/Secure (P/S)** profile the BIMI Inspector requires: square 512×512 `viewBox`, `version="1.2"` `baseProfile="tiny-ps"`, no `x`/`y` on root, required `<title>` + accessibility `<desc>`, solid (non-transparent) background, no script/style/animation/external refs. **457 bytes**, well under the 32 KB cap.
- Treatment: dark delta outline on solid teal `#00D9B5` — chosen for best legibility at small avatar sizes over the darker and light-background variants.
- Updates `vercel.json` to serve the asset with `Content-Type: image/svg+xml`.
- Ticks the two code-completable acceptance criteria in the backlog.

Requirements were verified against the authoritative [bimigroup.org SVG spec](https://bimigroup.org/creating-bimi-svg-logo-files/) rather than from memory, since the BIMI Inspector gates acceptance.

## Verification

- 12/12 P/S conformance checks pass (profile attrs, `<title>`, square viewBox, no `x/y`, solid bg, no script/style/animation/href/image).
- `vercel.json` re-validated as JSON.

## Remaining (deploy + DNS — post-merge, operator-driven)

- [ ] `curl -I https://globalstrategic.tech/branding/logo-bimi.svg` → `200` + `image/svg+xml`, no redirects
- [ ] Cloudflare TXT: `default._bimi` → `v=BIMI1; l=https://globalstrategic.tech/branding/logo-bimi.svg; a=;`
- [ ] BIMI Inspector validation passes
- [ ] Test email to Gmail shows the logo in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)