### PR TITLE
docs(observability): SLO alert rules as-built — API-created + first verified evaluator firing

### DIFF
--- a/mcp-server/scripts/create-slo-alert-rules.mjs
+++ b/mcp-server/scripts/create-slo-alert-rules.mjs
@@ -1,0 +1,85 @@
+/**
+ * BL-032.75 Phase 3 — create Sentry issue-alert Rules 5 + 6
+ * (slo-alert page / ticket) via the REST API.
+ *
+ * The Sentry UI's Tagged-event key combobox only offers already-indexed
+ * tag keys, and `severity` has never been emitted, so the rules cannot be
+ * built in the UI until the first breach fires. The API has no such
+ * constraint. Payload shapes mirror the working Rule 4 (synthetic,
+ * id 3508841) read back via the Sentry MCP on 2026-07-14.
+ *
+ * Auth: $env:SENTRY_API_TOKEN — a USER auth token (Settings → User
+ * Settings → Auth Tokens) with scopes: project:read + project:write +
+ * org:read. Fails loudly when unset; token never appears in args.
+ *
+ * Usage: node create-slo-alert-rules.mjs
+ */
+
+const ORG = 'gst-7o';
+const PROJECT = 'gst-mcp-server';
+const BASE = `https://us.sentry.io/api/0/projects/${ORG}/${PROJECT}/rules/`;
+// Operator's Sentry user id — read from Rule 4's email action (2026-07-14).
+const OPERATOR_USER_ID = 4422941;
+
+const token = process.env.SENTRY_API_TOKEN;
+if (!token) {
+  console.error(
+    "SENTRY_API_TOKEN not set. Mint a User Auth Token (scopes: project:read, project:write, org:read) and run: $env:SENTRY_API_TOKEN = '<token>'"
+  );
+  process.exit(1);
+}
+
+const ruleFor = (severity) => ({
+  name: `MCP — SLO alert (${severity} severity)`,
+  // Trigger: "A new issue is created" — single trigger, per the per-day
+  // fingerprint design (each day's first breach opens a new issue).
+  conditions: [{ id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition' }],
+  actionMatch: 'any',
+  // Both tag filters must match.
+  filterMatch: 'all',
+  filters: [
+    {
+      id: 'sentry.rules.filters.tagged_event.TaggedEventFilter',
+      key: 'event',
+      match: 'eq',
+      value: 'slo-alert',
+    },
+    {
+      id: 'sentry.rules.filters.tagged_event.TaggedEventFilter',
+      key: 'severity',
+      match: 'eq',
+      value: severity,
+    },
+  ],
+  actions: [
+    {
+      id: 'sentry.mail.actions.NotifyEmailAction',
+      targetType: 'Member',
+      targetIdentifier: OPERATOR_USER_ID,
+    },
+  ],
+  frequency: 60, // minutes — per-issue action debounce
+  environment: 'production', // evaluator cron is production-only
+});
+
+const headers = {
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+};
+
+for (const severity of ['page', 'ticket']) {
+  const payload = ruleFor(severity);
+  const res = await fetch(BASE, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    console.error(`FAILED creating '${payload.name}': HTTP ${res.status}\n${body.slice(0, 500)}`);
+    process.exit(1);
+  }
+  const created = JSON.parse(body);
+  console.log(`Created '${created.name}' — id ${created.id}`);
+}
+console.log('Both rules created. Verify via Sentry → Alerts, or ask Claude to read them back.');

--- a/mcp-server/src/docs/operations/SENTRY_ALERT_RULES.md
+++ b/mcp-server/src/docs/operations/SENTRY_ALERT_RULES.md
@@ -124,12 +124,25 @@ For Rules 1-3, the cheapest production-safe verification is: open `mcp-server/sc
 
 The `*/15 * * * *` alert-evaluator cron ([`alert-evaluator.ts`](../../observability/alert-evaluator.ts)) posts fingerprinted issue events (tag `event: slo-alert`) for breaches of the 7 canonical rules in [`alert-rules.ts`](../../observability/alert-rules.ts). Thresholds derive from the signed-off [`slo-baselines.md`](../../../observability/slo-baselines.md) targets. Runbooks live at [`observability/runbooks/`](../../../observability/runbooks/).
 
-**Two new UI email rules to create** (same skeleton as § 3; free-tier email channel):
+**The two email rules** (✅ created 2026-07-14 — **via the REST API, not the UI**; see the as-built note below):
 
-| #   | Name                 | IF (filters)                                                      | Trigger                                                                                                                                                                     | Action frequency |
-| --- | -------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| 5   | `slo-alert — page`   | tag `event` equals `slo-alert` AND tag `severity` equals `page`   | "A new issue is created" (single trigger — per-day fingerprints make each day's first breach a NEW issue, per the synthetic's precedent; no manual-resolve workflow needed) | 60 min           |
-| 6   | `slo-alert — ticket` | tag `event` equals `slo-alert` AND tag `severity` equals `ticket` | "A new issue is created"                                                                                                                                                    | 60 min           |
+| #   | Name                                | Rule ID | IF (filters)                                                      | Trigger                                                                                                                                                                     | Action frequency |
+| --- | ----------------------------------- | ------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 5   | `MCP — SLO alert (page severity)`   | 3706338 | tag `event` equals `slo-alert` AND tag `severity` equals `page`   | "A new issue is created" (single trigger — per-day fingerprints make each day's first breach a NEW issue, per the synthetic's precedent; no manual-resolve workflow needed) | 60 min           |
+| 6   | `MCP — SLO alert (ticket severity)` | 3706339 | tag `event` equals `slo-alert` AND tag `severity` equals `ticket` | "A new issue is created"                                                                                                                                                    | 60 min           |
+
+> **As-built note (2026-07-14) — the UI cannot create these rules; use the script.** The
+> UI's `Tagged event` tag-key field is now a strict combobox constrained to tag keys the
+> project's indexer has already seen (§ 3 skeleton's "the field accepts arbitrary text"
+> no longer holds — it snaps to `message` on blur). Since `severity` is only emitted by
+> slo-alert breaches, the key can't be selected before the first breach ever fires — a
+> bootstrap deadlock. The REST API has no such constraint, so the rules were created via
+> [`scripts/create-slo-alert-rules.mjs`](../../../scripts/create-slo-alert-rules.mjs)
+> (payload shapes mirrored from Rule 4's stored config) and verified by reading them back
+> through the Sentry MCP integration. To recreate or modify them, prefer re-running the
+> script with a freshly-minted **personal token** (Permissions: Alerts = Admin,
+> Project = Read, Organization = Read; **revoke after use**) — this also gives Rules 5-6
+> an in-repo source of truth that the § "Status" header disclaims for Rules 1-4.
 
 **Issue-churn expectation**: a multi-day incident opens one issue per rule per UTC day (fingerprint includes the date). That's intended — each day's email is a re-page. Cooldowns (page 2h / ticket 6h, Upstash `SET NX EX`) bound intra-day volume; worst case across all 7 rules is ≈840 events/month against the 5k free-tier budget.
 
@@ -151,7 +164,7 @@ curl "http://localhost:8787/__scheduled?cron=*/15+*+*+*+*"
 
 Document the first verified firing date here once complete:
 
-> **First verified evaluator firing**: _(pending — record after PR 2 deploys with the CF_AE_TOKEN / CF_ACCOUNT_ID secrets bound and Rules 5-6 exist)_
+> **First verified evaluator firing**: **2026-07-14T13:45:19Z** — the first natural `*/15` tick after the 0.39.0 production deploy (no force-fire needed). Verified via `/status`: all 7 rules evaluated healthy, and the AE-backed rules returned REAL query results ("0 scope-mismatch 403s in 15 min", "no per-key traffic spike") rather than the fail-open "AE unavailable" marker — proving the `CF_AE_TOKEN`/`CF_ACCOUNT_ID` Worker secrets and the Worker's first `api.cloudflare.com` egress work end-to-end. The email leg was NOT exercised (nothing was breached — correctly); it rides the identical tag-filtered new-issue → email mechanics the synthetic proved on 2026-05-30, and Rules 5-6's stored configs were read back and verified via the Sentry MCP after API creation. First genuine breach will complete the empirical chain.
 
 ## 6. Provenance
 


### PR DESCRIPTION
## Summary

Closes the last BL-032.75 Gate C loop. Records reality in SENTRY_ALERT_RULES.md § 5:

- **Rules 5 (3706338, page) + 6 (3706339, ticket) were created via the REST API**, because the Sentry UI cannot build them: the Tagged-event tag-key combobox now only offers already-indexed keys, and `severity` is only emitted by slo-alert breaches — a bootstrap deadlock (§ 3's 2026-05-30 'accepts arbitrary text' claim no longer holds).
- **`scripts/create-slo-alert-rules.mjs` committed** as the rules' in-repo source of truth (payloads mirrored from Rule 4's stored config; short-lived personal token from env, revoke after use). Both rules verified post-creation by reading them back through the Sentry MCP integration.
- **First verified evaluator firing recorded: 2026-07-14T13:45:19Z** — the first natural `*/15` tick after the 0.39.0 deploy. All 7 rules evaluated healthy on `/status`, with AE-backed rules returning real query results (Worker secrets + first `api.cloudflare.com` egress proven end-to-end). Email leg awaits the first genuine breach (mechanics proven by the synthetic since 2026-05-30).

**Merge with a merge commit (not squash).** The script under `mcp-server/` triggers a behaviorally-no-op deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)