### PR TITLE
docs(index): wire cross-tree navigation + truth-pass stale doc counts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,7 +84,7 @@ This document provides Claude with essential context about the GST Website proje
 
 ### 11. Developer Tooling is Authoritative
 
-- Before suggesting or implementing changes to linting, formatting, type-checking, pre-commit hooks, or CI, read [DEVELOPER_TOOLING.md](../src/docs/development/DEVELOPER_TOOLING.md) first
+- Before suggesting or implementing changes to linting, formatting, type-checking, pre-commit hooks, or CI, read [DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md) first
 - The authoritative local validation sequence (matches CI) is:
   ```
   npx astro check && npm run lint && npm run lint:css && npm run test:run
@@ -92,12 +92,12 @@ This document provides Claude with essential context about the GST Website proje
   If all four pass locally, CI will almost certainly pass
 - **Every commit is auto-formatted by the husky pre-commit hook** — lint-staged runs `eslint --fix` then `prettier --write` on staged files. Your staged files may look different in the final commit than in your working tree. This is intentional and documented
 - **`npm audit` policy**: production dependencies must stay at zero advisories (enforced via `--audit-level=moderate --omit=dev` in CI). Dev-only advisories are tolerated case-by-case
-- **Do not add or edit hooks, lint configs, or CI jobs without updating [DEVELOPER_TOOLING.md](../src/docs/development/DEVELOPER_TOOLING.md)** — the doc is the single source of truth for new contributors and future sessions
+- **Do not add or edit hooks, lint configs, or CI jobs without updating [DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md)** — the doc is the single source of truth for new contributors and future sessions
 - **Do not use `git commit --no-verify`** unless you are explicitly told the change is an emergency and the user has agreed to the follow-up. CI will still enforce what the hook would have caught, so `--no-verify` only defers the problem
 
 ### 12. One Command Per Bash Call (Avoid Permission-Prompt Thrash)
 
-Claude Code's permission matcher evaluates the ENTIRE command string against the `allow` list in [`.claude/settings.local.json`](../.claude/settings.local.json). A compound command like `cd X && npm run Y | tee Z` is ONE string that matches no wildcard, even when every individual command (`cd`, `npm run`, `tee`) is pre-approved. The result: a permission prompt for work the user already authorized.
+Claude Code's permission matcher evaluates the ENTIRE command string against the `allow` list in [`.claude/settings.local.json`](.claude/settings.local.json). A compound command like `cd X && npm run Y | tee Z` is ONE string that matches no wildcard, even when every individual command (`cd`, `npm run`, `tee`) is pre-approved. The result: a permission prompt for work the user already authorized.
 
 **Rules:**
 
@@ -226,7 +226,15 @@ npm run astro                 # Run Astro CLI
 
 ## 📚 Critical Documentation
 
-**Master index**: [src/docs/README.md](src/docs/README.md) — links to all 6 documentation directories with use-case navigation. Start here when looking for any project documentation.
+**Master index**: [src/docs/README.md](src/docs/README.md) — links to every documentation directory with use-case navigation. Start here when looking for any website-side project documentation.
+
+### MCP Server & Architecture Decisions
+
+The `@gst/mcp-server` workspace has its **own** maintained doc tree — the website master index above does not contain it. Start there for anything server-side:
+
+- **MCP server docs home**: [mcp-server/src/docs/README.md](mcp-server/src/docs/README.md) — navigator for the server's internal doc surface (tools, resources, prompts, operations, testing)
+- **System architecture (maintained reference)**: [mcp-server/src/docs/ARCHITECTURE.md](mcp-server/src/docs/ARCHITECTURE.md) — system shape, remote transport & request flow, auth/CORS/deploy topology, rate limiting, radar pipeline, observability. Code comments cite its anchors — treat them as load-bearing
+- **Architecture Decision Records**: [src/docs/adr/README.md](src/docs/adr/README.md) — load-bearing design decisions distilled from closed initiatives. **Making a new architectural decision? Write an ADR for it in the same PR** (see [adr/TEMPLATE.md](src/docs/adr/TEMPLATE.md))
 
 ### Developer Tooling (Lint, Format, Hooks, CI)
 

--- a/mcp-server/src/docs/README.md
+++ b/mcp-server/src/docs/README.md
@@ -2,7 +2,7 @@
 
 > **Audience**: engineers and senior consultants working on the `@gst/mcp-server` workspace.
 >
-> This is the navigator for the MCP server's internal doc surface. For the user-facing tool/resource/prompt inventory, start at [`mcp-server/README.md`](../../README.md).
+> This is the navigator for the MCP server's internal doc surface. For the user-facing tool/resource/prompt inventory, start at [`mcp-server/README.md`](../../README.md). For website-side documentation (styles, testing, SEO, analytics, security, roadmap), start at the [repo documentation master index](../../../src/docs/README.md).
 
 The docs are organized by **what** they describe — the system architecture, the three MCP capability surfaces (Tools, Resources, Prompts), plus operational and testing references.
 
@@ -39,4 +39,4 @@ Per-initiative plans are **point-in-time records** — frozen at authoring time,
 
 ---
 
-_Last updated: 2026-07-17 (BL-088 PR 2 — added `ARCHITECTURE.md` + lifecycle pointer). Prior: 2026-07-02 (BL-034 doc-structure pass)._
+_Last updated: 2026-07-18 (docs-wiring pass — added backlink to the repo documentation master index). Prior: 2026-07-17 (BL-088 PR 2 — added `ARCHITECTURE.md` + lifecycle pointer); 2026-07-02 (BL-034 doc-structure pass)._

--- a/mcp-server/src/docs/prompts/README.md
+++ b/mcp-server/src/docs/prompts/README.md
@@ -120,7 +120,7 @@ Three reasons, in order of importance:
 
 1. **Adding a prompt is a closed-form operation.** Write one new TS file in `prompts/` + add one entry to `ALL_PROMPTS`. You don't touch the registry logic, the server, the SDK, or any other prompt. The cost of the 9th prompt is the same as the cost of the 2nd.
 
-2. **The invariants don't get heavier as the system grows.** The registry test runs the same 4 checks against 8 prompts that it runs against 80. Adding a prompt doesn't add a test case anywhere except its own per-prompt unit test.
+2. **The invariants don't get heavier as the system grows.** The registry test runs the same 4 checks against 9 prompts that it runs against 80. Adding a prompt doesn't add a test case anywhere except its own per-prompt unit test.
 
 3. **Schemas compose from existing source-of-truth.** A prompt's `argsSchema` is built from the same Zod schemas the underlying Tools already use — `UserInputsSchema` for diligence, `TechParInputsSchema` for TechPar, etc. When a Tool's input schema evolves, every prompt that composes from it picks up the change automatically.
 
@@ -132,7 +132,7 @@ The combination is what makes this approach durable: **the only thing that grows
 
 The system from your keystroke to the model's first response:
 
-1. **You type `/`** in Claude Desktop. Desktop has already called `prompts/list` on every connected MCP server at session start, so it has the GST server's eight prompt names + descriptions + argsSchemas cached. It renders the picker.
+1. **You type `/`** in Claude Desktop. Desktop has already called `prompts/list` on every connected MCP server at session start, so it has the GST server's nine prompt names + descriptions + argsSchemas cached. It renders the picker.
 
 2. **You select `gst_diligence_kickoff`.** Desktop renders a form: `targetName` (required text), `transactionType` (dropdown of valid enum values from the argsSchema), all 13 other fields. You fill it in.
 
@@ -165,4 +165,4 @@ The prompt itself is **passive infrastructure** — a templated message body. Al
 
 ---
 
-_Last updated: 2026-05-22 (BL-043 — added `gst_information_request_list`)._
+_Last updated: 2026-07-18 (count truth-pass — registry now holds nine prompts; `gst_irl_ingestion` added under BL-045). Prior: 2026-05-22 (BL-043 — added `gst_information_request_list`)._

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -4,17 +4,28 @@ Master index for all project documentation.
 
 ## Directories
 
-| Directory                    | Purpose                                                                                                                                                                                         | Docs      | Entry Point                                             |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------- |
-| [adr/](adr/)                 | Architecture Decision Records — load-bearing design decisions distilled from closed initiatives                                                                                                 | 3 + index | [README.md](adr/README.md)                              |
-| [analytics/](analytics/)     | GA4 integration, event tracking                                                                                                                                                                 | 3         | [README.md](analytics/README.md)                        |
-| [development/](development/) | Roadmap, tooling, active initiatives (closed-initiative docs distill + archive per the [lifecycle](development/README.md#initiative-doc-lifecycle-convention-codified-2026-07-15-under-bl-088)) | 7 living  | [README.md](development/README.md)                      |
-| [hub/](hub/)                 | Hub tool technical docs                                                                                                                                                                         | 4         | [README.md](hub/README.md)                              |
-| [operations/](operations/)   | Secrets inventory, deploy, rotation                                                                                                                                                             | 1         | [SECRETS_INVENTORY.md](operations/SECRETS_INVENTORY.md) |
-| [security/](security/)       | Headers, CSP, privacy, compliance                                                                                                                                                               | 1         | [README.md](security/README.md)                         |
-| [seo/](seo/)                 | SEO implementation, JSON-LD                                                                                                                                                                     | 4         | [README.md](seo/README.md)                              |
-| [styles/](styles/)           | CSS conventions, brand, tokens                                                                                                                                                                  | 6         | [README.md](styles/README.md)                           |
-| [testing/](testing/)         | Test strategy, CI/CD, troubleshooting                                                                                                                                                           | 7         | [README.md](testing/README.md)                          |
+| Directory                    | Purpose                                                                                                                                                                                         | Docs     | Entry Point                                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| [adr/](adr/)                 | Architecture Decision Records — load-bearing design decisions distilled from closed initiatives                                                                                                 | 7        | [README.md](adr/README.md)                              |
+| [analytics/](analytics/)     | GA4 integration, event tracking                                                                                                                                                                 | 2        | [README.md](analytics/README.md)                        |
+| [development/](development/) | Roadmap, tooling, active initiatives (closed-initiative docs distill + archive per the [lifecycle](development/README.md#initiative-doc-lifecycle-convention-codified-2026-07-15-under-bl-088)) | 6 living | [README.md](development/README.md)                      |
+| [hub/](hub/)                 | Hub tool technical docs                                                                                                                                                                         | 4        | [README.md](hub/README.md)                              |
+| [operations/](operations/)   | Secrets inventory, deploy, rotation                                                                                                                                                             | 1        | [SECRETS_INVENTORY.md](operations/SECRETS_INVENTORY.md) |
+| [security/](security/)       | Headers, CSP, privacy, compliance                                                                                                                                                               | 1        | [README.md](security/README.md)                         |
+| [seo/](seo/)                 | SEO implementation, JSON-LD                                                                                                                                                                     | 4        | [README.md](seo/README.md)                              |
+| [styles/](styles/)           | CSS conventions, brand, tokens                                                                                                                                                                  | 5        | [README.md](styles/README.md)                           |
+| [testing/](testing/)         | Test strategy, CI/CD, troubleshooting                                                                                                                                                           | 5        | [README.md](testing/README.md)                          |
+
+_The **Docs** column counts maintained reference docs, excluding each folder's own `README.md` index (and `adr/`'s `TEMPLATE.md` scaffolding). Closed-initiative docs under `development/_archive/` are not counted._
+
+### MCP server documentation
+
+The `@gst/mcp-server` workspace maintains its **own** doc tree, not enumerated above — start at its navigator and architecture reference:
+
+| Doc                                                                              | Purpose                                                                                                                                                   |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [mcp-server/src/docs/README.md](../../mcp-server/src/docs/README.md)             | Navigator for the server's internal docs — architecture, tools, resources, prompts, operations, testing                                                   |
+| [mcp-server/src/docs/ARCHITECTURE.md](../../mcp-server/src/docs/ARCHITECTURE.md) | Maintained system reference: transport & request flow, auth/CORS/deploy topology, rate limiting, radar pipeline, observability (anchors are load-bearing) |
 
 ## Quick Navigation
 
@@ -35,3 +46,5 @@ Master index for all project documentation.
 | Set up branch protection                            | [testing/GITHUB_ACTIONS_SETUP.md](testing/GITHUB_ACTIONS_SETUP.md#branch-protection-rules)                                              |
 | See the MCP server in a concrete scenario           | [mcp-server/src/docs/tools/diligence/USAGE.md](../../mcp-server/src/docs/tools/diligence/USAGE.md) (each tool ships its own `USAGE.md`) |
 | Understand a Hub tool's input contract              | [mcp-server/src/docs/tools/README.md](../../mcp-server/src/docs/tools/README.md)                                                        |
+| Understand the MCP server's architecture            | [mcp-server/src/docs/ARCHITECTURE.md](../../mcp-server/src/docs/ARCHITECTURE.md)                                                        |
+| Look up an architecture decision (ADR)              | [adr/README.md](adr/README.md)                                                                                                          |

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -380,6 +380,33 @@ The diligence engine takes structured enum inputs only — low risk. The portfol
 
 ---
 
+### BL-089: Documentation Link & Anchor Integrity Guard
+
+**Source**: docs-wiring audit 2026-07-18 | **Effort**: ~0.5–1 day | **Status**: Open
+
+**As a** developer or agent relying on documentation cross-references, **I want** an automated test that verifies every relative markdown link target — and every load-bearing `#anchor` cited from code comments and cross-doc links — still resolves, **so that** the BL-088 distillation investment (ARCHITECTURE.md anchors, ADR pointers, dual-source SOPs) cannot silently rot when a file is renamed or a heading is reworded.
+
+**Why now**: BL-088 deliberately made code comments and cross-doc links point at specific doc anchors, on the assumption they'd be maintained. Nothing enforces that assumption. The audit found the load-bearing anchors resolve **today only because a human checked them by hand** — there is no guard. `contract-parity.test.ts` validates schema _file_ paths but not markdown `#anchor` fragments.
+
+#### Acceptance Criteria
+
+- [ ] A repo-local test (Vitest, following the `mcp-server/tests/integration/sop-dual-source-drift-guard.test.ts` pattern — no new external dependency like `markdown-link-check`) that:
+  - [ ] Resolves every relative markdown link target across both doc trees (`src/docs/**`, `mcp-server/src/docs/**`, plus the root and `mcp-server` READMEs) to an existing file
+  - [ ] Resolves every `#anchor` fragment on those links to a real heading in the target file (slugified per GitHub's rules)
+  - [ ] Resolves the load-bearing **code-comment → doc-anchor** citations. Known set at audit time: `mcp-server/src/lib/inoreader-egress.ts:37` → `ARCHITECTURE.md#inoreader-spend-accounting`; `mcp-server/src/tools/_local-only.ts:6` → `ARCHITECTURE.md#transport-binding-per-tool-q12`; `mcp-server/observability/slo-baselines.md:3` → `ARCHITECTURE.md#slo-baselines--targets`; `eslint.config.mjs:202` → `src/docs/adr/0004-hub-surface-resources-import-restriction.md` (path only)
+- [ ] Deliberately **excludes** `_archive/` docs from the "internal links must resolve" rule (frozen-verbatim policy — archived docs' relative links reflect their original location and may not resolve; assert this exclusion explicitly so the guard doesn't flag them)
+- [ ] Wired into the local validation sequence and CI (documented in `DEVELOPER_TOOLING.md` per Directive 11); consider a `lint:docs` npm script
+- [ ] A deliberately-broken link/anchor in a test fixture proves the guard fails (red-then-green)
+
+#### Technical Context
+
+- **Scope boundary**: this is a link/anchor _existence_ guard, not prose-freshness. It does not police "Last Updated" dates (a separate, lighter follow-up could flag docs whose stated date predates their last `git` commit).
+- **Slugification**: GitHub lowercases, strips punctuation, and replaces spaces with hyphens; `&` becomes empty (e.g. "SLO baselines & targets" → `slo-baselines--targets` — note the double hyphen). Reuse a vetted slugifier rather than hand-rolling.
+- **EOL**: doc files in this repo are CRLF — a line/heading scanner must be EOL-agnostic (see the drift-guard's `\r\n` handling).
+- **Discovery of code citations**: grep source comments for doc paths bearing `#` fragments; the known set above is the audit-time snapshot, but the test should scan rather than hard-code so new citations are covered automatically.
+
+---
+
 ## Exploration
 
 ### BL-035: Dynamic Visual Effects Prototype


### PR DESCRIPTION
## Why

A post-BL-088 audit (two read-only Explore probes across both doc trees) found the doc **content** healthy but the **wiring and truth** decayed — the two things that rot silently between initiatives:

- An agent's cold-start path (`CLAUDE.md` → `src/docs/README.md`) **never reached the mcp-server doc tree** — not `ARCHITECTURE.md`, not `adr/`, not the operations runbooks. The BL-088 distillation was effectively invisible from where we tell agents to start.
- Several index counts were stale (`adr/` said "3", 7 exist; `testing/` said "7", 5 exist) and the counting convention flipped row to row.
- `CLAUDE.md` mixed two relative-link bases within one file (3 links used a `../` base, ~30 used root-relative).

## What changed (docs-only, 5 files)

**Cross-tree wiring**
- `CLAUDE.md`: new **MCP Server & Architecture Decisions** block → mcp-server docs home, `ARCHITECTURE.md` (anchors flagged load-bearing), and `adr/`, with an "write an ADR for new decisions in the same PR" nudge.
- `src/docs/README.md`: new **MCP server documentation** section (docs home + `ARCHITECTURE.md`) and Quick-Nav rows for architecture + ADR lookup.
- `mcp-server/src/docs/README.md`: backlinks the website master index — the two navigators are now mutually linked.

**Truth-pass**
- Master index **Docs** column standardized to one rule (reference docs excluding each folder's own `README.md`), with a documented note; counts corrected (adr 3→7, testing 7→5, analytics 3→2, styles 6→5, development 7→6).
- `CLAUDE.md`: dropped the brittle "6 documentation directories" number; the 3 outlier `../`-based links now match the file's (and the IDE's workspace-root) house style.
- `mcp-server/src/docs/prompts/README.md`: present-tense "eight prompt names" → "nine" (9 registered). **Historical** "eight prompts" records (`mcp-server/README.md`, ADR-0005) left intact as dated point-in-time truth.

## Follow-up filed

**BL-089 — Documentation Link & Anchor Integrity Guard**: a repo-local test (in the `sop-dual-source-drift-guard` mold, no new external dep) that resolves every relative link target and every load-bearing code-comment → doc-`#anchor` citation. BL-088 made those anchors load-bearing on the assumption they'd be maintained; nothing enforces it today. This PR wires the docs; BL-089 keeps them from re-rotting.

## Verification

- Docs-only — no code paths touched.
- Every edited/new link target confirmed to exist on disk.
- No test asserts on any changed string (directive-8 grep clean).
- Pre-commit `prettier --check` passed (tables realigned).

## Not in scope (deliberately)

`lessons.md` vs the `memory/` system is a genuine convention conflict (Directive 3 mandates `lessons.md`; it's been dead since April because the memory system superseded it in practice). That's a directive change and the operator's call — left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
