### PR TITLE
BL-049 closeout: BACKLOG truth-pass + curly-quote normalization + meta-fence literal (mcp-server 0.38.0)

### DIFF
--- a/mcp-server/BREAKING_CHANGES.md
+++ b/mcp-server/BREAKING_CHANGES.md
@@ -11,7 +11,7 @@
 ## Current manifest hash
 
 ```
-6105444438c74a283764949e0c85066c7d239c3ee6d05974369e8e1e44d5943c
+26dce144d2cc433b045f088869c66896e28fe62fb1ba10b660e1d96eb3724b6f
 ```
 
 Computed over (sorted):
@@ -20,12 +20,27 @@ Computed over (sorted):
 - 123 Regulation URIs (BL-057: +3 — NIST AI RMF, UK pro-innovation AI framework, Chile Ley 21.719). Aliases (BL-073 + BL-073 acronym add-on `NIST AI RMF` / `NIST RMF` on `US-NIST-AI-RMF.json`) are NOT in the manifest hash inputs — they're an additive matching layer in `compose_dossier_envelope`'s server-side validation, not a registry shape change.
 - 6 Radar URIs.
 - **16** tool names (`list_irl_requests` added by the 0.37.0 per-question-removal work; tool names are NOT manifest-hash inputs — the count here is descriptive).
-- **9** prompt `name@version` tuples — `gst_information_request_list` at `0.0.7` (per-question removal + BL-044.5 directives — see the 0.37.0 stanza below) + `gst_irl_ingestion` at `0.21.0` (its IRL taxonomy embed decoupled onto the generator source — see the 0.36.0 stanza below).
+- **9** prompt `name@version` tuples — `gst_information_request_list` at `0.0.7` (per-question removal + BL-044.5 directives — see the 0.37.0 stanza below) + `gst_irl_ingestion` at `0.21.1` (meta-fence stale version literal replaced with a server-derived placeholder — see the 0.38.0 stanza below).
 
 If this hash differs from the value in
 [`tests/integration/manifest-stability.test.ts`](./tests/integration/manifest-stability.test.ts) → `EXPECTED_MANIFEST_HASH`,
 the test will fail with a remediation message. Update **both** values
 in lockstep when the registry shape changes.
