### PR TITLE
feat(irl-generator): per-section request preview panels + placeholder fix

### DIFF
--- a/src/pages/hub/tools/information-request-list-generator/index.astro
+++ b/src/pages/hub/tools/information-request-list-generator/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubHeader from '../../../../components/hub/HubHeader.astro';
+import DeltaIcon from '../../../../components/DeltaIcon.astro';
 import articleBodyRaw from '../../../../data/irl/information-request-list.md?raw';
 import { parseIrlArticle } from '../../../../utils/irl/parse-article';
 
@@ -11,6 +12,9 @@ import { parseIrlArticle } from '../../../../utils/irl/parse-article';
 const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
   number: s.number,
   title: s.title,
+  // Canonical request texts — rendered into the per-section hover panel so a
+  // user can preview what each section includes before choosing it.
+  bullets: s.bullets.map((b) => b.text),
 }));
 ---
 
@@ -61,7 +65,7 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
             name="companyName"
             type="text"
             class="brutal-input"
-            placeholder="e.g., Praxis Capital"
+            placeholder="e.g., Global Strategic Technologies"
             autocomplete="organization"
             maxlength="120"
           />
@@ -131,13 +135,60 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
             {
               irlSections.map((s) => (
                 <div class="irl-gen__section" data-section={s.number}>
-                  <label class="irl-gen__section-toggle">
-                    <input type="checkbox" name="sections" value={s.number} checked />
-                    <span class="irl-gen__section-name">
-                      <span class="irl-gen__section-num">{s.number}</span>
-                      {s.title}
+                  <div class="irl-gen__section-head">
+                    <label class="irl-gen__section-toggle">
+                      <input type="checkbox" name="sections" value={s.number} checked />
+                      <span class="irl-gen__section-name">
+                        <span class="irl-gen__section-num">{s.number}</span>
+                        {s.title}
+                      </span>
+                    </label>
+                    <span class="irl-gen__section-info">
+                      <button
+                        type="button"
+                        class="irl-gen__section-info-btn"
+                        aria-label={`Requests included in section ${s.number} ${s.title}`}
+                        aria-describedby={`irl-sec-panel-${s.number}`}
+                      >
+                        <svg
+                          viewBox="0 0 16 16"
+                          width="15"
+                          height="15"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" />
+                          <line
+                            x1="8"
+                            y1="7"
+                            x2="8"
+                            y2="11.5"
+                            stroke="currentColor"
+                            stroke-width="1.5"
+                            stroke-linecap="round"
+                          />
+                          <circle cx="8" cy="4.6" r="0.95" fill="currentColor" />
+                        </svg>
+                      </button>
+                      <div
+                        class="irl-gen__section-panel"
+                        role="tooltip"
+                        id={`irl-sec-panel-${s.number}`}
+                      >
+                        <span class="irl-gen__section-panel-head">
+                          Requests in {s.number} — {s.title}
+                        </span>
+                        <ul class="irl-gen__section-panel-list">
+                          {s.bullets.map((b) => (
+                            <li>
+                              <DeltaIcon class="bullet-icon" />
+                              {b}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                     </span>
-                  </label>
+                  </div>
                   <div class="irl-gen__custom-list" data-section={s.number} />
                   <button
                     type="button"
@@ -572,6 +623,103 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
     color: var(--color-primary);
   }
 
+  /* Section row: the toggle label + the info affordance sit on one line. */
+  .irl-gen__section-head {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+  }
+
+  /* Hover/focus affordance that reveals the per-section request panel. */
+  .irl-gen__section-info {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .irl-gen__section-info-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    background: none;
+    border: 0;
+    color: var(--text-muted);
+    cursor: help;
+    transition: color var(--transition-fast);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .irl-gen__section-info-btn:hover,
+  .irl-gen__section-info-btn:focus-visible {
+    color: var(--color-primary);
+  }
+
+  .irl-gen__section-info-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
+
+  /* Floating request-preview panel — mirrors the .brutal-map-tooltip language
+     (solid surface, 2px square border, mono head). Positioned to the right of
+     the icon on desktop; repositioned below on mobile (see media query). */
+  .irl-gen__section-panel {
+    position: absolute;
+    top: 50%;
+    left: calc(100% + var(--spacing-sm));
+    transform: translateY(-50%);
+    z-index: 30;
+    width: max-content;
+    max-width: 340px;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: light-dark(var(--bg-light), var(--bg-dark-secondary));
+    border: 2px solid light-dark(var(--border-light), var(--border-dark-default));
+    border-radius: 0;
+    text-align: left;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      opacity var(--transition-fast),
+      visibility var(--transition-fast);
+  }
+
+  .irl-gen__section-info:hover .irl-gen__section-panel,
+  .irl-gen__section-info:focus-within .irl-gen__section-panel {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .irl-gen__section-panel-head {
+    display: block;
+    margin-bottom: var(--spacing-xs);
+    font-family: var(--font-family-mono);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-bold);
+    color: var(--text-primary);
+  }
+
+  .irl-gen__section-panel-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Delta-symbol bullets — the site-wide `.bullet-icon` convention (see
+     /brand and .brutal-gateway-card__features): flex row, delta glyph + text. */
+  .irl-gen__section-panel-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+    font-size: var(--text-sm);
+    line-height: 1.45;
+    color: var(--text-secondary);
+  }
+
   /* "Add custom request" uses the global .brutal-btn--secondary brand class;
      only its placement + compact sizing are page-local. */
   .irl-gen__add-custom {
@@ -651,6 +799,16 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
 
     .irl-gen__form {
       padding: var(--spacing-lg);
+    }
+
+    /* No hover on touch and no room to the side — anchor the panel below the
+       icon (tapping the button focuses it, so :focus-within still reveals it). */
+    .irl-gen__section-panel {
+      top: calc(100% + var(--spacing-xs));
+      left: auto;
+      right: 0;
+      transform: none;
+      max-width: min(340px, 82vw);
     }
   }
 


### PR DESCRIPTION
Misc changes to the Information Request List generator (Hub tool). Grouped on a `feat/misc-changes` branch.

## 1. Per-section request preview panels

Each section in "Sections to include" now has a small **ⓘ button**. Hovering it (desktop), focusing it (keyboard), or tapping it (mobile) reveals a panel listing that section's canonical requests — so a user can preview what a section covers before choosing it.

- **Server-rendered, no client JS** — the request texts are added to the existing build-time `irlSections` map and rendered into a static `role="tooltip"` panel per section, so the content stays in lockstep with the generator source automatically.
- **On-brand styling** — brutalist tooltip surface (`light-dark()` tokens, 2px square border, mono heading) with the site-wide `.bullet-icon` **delta-symbol** bullets (same convention as the hub cards / TOC / `/brand`). Works in light + dark.
- **Position** — to the right of the section on desktop; repositioned below on mobile (`≤768px`).
- **Accessible** — real `<button>` trigger with `aria-label` + `aria-describedby` → the tooltip; `:focus-within` reveals it for keyboard, tap-focus reveals it on touch.
- **No DOM-contract change** — checkboxes are still `input[name="sections"]` / `data-section`; the client JS (select-all, deeplink hydration, custom requests) and E2E are unaffected (verified by inspection).

## 2. Placeholder fix

Replaced the fake default company-name placeholder **"Praxis Capital"** with **"Global Strategic Technologies"** (the actual requesting company). Only the visible placeholder changed — the test fixtures / MCP doc example that use "Praxis Capital" pass their own values and are untouched; no test asserts the placeholder text.

## Verification

- `astro check` (0 errors), `lint:css` clean, production build clean.
- Panel confirmed rendering correctly (delta bullets, not clipped) in **light and dark** at desktop width.
- Website-only change (`src/pages/**`); the MCP suite correctly does not run for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