+
+---
+
+## 0.38.0 — 2026-07-09 — BL-049 closeout hardening — `normalizeForMatching` curly-quote flattening + meta-fence stale version literal (`gst_irl_ingestion` v0.21.0 → v0.21.1)
+
+**Theme**: closes out BL-049 (BACKLOG truth-pass landed in the same PR — the stanza's "Open" status was a month stale; the server-side xlsx path stays deferred indefinitely per the [revisit blueprint](../src/docs/development/MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md)). Two code remnants ship:
+
+**1. Curly-quote flattening in `normalizeForMatching`** (`src/schemas/validate-irl-provenance.ts`): U+2018 U+2019 U+201C U+201D join the punctuation-to-space class, symmetric with the existing straight-quote handling. This closes the last encoding-drift class from BL-049's original problem statement — em-dashes were already flattened, and NBSP variants (U+00A0/U+202F) were already covered because JS `\s` matches all Unicode space separators (now locked with regression tests).
+
+- **Dossier impact (verdict-widening only)**: citations that previously landed `unverified` purely on curly-vs-straight quote drift between citation and body now verify. The transform is symmetric on needle and haystack, so nothing previously verified can regress. `compose_dossier_envelope` inherits transitively via `runIrlProvenanceCheck`.
+- No contract shape change: no tool/prompt/Resource names or schemas touched by this part.
+
+**2. Meta-fence stale version literal** (`gst_irl_ingestion` **v0.21.0 → v0.21.1**): the `META_JSON_FENCE_DIRECTIVE` example JSON hardcoded `"promptVersion": "0.4.0"` (five months stale). Replaced with a self-explaining placeholder — `compose_dossier_envelope` server-derives `promptVersion` from the prompt registry and overrides whatever the model emits, so the literal was cosmetic; the placeholder now says so. Deliberately NOT interpolating the live version constant: that would drift the body hashes on every future version bump and destroy the hash-stability test's attribution value.
+
+- **Hash fan-out**: the directive appears only in the one-shot and extract-only bodies, so **6 of 7** `irl-ingestion-body-hash-stability` hashes rebaseline (interactive unchanged). Manifest hash rebaselines from the single `gst_irl_ingestion@0.21.1` tuple: `6105444438c74a28…` → `26dce144d2cc433b…`.
 
 ---
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/prompts/irl-ingestion.ts
+++ b/mcp-server/src/prompts/irl-ingestion.ts
@@ -261,7 +261,7 @@ const META_JSON_FENCE_DIRECTIVE = [
   '```json',
   '{',
   '  "promptName": "gst_irl_ingestion",',
-  '  "promptVersion": "0.4.0",',
+  '  "promptVersion": "<server-derived — compose_dossier_envelope overrides this with the prompt-registry version>",',
   '  "modelVersion": "<your model id at invocation time, e.g. claude-opus-4-7>",',
   '  "mode": "full | extract-only",',
   '  "verbosity": "verbose | compact",',
@@ -1068,8 +1068,8 @@ export const irlIngestionPrompt: GstPrompt<typeof argsSchema> = {
   name: PROMPT_NAME,
   description:
     'Bookend to gst_information_request_list — ingest a populated IRL and orchestrate every applicable Hub tool + downstream artifact to produce a unified engagement dossier. Scenario-neutral: serves buy-side diligence, sell-side prep, value-creation engagements, and post-close hardening. The "high-fidelity intake → full platform ingestion" workflow.',
-  version: '0.21.0',
-  lastReviewedAt: '2026-07-04',
+  version: '0.21.1',
+  lastReviewedAt: '2026-07-09',
   orchestrates: [...ORCHESTRATED_TOOLS, IRL_SOURCE_EMBED_URI, VDR_RESOURCE_URI] as const,
   argsSchema,
   build: (args) => {

--- a/mcp-server/src/schemas/validate-irl-provenance.ts
+++ b/mcp-server/src/schemas/validate-irl-provenance.ts
@@ -170,13 +170,20 @@ export interface ValidateIrlProvenanceResult {
  * the fuzzy-run logic can use. Before this, `cad/mo` survived intact as
  * a single token, which made `cad/mo` in citation vs `cad / mo` in body
  * fail substring AND fuzzy.
+ *
+ * BL-049 closeout hardening (2026-07-09): curly quotes (U+2018 U+2019
+ * U+201C U+201D) flatten to space alongside their straight equivalents,
+ * so `don’t` in a citation matches `don't` in the body and vice versa —
+ * the last encoding-drift class from the BL-049 problem statement
+ * (em-dashes were already flattened; NBSP variants are already covered
+ * because JS `\s` matches all Unicode space separators).
  */
 export function normalizeForMatching(s: string): string {
   return s
     .toLowerCase()
     .replace(/[*`_~]+/g, '')
     .replace(/[—–-]+/g, ' ')
-    .replace(/[,;:.?!()[\]{}'"/+]+/g, ' ')
+    .replace(/[,;:.?!()[\]{}'"‘’“”/+]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/mcp-server/tests/integration/irl-ingestion-body-hash-stability.test.ts
+++ b/mcp-server/tests/integration/irl-ingestion-body-hash-stability.test.ts
@@ -240,16 +240,22 @@ function hashPromptOutput(args: Parameters<typeof irlIngestionPrompt.build>[0]):
 // gst_information_request_list embed-strip means the new skip-if tag itself
 // does NOT change the tag-free bytes (the prompt embed-strip unit test locks
 // that) — this rebaseline is line-ending hygiene, not a body-semantics change.
+// BL-049 closeout rebaseline (prompt v0.21.0 → v0.21.1, 2026-07-09): the stale
+// `promptVersion: "0.4.0"` literal in META_JSON_FENCE_DIRECTIVE was replaced
+// with a server-derived placeholder. That directive appears only in the
+// one-shot and extract-only bodies, so 6 of 7 hashes drift — the interactive
+// hash is unchanged (deliberately NOT interpolating the live version constant,
+// which would churn these hashes on every future version bump).
 const EXPECTED_HASH_INTERACTIVE =
   'de70481c9ef59babc8bd2282c2d0867d25833e944fb42547771b3c66132e881c';
 const EXPECTED_HASH_ONESHOT_MINIMAL =
-  'fd1e8482c7c96108326bfe766889210bc100d6face379c83e540d55e053bc326';
+  'cfc9413bec5dd98e9c9e03f91a8048917487d08d6863d17bccb2cd89d653eb11';
 const EXPECTED_HASH_ONESHOT_FULL =
-  '6c20f9831df56dc480eab53f00da68c745fb424d11898bb7b52c60a0264bdccb';
+  'd00deefd4b0f354314b5c948d945640926de328a99ddaeea770bdb1c2e59c736';
 const EXPECTED_HASH_EXTRACT_ONLY_MINIMAL =
-  'a959d2f1053749d43657030f0c66942d84c1c081b0cfc5b9eaee71fc03964f39';
+  '6ad7aeb685c273bca6137e5cee65422e93d13c2e7ae91da2cd1b22a61d48dfd3';
 const EXPECTED_HASH_EXTRACT_ONLY_FULL =
-  '1c9b50b0aa0e7ede77ba7021fd8bd7109d3c25ed136cc2350c30045504e1dc7f';
+  '2a7f7e4f85c5342ae6a2955a95cde50adaf7eaff337c4d2b04451db7fc557d03';
 // BL-045 PR B audit M1 — compact-verbosity coverage. Verbose-default
 // scenarios above don't catch a regression where compact mode silently
 // gains a verbose-only directive (PER_SECTION_JSON_FENCE_DIRECTIVE,
@@ -259,9 +265,9 @@ const EXPECTED_HASH_EXTRACT_ONLY_FULL =
 // Compact bodies include the directive annotations + verify-block schema
 // expansion same as verbose.
 const EXPECTED_HASH_ONESHOT_FULL_COMPACT =
-  'b1aefd91392bb2cc128ba171fb3d887906d8eb7ccfd7a25348fbabba7427fe7c';
+  '9f0458c1d012f026cf2d52cfc96dca7831248fa7e999a553ea79c81cf457ab97';
 const EXPECTED_HASH_EXTRACT_ONLY_FULL_COMPACT =
-  '6fe7d56c06071a781476b7d90021a029a892d2b5b7c18686ecd112f69f55d6d6';
+  '869175c9fc58193e75d95ffe52d89c3618bcc2d6ff6bc094f8ca10a06604eeff';
 
 interface Scenario {
   name: string;

--- a/mcp-server/tests/integration/manifest-stability.test.ts
+++ b/mcp-server/tests/integration/manifest-stability.test.ts
@@ -129,7 +129,11 @@ import { ALL_PROMPTS } from '../../src/prompts/_registry';
 // hashed), and the tagged source .md does NOT drift the irl-ingestion body
 // hashes because embedIrlGeneratorSource strips directive comment lines
 // (the embedded bytes are unchanged).
-const EXPECTED_MANIFEST_HASH = '6105444438c74a283764949e0c85066c7d239c3ee6d05974369e8e1e44d5943c';
+// BL-049 closeout rebaseline: gst_irl_ingestion v0.21.0 → v0.21.1 (stale
+// promptVersion literal in META_JSON_FENCE_DIRECTIVE replaced with a
+// server-derived placeholder). Drifts solely from that one prompt
+// name@version tuple.
+const EXPECTED_MANIFEST_HASH = '26dce144d2cc433b045f088869c66896e28fe62fb1ba10b660e1d96eb3724b6f';
 
 function computeManifestHash(): string {
   const libraryUris = LIBRARY_ENTRIES.map((e) => e.uri).sort();

--- a/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
+++ b/mcp-server/tests/unit/prompts/irl-ingestion.test.ts
@@ -92,7 +92,9 @@ describe('gst_irl_ingestion', () => {
     // rescope (rename, scenario-neutral framing, mode/verbosity/forceTools args,
     // inclusion gates, JSON fences, provenance footer, gap list).
     // v0.21.0: IRL taxonomy embed decoupled onto the generator source (gst://irl/source).
-    expect(irlIngestionPrompt.version).toBe('0.21.0');
+    // v0.21.1: stale promptVersion literal in META_JSON_FENCE_DIRECTIVE replaced
+    // with a server-derived placeholder (BL-049 closeout).
+    expect(irlIngestionPrompt.version).toBe('0.21.1');
     expect(irlIngestionPrompt.lastReviewedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(irlIngestionPrompt.orchestrates.length).toBeGreaterThanOrEqual(11);
   });

--- a/mcp-server/tests/unit/schemas/validate-irl-provenance.test.ts
+++ b/mcp-server/tests/unit/schemas/validate-irl-provenance.test.ts
@@ -55,6 +55,22 @@ describe('normalizeForMatching', () => {
     const twice = normalizeForMatching(once);
     expect(twice).toBe(once);
   });
+  it('flattens curly quotes into spaces (BL-049 closeout hardening)', () => {
+    expect(normalizeForMatching('“smart” ‘quotes’')).toBe('smart quotes');
+  });
+  it('normalizes curly and straight quotes identically', () => {
+    expect(normalizeForMatching('don’t “quote” me')).toBe(
+      normalizeForMatching('don\'t "quote" me')
+    );
+  });
+  it('collapses NBSP variants like regular whitespace (regression lock — JS \\s covers Zs)', () => {
+    expect(normalizeForMatching('a\u00A0b\u202Fc')).toBe('a b c');
+  });
+  it('is idempotent over curly-quote + NBSP input', () => {
+    const sample = 'the CTO said “we can’t\u00A0migrate” — twice';
+    const once = normalizeForMatching(sample);
+    expect(normalizeForMatching(once)).toBe(once);
+  });
 });
 
 describe('extractExcerpt', () => {
@@ -100,6 +116,89 @@ describe('runIrlProvenanceCheck — verbatim verification', () => {
         {
           path: '_audit.revenueRange.citation',
           citation: 'Section 00 — annual RECURRING revenue: $45.2M Q1-FY26 annualized',
+        },
+      ],
+    });
+    expect(result.verified).toBe(1);
+    expect(result.verdicts[0].status).toBe('verified');
+  });
+});
+
+describe('runIrlProvenanceCheck — encoding drift (BL-049 closeout hardening)', () => {
+  // The v11 StoreForce false-positive class: body and citation carry the
+  // same content but drift on quote style, NBSP, or dash flavor because
+  // they were produced by different text pipelines. NBSP is injected
+  // via \u00A0 escapes so the drift under test stays visible here.
+  const STRAIGHT_QUOTE_IRL = `# Information Request List — Acme (returned)
+
+## 03 — Vendor Lock-In
+
+- Migration posture: the CTO said "we cannot migrate off Aurora before FY27" per the diligence call
+- Failover topology: Redis – Aurora failover is exercised quarterly in us-east-1
+`;
+
+  const CURLY_QUOTE_IRL = `# Information Request List — Acme (returned)
+
+## 03 — Vendor Lock-In
+
+- Migration posture: the CTO said “we cannot migrate off Aurora before FY27” per the diligence call
+`;
+
+  it('verifies a curly-quote citation against a straight-quote body', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: STRAIGHT_QUOTE_IRL,
+      citations: [
+        {
+          path: '_audit.lockIn.citation',
+          citation:
+            'Section 03 — the CTO said “we cannot migrate off Aurora before FY27” per the diligence call',
+        },
+      ],
+    });
+    expect(result.verified).toBe(1);
+    expect(result.verdicts[0].status).toBe('verified');
+  });
+
+  it('verifies a straight-quote citation against a curly-quote body', () => {
+    const result = runIrlProvenanceCheck({
+      filledIrl: CURLY_QUOTE_IRL,
+      citations: [
+        {
+          path: '_audit.lockIn.citation',
+          citation:
+            'Section 03 — the CTO said "we cannot migrate off Aurora before FY27" per the diligence call',
+        },
+      ],
+    });
+    expect(result.verified).toBe(1);
+    expect(result.verdicts[0].status).toBe('verified');
+  });
+
+  it('verifies a plain-space citation against an NBSP-bearing body (regression lock)', () => {
+    const nbspBody = STRAIGHT_QUOTE_IRL.replace('exercised quarterly', 'exercised\u00A0quarterly');
+    const result = runIrlProvenanceCheck({
+      filledIrl: nbspBody,
+      citations: [
+        {
+          path: '_audit.failover.citation',
+          citation: 'Section 03 — Redis – Aurora failover is exercised quarterly in us-east-1',
+        },
+      ],
+    });
+    expect(result.verified).toBe(1);
+    expect(result.verdicts[0].status).toBe('verified');
+  });
+
+  it('verifies under combined drift: curly quotes + NBSP in the same excerpt', () => {
+    const driftedBody = CURLY_QUOTE_IRL.replace('per the', 'per\u00A0the');
+    const result = runIrlProvenanceCheck({
+      filledIrl: driftedBody,
+      citations: [
+        {
+          path: '_audit.lockIn.citation',
+          // straight quotes + plain spaces vs the body's curly quotes + NBSP
+          citation:
+            'Section 03 — the CTO said "we cannot migrate off Aurora before FY27" per the diligence call',
         },
       ],
     });

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -3302,11 +3302,11 @@ Audit caught that the counters T4 surfaces don't exist yet — they require new 
 
 Per CLAUDE.md § 4a "no deferred tech debt": deferral is acceptable when there is a written trigger condition for revisit and the deferred work is NOT verification of code currently in scope. Phase D meets both criteria — it's net-new automation with explicit trigger thresholds above, not unfinished verification. The deprioritization stays honest by naming the conditions under which it gets re-evaluated.
 
-### BL-049: `gst_irl_ingestion` — Server-Side xlsx Canonicalization for Hash-Bind Authority
+### BL-049: `gst_irl_ingestion` — Server-Side xlsx Canonicalization for Hash-Bind Authority ✅ CLOSED 2026-07-09 (subset shipped at 0.13.1; xlsx path deferred indefinitely → design doc)
 
 > **Design doc**: [MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md](MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md)
 
-**Source**: BL-045 PR B v11 StoreForce live exercise (2026-06-03) — the hash-bind forcing function in `compose_dossier_envelope` (shipped under v0.12.0 / prompt `gst_irl_ingestion@0.4.0`) empirically validated the architectural pattern: when the model passes the verbatim IRL bytes as `filledIrl`, the verifier authoritatively confirms each citation's substring presence. **But the v11 trace also exposed an upstream workflow gap**: when partners attach an `.xlsx` IRL file in Claude Desktop rather than pasting markdown into the `filledIrl` prompt arg, the model must reconstruct the IRL body from spreadsheet cells — and BOTH the body AND the citations become model-generated. Hash-bind then validates internal consistency (the model's bytes hash to the model's hash) but cannot bind to the original spreadsheet as an authoritative source. The v11 dossier produced 30 false-positive `tier-mismatch:` entries on this exact mechanism even after the model executed a substring-validation loop, because the model regenerated the body and citations as two separate text streams with subtle encoding drift between them. | **Effort**: 2-4 hours (Path A — new MCP tool) OR 4-6 hours (Path B — extended prompt arg). | **Status**: 🟦 **Open · Priority: medium** — closes the architecture's last empirical gap for the most operator-natural workflow (xlsx file attachment). Senior-consultant 9×4 review (BL-045 PR B closure) can proceed at v0.12.0 because the v11 trace demonstrates the model self-correction loop works; this ticket eliminates the remaining false-positive class. | **Depends on**: BL-045 PR B merged at v0.12.0.
+**Source**: BL-045 PR B v11 StoreForce live exercise (2026-06-03) — the hash-bind forcing function in `compose_dossier_envelope` (shipped under v0.12.0 / prompt `gst_irl_ingestion@0.4.0`) empirically validated the architectural pattern: when the model passes the verbatim IRL bytes as `filledIrl`, the verifier authoritatively confirms each citation's substring presence. **But the v11 trace also exposed an upstream workflow gap**: when partners attach an `.xlsx` IRL file in Claude Desktop rather than pasting markdown into the `filledIrl` prompt arg, the model must reconstruct the IRL body from spreadsheet cells — and BOTH the body AND the citations become model-generated. Hash-bind then validates internal consistency (the model's bytes hash to the model's hash) but cannot bind to the original spreadsheet as an authoritative source. The v11 dossier produced 30 false-positive `tier-mismatch:` entries on this exact mechanism even after the model executed a substring-validation loop, because the model regenerated the body and citations as two separate text streams with subtle encoding drift between them. | **Effort**: 2-4 hours (Path A — new MCP tool) OR 4-6 hours (Path B — extended prompt arg). | **Status**: ✅ **CLOSED 2026-07-09** — empirically-validated subset shipped at v0.13.1 (PR #219); server-side xlsx path deferred indefinitely with the design doc as canonical revisit blueprint (see Closure below). | **Depends on**: BL-045 PR B merged at v0.12.0.
 
 **As a** GST partner ingesting a populated IRL via Claude Desktop, **I want** to attach the `.xlsx` directly to the conversation instead of pre-converting to markdown **so that** the hash-bind forcing function in `compose_dossier_envelope` validates citations against an authoritative server-canonicalized IRL body — eliminating the v11-class false-positive `tier-mismatch` entries that occur when the model regenerates both the body and the citations independently.
 
@@ -3322,37 +3322,17 @@ Under v0.12.0 the prompt body embeds `**Body-binding hash:** <16-hex>` computed 
 4. Model reconstructs a markdown IRL body from xlsx cells + computes its own hash. Tool's hash check passes (model's bytes hash to model's hash) but the binding is to **the model's reconstruction**, not the original spreadsheet.
 5. Citations the model emits are also reconstructed from the spreadsheet; subtle encoding drift between the body and citations (em-dash vs hyphen, smart quotes, NBSP) causes substring matching to fail even after normalization.
 
-#### Two implementation paths (pick during scoping)
+#### Closure (2026-07-09) — truth-pass
 
-**Path A — New MCP tool `extract_irl_from_xlsx`**
+This stanza sat at "Open" for a month after the work actually happened. Reconciled record:
 
-- New pure tool taking `xlsxBase64: string` (or `resourceUri: string` pointing at a session-scoped cached file) → returns `{ filledIrlMarkdown: string, irlBodyHash: string, sectionsParsed: number, substantiveCellsCounted: number }`.
-- Operator workflow: attach xlsx → invoke `/gst_irl_ingestion` interactive → ask model to call `extract_irl_from_xlsx` first → model re-invokes `/gst_irl_ingestion` with the returned `filledIrlMarkdown` as the `filledIrl` arg. From that point the existing hash-bind architecture fires correctly.
-- Effort: ~2-4 hours (xlsx parsing via the existing `xlsx-js-style` dep already in `mcp-server/package.json`; canonical-form serializer per the IRL article shape; unit tests against the StoreForce + MedSig fixtures).
-- Drawback: two-step model interaction (extract, then re-invoke) — adds one round-trip but keeps the prompt arg contract pure.
+**Shipped subset (v0.13.1, PR #219 — merge `ee607a11`, content `12f50691`, 2026-06-04).** Path A was implemented in full inside PR #219 (`extract_irl_from_xlsx` tool, `receipt-hmac.ts` + `RECEIPT_HMAC_KEY`, `irlSource: 'xlsx-canonicalized'` + `receipt` schema fields, ~37 tests), live-validated (v12 StoreForce), then **partial-reverted pre-merge**: Claude Desktop attachments cannot deliver bytes to the MCP server — base64 args truncate at ~10KB (real workbooks run 30–100KB) and cross-host file paths are unreachable in the Desktop + stdio topology. What survived the revert: `tier-fabrication` gap category + `deriveTier()` (demote-to-dodge guard), `BL_045_VERIFY_DIRECTIVE` on every prompt body, `extractExcerpt` `lastIndexOf('—')` hardening, and `normalizeForMatching` `/` + `+` flattening. The same commit shipped BL-055's `pass-bound`/`pass-internal` hashBindResult split (no BACKLOG stanza — documented in BREAKING_CHANGES 0.13.1).
 
-**Path B — Extended `gst_irl_ingestion` prompt arg `filledIrlXlsx?: string`**
+**Goal met via superseding mechanisms.** The authoritative-source objective is served today by: the offline extractor `mcp-server/scripts/extract-irl-markdown.mjs` (`npm run irl:extract`, PR #248) + [IRL_PARTNER_PASTE_RUNBOOK.md](IRL_PARTNER_PASTE_RUNBOOK.md); BL-072's auto `provenance-gap:` disclosure on `model-reconstruction-*` sources (0.26.0); BL-076 body-by-hash; BL-079 render-time cache prepop (`partner-paste-verbatim-prepop` → `pass-bound`); and the `requireVerbatimBody: true` hard gate (`Bl070VerbatimBodyRequiredError`).
 
-- Extend `argsSchema` with an optional `filledIrlXlsx: z.string()` arg accepting base64 xlsx bytes.
-- Prompt build seam: if `filledIrlXlsx` is supplied, server-side decodes + canonicalizes to markdown BEFORE computing the body-binding hash. The body-shown hash binds to the canonicalized markdown, which IS what gets passed downstream.
-- Operator workflow: paste base64-encoded xlsx into the slash-menu arg field (or have a future Claude Desktop attachment-to-arg adapter handle the encoding).
-- Effort: ~4-6 hours (arg schema extension; build-time xlsx decoding; cross-section interaction with existing args; body-hash test scenarios for the new arg).
-- Drawback: base64 input via slash menu is awkward UX; really wants attachment → arg automation that doesn't exist yet (overlaps with BL-046).
+**Deferred remainder.** The server-side xlsx path (re-introduction ticket BL-054 was filed then retired, `98ec581b`) is deferred indefinitely. [MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md](MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md) is the canonical revisit blueprint with three re-engagement triggers: (1) MCP spec ships a binary-resource primitive delivering >100KB payloads to tool handlers; (2) Claude Desktop ships an attachment-to-host bridge; (3) operator pivots off the Desktop + stdio topology. Do not re-open this stanza — re-engage via the blueprint if a trigger materializes.
 
-#### Acceptance criteria
-
-- A v12 (or higher) StoreForce live exercise against the same `PRAXIS-IRL-StoreForce_JLIVET.xlsx` produces a dossier with:
-  - `provenanceVerification.verified + verifiedFuzzy >= 25` (out of ~30 IRL-cited claims)
-  - `provenanceVerification.tierMismatches == 0` for properly-cited tier-1 claims
-  - `(J)` gap list contains ≤ 2 auto-appended entries (real fabrications would still surface; encoding-drift false positives eliminated)
-- The forcing function tests in `mcp-server/tests/unit/schemas/compose-dossier-envelope.test.ts` extend to cover the xlsx-canonicalized round-trip.
-- BREAKING_CHANGES entry documents the version bump (likely `mcp-server` 0.12.x → 0.13.0 for Path A's new tool; → 0.12.1 for Path B's additive arg).
-
-#### Why "medium priority" not "high"
-
-The BL-045 PR B v11 trace empirically demonstrated that the **forcing-function architecture itself works** — the model used the (K) verdict surface as actionable feedback and executed a real self-correction loop (substring validation script, citation re-write, tier demotion). The remaining false-positive class is a **verifier-input-quality artifact**, not an architectural failure. A partner reading the v11 dossier sees explicit disclosure of the artifact (the model's own footnote on `(J)` entries 12-41 explains the mechanism). BL-049 closes the cosmetic gap by giving the hash-bind an authoritative source; it does not unblock anything currently load-bearing.
-
-Senior-consultant 9×4 review against v0.12.0 + the v11 trace evidence proceeds without this ticket. BL-049 ships as a clean post-merge follow-up.
+**Closeout hardening (this truth-pass, mcp-server 0.38.0).** The one remaining code remnant of the original encoding-drift problem statement — curly quotes (U+2018/U+2019/U+201C/U+201D) missing from `normalizeForMatching`'s punctuation flattening — shipped alongside this closure (NBSP turned out to be already covered by JS `\s`). Also replaced the stale `promptVersion: "0.4.0"` literal in `META_JSON_FENCE_DIRECTIVE` with a server-derived placeholder (prompt 0.21.1).
 
 ### BL-051: `gst_irl_ingestion` — Citation Iteration via `validate_irl_provenance` Before Envelope
 

--- a/src/docs/development/MCP_SERVER_COMPOSE_BODY_BY_HASH_BL-076.md
+++ b/src/docs/development/MCP_SERVER_COMPOSE_BODY_BY_HASH_BL-076.md
@@ -1,6 +1,6 @@
 # MCP Server — `compose_dossier_envelope` Body-by-Hash Latency Reduction (BL-076)
 
-> **Backlog initiative**: [BL-076: `compose_dossier_envelope` body-by-hash latency reduction](BACKLOG.md#bl-076-compose_dossier_envelope-body-by-hash-latency-reduction--open-2026-06-07)
+> **Backlog initiative**: [BL-076: `compose_dossier_envelope` body-by-hash latency reduction](BACKLOG.md#bl-076-compose_dossier_envelope-body-by-hash-latency-reduction--closed-2026-06-07-shipped-at-mcp-server-0300)
 >
 > **Companion docs**:
 >

--- a/src/docs/development/MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md
+++ b/src/docs/development/MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md
@@ -1,6 +1,6 @@
 # MCP Server — IRL xlsx Canonicalization for Hash-Bind Authority (BL-049)
 
-> **Backlog initiative**: BL-049 filed June 3, 2026; BL-054 (revisit ticket) retired from BACKLOG June 4, 2026. This document is now the **canonical revisit blueprint** — there is no live BACKLOG entry. Re-engage by re-reading this doc when one of the trigger conditions below materializes; no backlog ping will arrive.
+> **Backlog initiative**: BL-049 filed June 3, 2026; BL-054 (revisit ticket) retired from BACKLOG June 4, 2026. This document is now the **canonical revisit blueprint** — no open BACKLOG entry exists; the BL-049 stanza is closed (2026-07-09 truth-pass) with a pointer here. Re-engage by re-reading this doc when one of the trigger conditions below materializes; no backlog ping will arrive.
 >
 > **Companion docs**:
 >
@@ -634,7 +634,7 @@ A v12+ StoreForce live exercise against the same `PRAXIS-IRL-StoreForce_JLIVET.x
 ### Phase 4 — Doc updates + close (~15 min)
 
 - Update this design doc's Status to "Shipped".
-- Update [BL-049 BACKLOG entry](BACKLOG.md#bl-049-gst_irl_ingestion--server-side-xlsx-canonicalization-for-hash-bind-authority) → Done.
+- Update [BL-049 BACKLOG entry](BACKLOG.md#bl-049-gst_irl_ingestion--server-side-xlsx-canonicalization-for-hash-bind-authority--closed-2026-07-09-subset-shipped-at-0131-xlsx-path-deferred-indefinitely--design-doc) → Done. _(Anchor updated 2026-07-09: the stanza is closed; this Phase 4 step applies only if the blueprint is ever re-engaged.)_
 - Close the post-merge sequel checkbox on BL-045 PR B's PR description (if PR #212 is still open at merge time) — otherwise comment on the merged PR with the v12 dossier as architectural-closure evidence.
 
 ---

--- a/src/docs/development/MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md
+++ b/src/docs/development/MCP_SERVER_PROMPT_ARG_CACHE_PREPOP_BL-079.md
@@ -1,6 +1,6 @@
 # MCP Server — Prompt-Arg Cache Pre-Population + Body-by-Hash on Validate (BL-079)
 
-> **Backlog initiative**: [BL-079: Server-side body delivery via prompt-arg + body-by-hash on `validate_irl_provenance`](BACKLOG.md#bl-079-server-side-body-delivery-via-prompt-arg--body-by-hash-on-validate_irl_provenance--open-2026-06-07)
+> **Backlog initiative**: [BL-079: Server-side body delivery via prompt-arg + body-by-hash on `validate_irl_provenance`](BACKLOG.md#bl-079-server-side-body-delivery-via-prompt-arg--body-by-hash-on-validate_irl_provenance--closed--part-a-shipped-2026-06-07-0305-part-b-shipped-2026-06-07-0310)
 >
 > **Companion docs**:
 >


### PR DESCRIPTION
## Summary

Closes out **BL-049** (server-side xlsx canonicalization for hash-bind authority), whose BACKLOG stanza sat at *Open · Priority: medium* for a month after the work actually happened — the full implementation was built in PR #219, live-validated, then deliberately partial-reverted (Claude Desktop attachments cannot deliver bytes to the MCP server), with the goal since met by the offline extractor + partner-paste + BL-055/072/076/079 mechanisms.

Three commits:

1. **docs(backlog)** — rewrite the BL-049 stanza as a closure record (shipped subset at v0.13.1 / superseding mechanisms / deferred remainder → the [revisit blueprint](src/docs/development/MCP_SERVER_IRL_XLSX_CANONICALIZATION_BL-049.md) with its 3 re-engagement triggers). Also repairs three dead BACKLOG anchors in sibling design docs (BL-049 Phase-4 link, BL-076 + BL-079 backlog-initiative links) whose header slugs changed when those stanzas closed.
2. **feat(mcp)** — curly quotes (U+2018/U+2019/U+201C/U+201D) join `normalizeForMatching`'s punctuation-to-space class — the last encoding-drift class from BL-049's problem statement (em-dashes already flattened; NBSP already covered by JS `\s`, now regression-locked). Strictly verdict-widening: symmetric transform, no fixture flips, `compose_dossier_envelope` inherits transitively. Citations that previously failed verification purely on smart-quote drift now verify.
3. **chore(mcp) release 0.38.0** — replace the five-months-stale `promptVersion: "0.4.0"` literal in `META_JSON_FENCE_DIRECTIVE` with a server-derived placeholder (prompt **0.21.1**); rebaseline 6/7 body hashes + manifest hash in lockstep.

## Verification

- mcp-server suite: **116 files / 1605 tests green** (incl. 9 new normalization/drift tests; negative control confirmed the new assertions fail against the old regex)
- workspace typecheck clean
- website gate: `astro check` 0 errors, eslint + stylelint clean, 1169 tests green
- interactive body hash deliberately unchanged (the edited directive isn't in that body)

**Merge with a merge commit (not squash).** Staging auto-deploys via `deploy-mcp-staging.yml` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)