### PR TITLE
feat(claude): CLAUDE.md accuracy overhaul + enforced design/implementation review gates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This document provides Claude with essential context about the GST Website project, enabling it to provide more targeted and effective assistance.
 
+**This repo is two workspaces in one** (npm workspaces): the **Astro website** (root — static site on Vercel) and the **`@gst/mcp-server`** package (`mcp-server/` — an MCP server deployed as a Cloudflare Worker at `mcp.globalstrategic.tech`). Most non-trivial work touches conventions documented in one of the two doc trees — find them before building (see 📚 Critical Documentation).
+
 ---
 
 ## 🔧 Claude Workflow Directives
@@ -13,20 +15,29 @@ This document provides Claude with essential context about the GST Website proje
 - Use plan mode for verification steps, not just building
 - Write detailed specs upfront to reduce ambiguity
 
-### 2. Subagent Strategy to Keep Main Context Window Clean
+### 2. Design Review Gate (enforced by hook)
+
+- **Every implementation plan must be reviewed by the `plan-reviewer` agent before ExitPlanMode.** The reviewer verifies the plan's claims against the actual codebase, checks convention compliance against the authoritative docs, hunts missed reuse and unverified assumptions, and writes `.claude/tasks/plan-review.json` with the plan's content hash.
+- A PreToolUse hook **mechanically blocks ExitPlanMode** without a fresh approving marker bound to the current plan text. Editing the plan after review invalidates the marker (hash mismatch) — send the revised plan back to the reviewer.
+- If the reviewer returns REVISE: fix the blockers/majors (or explicitly justify accepting a major), update the plan, re-review.
+- **Only the user can waive this gate.** On an explicit waiver, write the marker with verdict `USER_WAIVED` and the user's quoted waiver — never fabricate a waiver or hand-write an APPROVE.
+- Mechanics, marker schema, troubleshooting: [DEVELOPER_TOOLING.md § Claude Code review gates](src/docs/development/DEVELOPER_TOOLING.md). Fresh machine? Run `npm run setup:claude-hooks` once to arm the gates.
+
+### 3. Subagent Strategy to Keep Main Context Window Clean
 
 - Offload research, exploration, and parallel analysis to subagents
 - For complex problems, throw more compute at it via subagents
 - One task per subagent for focused execution
 
-### 3. Self-Improvement Loop
+### 4. Self-Improvement Loop
 
 - After ANY correction from the user: **write it to the persistent memory system** as a `feedback` memory — one file per lesson in the memory directory, plus a one-line pointer in `MEMORY.md`. Capture the rule **and the why** so the correction survives the conversation ending.
 - The `MEMORY.md` index is loaded automatically at the start of every session — that is how prior corrections are recalled without repeating them. There is no separate "review at session start" step to remember.
 - Write rules for yourself that prevent the same mistake; before saving, check for an existing memory that already covers it and update that file rather than duplicating.
-- **Retired**: the old `.claude/tasks/lessons.md` learning log (removed 2026-07-19). Its still-relevant lessons were migrated to memory; the two codified ones already live as Directives 8 and 10. Recover the original via `git log -- .claude/tasks/lessons.md`.
+- **When a private lesson is really a repo convention, codify it here (or in the relevant doc) so every session sees it** — private memory is invisible to other sessions and collaborators.
+- **Retired**: the old `.claude/tasks/lessons.md` learning log (removed 2026-07-19). Its still-relevant lessons were migrated to memory; the two codified ones live as Directives 11 and 13. Recover the original via `git log -- .claude/tasks/lessons.md`.
 
-### 4. Verification Before Done
+### 5. Verification Before Done
 
 - Never mark a task complete without proving it works
 - Diff behavior between main and your changes when relevant
@@ -34,7 +45,7 @@ This document provides Claude with essential context about the GST Website proje
 - Run unit and integration tests to verify correctness
 - **Do NOT run E2E tests unless explicitly told to do so** — except when the task itself is writing or fixing E2E tests, in which case running them _is_ the verification step (use `--project=chromium` for a fast single-browser check)
 
-### 4a. No Deferred Tech Debt — Fix Now, Not Later
+### 6. No Deferred Tech Debt — Fix Now, Not Later
 
 - **If a fix can be done in this session, do it in this session.** Do not write off remaining work as "deferred to next session," "future cleanup," or "follow-up needed" when the fix is in scope and reachable.
 - **Verification work counts.** A "live exercise" or "human-driven UI verification" labeled "deferred to next session" is the same anti-pattern as a code TODO. If the live exercise can't be done in-session due to a real infrastructure constraint (e.g., a long-running subprocess that pre-dates this session's commits), substitute with a comprehensive integration test that exercises the same handler code path so engineering correctness is proven now — and document the constraint transparently, not as deferred work.
@@ -42,47 +53,54 @@ This document provides Claude with essential context about the GST Website proje
 - **For surfaces with active clients**: a rename, removal, or enum tightening must ship with a coordinated migration of every known caller OR a backward-compat shim at the same boundary. Confirm with the user whether active clients exist before scoping migration work — don't assume risk when the codebase is internal.
 - **Reason**: deferred tech debt compounds. Each "we'll handle that later" makes the next session harder, not easier. Closing the loop in the same session that opened it is the only sustainable rhythm.
 
-### 5. Demand Elegance (Balanced)
+### 7. Implementation Review Gate (enforced by hook)
+
+- **Before any `git push`, the diff must be reviewed by the `code-reviewer` agent.** It reviews `master...HEAD` against repo conventions (reuse, styles, tests, MCP contracts), records the HEAD sha, and writes `.claude/tasks/impl-review.json`.
+- A PreToolUse hook **mechanically blocks `git push`** unless the marker's `headSha` matches the current HEAD — commits added after the review force a re-review; a failed push retries without burning the review.
+- Fix critical findings before pushing. **Only the user can waive** (verdict `USER_WAIVED` + quoted waiver — appropriate for trivial docs-only diffs the user has already authorized).
+- Never push without explicit user authorization in the first place; an approved plan authorizes only the pushes it states.
+
+### 8. Demand Elegance (Balanced)
 
 - For non-trivial changes: pause and ask "is there a more elegant way?"
 - If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
 - Skip this for simple, obvious fixes - don't over-engineer
 - Challenge your own work before presenting it
 
-### 6. Autonomous Bug Fixing
+### 9. Autonomous Bug Fixing
 
 - When given a bug report: just fix it. Don't ask for hand-holding
 - Point at logs, errors, failing tests → then resolve them
 - Zero context switching required from the user
 - Go fix failing CI tests without being told how
 
-### 7. Technical Documentation Reference
+### 10. Technical Documentation Reference
 
 - For API docs, framework features, or web standards: query **Context7 MCP Server** first
 - Don't rely on training data alone for rapidly-evolving standards (Schema.org, Astro, etc.)
 - Fallback: WebSearch/WebFetch to official documentation sources
 
-### 8. Content Changes Must Include Test Updates
+### 11. Content Changes Must Include Test Updates
 
 - After ANY content/copy change (brand names, headings, CTA text, labels), **grep `tests/` for every old string** before committing
 - E2E tests frequently assert on visible text content — changing source without updating tests breaks CI
 - Run: `grep -r "OLD_STRING" tests/` for each string replaced
 - This is a **blocking step** — do not commit content changes without this check
 
-### 9. Commit Convention
+### 12. Commit Convention
 
 - Use conventional commits: `feat()`, `fix()`, `refactor()`, `docs()`, `chore()`, `test()`
 - Scope in parentheses: `feat(design-system):`, `fix(e2e):`, `docs(brand):`
 - Message body explains **why**, not what (the diff shows what)
 - Group logically distinct changes into separate commits
 
-### 10. PR Scope Must Match New Commits Only
+### 13. PR Scope Must Match New Commits Only
 
-- When `dev` has been incrementally merged to `master` via prior PRs, `git log master..dev` shows ALL divergence — not just new work
-- Before creating a PR, identify the last merge point and only include commits after it
-- Use `git log origin/dev..dev` to see what's actually new and unmerged
+- Feature branches cut from `master` and PR straight back to `master` — scope is simply `git log master..HEAD`
+- Before creating a PR, confirm every commit on the branch belongs to this change; if the branch is stale, rebase-or-merge from `master` first rather than shipping unrelated divergence
+- Never reuse a branch for a second initiative — one branch, one PR, one concern
 
-### 11. Developer Tooling is Authoritative
+### 14. Developer Tooling is Authoritative
 
 - Before suggesting or implementing changes to linting, formatting, type-checking, pre-commit hooks, or CI, read [DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md) first
 - The authoritative local validation sequence (matches CI) is:
@@ -95,9 +113,9 @@ This document provides Claude with essential context about the GST Website proje
 - **Do not add or edit hooks, lint configs, or CI jobs without updating [DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md)** — the doc is the single source of truth for new contributors and future sessions
 - **Do not use `git commit --no-verify`** unless you are explicitly told the change is an emergency and the user has agreed to the follow-up. CI will still enforce what the hook would have caught, so `--no-verify` only defers the problem
 
-### 12. One Command Per Bash Call (Avoid Permission-Prompt Thrash)
+### 15. One Command Per Bash Call (Avoid Permission-Prompt Thrash)
 
-Claude Code's permission matcher evaluates the ENTIRE command string against the `allow` list in [`.claude/settings.local.json`](.claude/settings.local.json). A compound command like `cd X && npm run Y | tee Z` is ONE string that matches no wildcard, even when every individual command (`cd`, `npm run`, `tee`) is pre-approved. The result: a permission prompt for work the user already authorized.
+Claude Code's permission matcher evaluates the ENTIRE command string against the `allow` list in [`.claude/settings.local.json`](.claude/settings.local.json) (the same gitignored file that carries the review-gate hook registration installed by `npm run setup:claude-hooks`). A compound command like `cd X && npm run Y | tee Z` is ONE string that matches no wildcard, even when every individual command (`cd`, `npm run`, `tee`) is pre-approved. The result: a permission prompt for work the user already authorized.
 
 **Rules:**
 
@@ -105,6 +123,7 @@ Claude Code's permission matcher evaluates the ENTIRE command string against the
 - **Pipes are permitted only when the entire pipeline fits a single allow-list pattern.** `git log --oneline | head -20` works because `Bash(git *)` covers it and `head` is pre-approved too; but in practice most pipes mix tool families (e.g. `npm run X | tee /tmp/Y`) and trip the matcher. When in doubt, write to a file via the Write tool or split into two Bash calls.
 - **Prefer dedicated tools over shell pipelines.** `Grep` for content search, `Glob` for file patterns, `Read` for file contents — these bypass the shell entirely and are always allowed.
 - **Redirections and env-prefixes count.** `cmd > /tmp/out.txt`, `FOO=bar cmd`, `cmd 2>&1 | tail -5` are all compound strings to the matcher. Sidestep by writing the output via the Write tool, or by running the base command and parsing the result in the next call.
+- **Never inline raw secrets in any shell command** (yours or ones you ask the user to run) — use env-var references so tokens stay out of scrollback, history, and transcripts. `wrangler secret put` reads from stdin.
 - **Exception — genuine sequential coupling.** If two commands MUST be atomic (e.g. `git add X && git commit -m …` where the user explicitly authorized one combined action), keep them together. The cost of one prompt is lower than the cost of a half-applied state.
 
 This rule exists to reduce user prompt fatigue. A single compound command that thrashes the approval loop is worse than three clean calls that just work.
@@ -113,115 +132,72 @@ This rule exists to reduce user prompt fatigue. A single compound command that t
 
 ## 📋 Project Overview
 
-**GST Website** - A modern, high-performance static site for Global Strategic Technologies built with Astro and deployed to Vercel.
+**GST Website** — a modern, high-performance static site for Global Strategic Technologies, plus the GST MCP server exposing the Hub tools to LLM clients.
 
-- **Framework**: Astro 6.x
-- **Build Tool**: Vite
-- **Deployment**: Vercel
-- **Testing**: Vitest (unit/integration) + Playwright (E2E)
-- **Package Manager**: npm
+- **Website**: Astro 7.x + Vite, static output, deployed to Vercel
+- **MCP server** (`mcp-server/`, workspace `@gst/mcp-server`): TypeScript MCP server; runs over stdio locally and as a **Cloudflare Worker** remotely (staging + production); Upstash Redis for caching/rate-limiting; Sentry + custom observability
+- **Testing**: Vitest (unit/integration, both workspaces) + Playwright (E2E, website)
+- **Package Manager**: npm (workspaces: `.` and `mcp-server`)
 - **Node Version**: 22+ (LTS)
 
 ## 🎨 Design System
 
 - **Design Philosophy**: Tech brutalist with dark mode support and frosted-glass aesthetic
-- **All design tokens** (colors, spacing, typography, transitions): [src/docs/styles/VARIABLES_REFERENCE.md](src/docs/styles/VARIABLES_REFERENCE.md)
-- **Conventions and patterns**: [src/docs/styles/STYLES_GUIDE.md](src/docs/styles/STYLES_GUIDE.md)
-- **Brand decisions** (color hierarchy, palettes, voice, asset rules): [src/docs/styles/BRAND_GUIDELINES.md](src/docs/styles/BRAND_GUIDELINES.md)
-- **Palette system**: 6 alternative color palettes in `src/styles/palettes.css` — applied to `<html>` via class, persisted in localStorage
+- **Start here for any styling work**: [src/docs/styles/STYLES_GUIDE.md](src/docs/styles/STYLES_GUIDE.md) — the single entry point; it links the token catalog ([VARIABLES_REFERENCE.md](src/docs/styles/VARIABLES_REFERENCE.md)) and brand decisions ([BRAND_GUIDELINES.md](src/docs/styles/BRAND_GUIDELINES.md))
+- **Palette system**: alternative color palettes in `src/styles/palettes.css` — applied to `<html>` via class, persisted in localStorage
 - **Delta icon**: Use `DeltaIcon.astro` component (inline SVG with `currentColor`) — never `<img>` tags
 
 ## 🗂️ Project Structure
 
+Deliberately shallow — for full detail use the two doc-tree indexes ([src/docs/README.md](src/docs/README.md), [mcp-server/src/docs/README.md](mcp-server/src/docs/README.md)). Counts are omitted on purpose; they rot.
+
 ```
 gst-website/
-├── public/                    # Static assets (favicon, images, manifest)
-│   └── data/                 # Runtime-fetched data (TopoJSON, regulation JSON)
-├── src/
-│   ├── components/           # Astro components
-│   │   ├── DeltaIcon.astro   # Palette-aware inline SVG delta (use instead of <img>)
-│   │   ├── Header.astro
-│   │   ├── Footer.astro
-│   │   ├── Hero.astro
-│   │   ├── ThemeToggle.astro
-│   │   ├── SEO.astro
-│   │   ├── GoogleAnalytics.astro
-│   │   ├── Breadcrumb.astro
-│   │   ├── ... (14 root components)
-│   │   ├── brand/            # Brand page components (PalettePanel, ColorSpecimens)
-│   │   ├── hub/              # Hub page components (HubHeader, tool sub-components)
-│   │   ├── portfolio/        # M&A portfolio components (grid, modal, filters)
-│   │   └── radar/            # Radar feed components (FyiItem, CategoryFilter)
-│   ├── data/                 # Structured data
-│   │   ├── ma-portfolio/
-│   │   │   └── projects.json # 57 validated projects
-│   │   ├── palettes.ts       # Shared palette metadata (names, concepts, tips)
-│   │   ├── diligence-machine/# Attention areas, questions, wizard config
-│   │   ├── infrastructure-cost-governance/  # Domains, recommendations
-│   │   ├── techpar/          # Industry notes, recommendations, stages
-│   │   └── regulatory-map/   # 120 regulation JSON files
-│   ├── scripts/              # Client-side TypeScript modules
-│   │   └── palette-manager.ts# Site-wide palette switching, color editing, panel controls
-│   ├── docs/                 # Strategic documentation
-│   │   ├── testing/          # Test strategy & CI/CD docs
-│   │   ├── development/      # Development roadmap
-│   │   ├── analytics/        # GA4 integration guides
-│   │   ├── styles/           # CSS conventions, brand guidelines, variable reference
-│   │   ├── hub/              # Hub tool technical docs (Radar, DM, RegMap)
-│   │   └── seo/              # SEO implementation, JSON-LD, credentials
-│   ├── layouts/              # Page layouts
-│   │   └── BaseLayout.astro  # Includes Header, Footer, PalettePanel, theme/palette init
-│   ├── pages/                # Route files (auto-routed)
-│   │   ├── index.astro       # Homepage
-│   │   ├── brand.astro       # Brand style reference (palette explorer, specimens)
-│   │   ├── hub/              # Hub gateway + 6 tool pages + library articles
-│   │   └── ...               # services, about, ma-portfolio, privacy, terms
-│   └── styles/               # Global CSS (import order matters)
-│       ├── variables.css     # Design tokens (:root + html.dark-theme)
-│       ├── palettes.css      # 6 alternative palette definitions (html.palette-N)
-│       ├── typography.css    # Semantic text utility classes
-│       ├── interactions.css  # Interactive state patterns (hover, focus, chevron)
-│       ├── global.css        # Layout, utilities, responsive — imports component modules
-│       └── components/       # Extracted component styles (tool-ui, filter, cards, form, map, etc.)
-├── .claude/
-│   ├── agents/               # Claude agent definitions
-│   └── ...
-├── tests/                    # Test files
-│   ├── unit/
-│   ├── integration/
-│   └── e2e/
-├── .github/workflows/        # CI/CD pipelines
-├── vitest.config.ts          # Vitest configuration
-├── playwright.config.ts      # Playwright configuration
-├── astro.config.mjs          # Astro configuration
-├── package.json
-└── README.md
+├── src/                        # WEBSITE workspace (Astro)
+│   ├── components/             # Root components (DeltaIcon, Header, Hero, SEO, …)
+│   │   └── brand/ hub/ portfolio/ radar/ techpar/   # Feature component dirs
+│   ├── data/                   # Structured data
+│   │   ├── ma-portfolio/projects.json   # Portfolio entries (see 📊 Data Management)
+│   │   ├── common/             # Shared taxonomies (funding stages, stage adapters)
+│   │   ├── diligence-machine/ infrastructure-cost-governance/ techpar/
+│   │   ├── regulatory-map/     # Per-regulation JSON files
+│   │   └── palettes.ts         # Palette metadata
+│   ├── pages/                  # Routes: index, brand, services, about, ma-portfolio,
+│   │   └── hub/                #   privacy, terms, 404/500 + hub/{tools/,radar/,library/}
+│   ├── schemas/                # Zod input schemas shared with the MCP tools
+│   ├── scripts/                # Client-side TS (palette-manager, …)
+│   ├── styles/                 # variables.css → typography → interactions → palettes →
+│   │   └── components/         #   global.css + extracted component modules
+│   ├── layouts/BaseLayout.astro
+│   ├── docs/                   # WEBSITE doc tree (adr/ analytics/ development/ hub/
+│   │                           #   operations/ security/ seo/ styles/ testing/)
+│   └── utils/                  # Engine modules for Hub tools (TechPar, ICG, Tech Debt)
+├── mcp-server/                 # MCP SERVER workspace (@gst/mcp-server)
+│   ├── src/tools/ prompts/ resources/ schemas/ lib/ observability/ auth/ cache/
+│   ├── src/docs/               # SERVER doc tree — ARCHITECTURE.md is the maintained
+│   │                           #   system reference; tools/<tool>/CONTRACT.md + USAGE.md
+│   ├── tests/                  # Server unit + integration suites (run: npm run test:mcp)
+│   ├── observability/          # SLO baselines, runbooks, alert evaluator scripts
+│   └── wrangler.toml           # Worker config (staging + production envs)
+├── tests/                      # Website unit/ integration/ e2e/ suites
+├── .claude/                    # CLAUDE.md, PERMISSIONS.md, agents/, skills/, hooks/
+├── .github/workflows/          # CI/CD (see DEVELOPER_TOOLING.md for the pipeline map)
+└── public/                     # Static assets (+ runtime-fetched data)
 ```
 
 ## 🚀 Key Development Commands
 
+The **authoritative command table** (all scripts, both workspaces) lives in [DEVELOPER_TOOLING.md § Quick reference](src/docs/development/DEVELOPER_TOOLING.md). Daily drivers:
+
 ```bash
-# Development
-npm run dev                    # Start dev server (http://localhost:4321)
-npm run build                  # Build for production
-npm run preview               # Preview production build locally
-
-# Testing
-npm run test                   # Run tests in watch mode
-npm run test:run              # Run all tests once
-npm run test:coverage         # Run with coverage report
-npm run test:e2e              # Run E2E tests
-npm run test:e2e:ui           # E2E tests with visual UI
-npm run test:e2e:debug        # E2E tests with debugger
-npm run test:all              # Run all tests (unit + integration + E2E)
-npm run test:ui               # Visual test UI
-
-# Radar (see src/docs/hub/RADAR.md § Working Offline)
-npm run radar:seed            # Seed dev cache with mock data for offline/rate-limited dev
-npm run radar:unseed          # Clear seeded mock data, return to live API
-
-# Other
-npm run astro                 # Run Astro CLI
+npm run dev                    # Dev server (http://localhost:4321)
+npm run build                  # Production build
+npm run test:run               # Website unit + integration (once)
+npm run test:mcp               # MCP server suite (delegates to the workspace)
+npm run test:docs              # Docs link & anchor integrity guard (required CI check)
+npm run test:e2e               # Playwright E2E (only when told — see Directive 5)
+npm run lint / lint:css        # ESLint / stylelint
+npm run setup:claude-hooks     # One-time per machine: arm the review-gate hooks
 ```
 
 ## 📚 Critical Documentation
@@ -238,14 +214,13 @@ The `@gst/mcp-server` workspace has its **own** maintained doc tree — the webs
 
 ### Developer Tooling (Lint, Format, Hooks, CI)
 
-- **Authoritative reference**: [src/docs/development/DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md) — quick-reference table of all scripts, pre-commit hook flow, CI pipeline diagram, config file locations, troubleshooting
-- **When to read it**: before touching `.prettierrc.json`, `eslint.config.mjs`, `.stylelintrc.json`, `tsconfig.json`, `.husky/*`, `.github/workflows/test.yml`, or the `scripts` / `lint-staged` / `overrides` sections of `package.json`
-- **Local validation command** (matches CI): `npx astro check && npm run lint && npm run lint:css && npm run test:run`
+- **Authoritative reference**: [src/docs/development/DEVELOPER_TOOLING.md](src/docs/development/DEVELOPER_TOOLING.md) — quick-reference table of all scripts, pre-commit hook flow, CI pipeline diagram, config file locations, review-gate mechanics, troubleshooting
+- **When to read it**: before touching `.prettierrc.json`, `eslint.config.mjs`, `.stylelintrc.json`, `tsconfig.json`, `.husky/*`, `.github/workflows/*.yml`, `.claude/hooks/*`, or the `scripts` / `lint-staged` / `overrides` sections of `package.json`
 
 ### Testing & CI/CD
 
 - **Start here**: [src/docs/testing/README.md](src/docs/testing/README.md) — use-case-based navigation to all testing docs
-- **Writing or fixing E2E tests**: read [src/docs/testing/TEST_BEST_PRACTICES.md](src/docs/testing/TEST_BEST_PRACTICES.md) first — 25 documented anti-patterns and their fixes
+- **Writing or fixing E2E tests**: read [src/docs/testing/TEST_BEST_PRACTICES.md](src/docs/testing/TEST_BEST_PRACTICES.md) first — a numbered catalog of documented anti-patterns that cause flaky failures, with fixes
 - **Writing new tests**: read [src/docs/testing/TEST_STRATEGY.md](src/docs/testing/TEST_STRATEGY.md) for test patterns by component type
 - **Tests failing**: check [src/docs/testing/TROUBLESHOOTING.md](src/docs/testing/TROUBLESHOOTING.md) before debugging manually
 
@@ -259,6 +234,7 @@ The `@gst/mcp-server` workspace has its **own** maintained doc tree — the webs
 
 - **Security headers & CSP**: [src/docs/security/SECURITY_HEADERS.md](src/docs/security/SECURITY_HEADERS.md) — header inventory, CSP allowlist, how to add external services
 - **Before adding any external script, API, or embed**: check the CSP allowlist and update both `vercel.json` and `src/middleware.ts`
+- **Secrets**: never inline in shell commands or chat (Directive 15); inventory at [src/docs/operations/SECRETS_INVENTORY.md](src/docs/operations/SECRETS_INVENTORY.md)
 
 ### Analytics
 
@@ -269,69 +245,66 @@ The `@gst/mcp-server` workspace has its **own** maintained doc tree — the webs
 
 Specialized agents in `.claude/agents/`. Use the right agent for the task:
 
-| Agent                            | Use When                                                |
-| -------------------------------- | ------------------------------------------------------- |
-| **code-reviewer**                | After code changes — quality, security, maintainability |
-| **javascript-typescript-expert** | Architecture decisions, performance optimization        |
-| **test-automation-specialist**   | Implementing tests, designing test strategies           |
-| **test-strategy-architect**      | Test pyramid design, coverage analysis, CI/CD workflows |
-| **ui-ux-playwright-reviewer**    | E2E test strategy, Playwright patterns                  |
-| **performance-testing-expert**   | Load testing, performance regression detection          |
-| **technical-debt-analyst**       | Refactoring, complexity analysis, debt reduction        |
+| Agent                            | Use When                                                                                           |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **plan-reviewer**                | MANDATORY before ExitPlanMode (Directive 2) — adversarial design review, writes plan-review marker |
+| **code-reviewer**                | MANDATORY before `git push` (Directive 7) — reviews the diff, writes impl-review marker            |
+| **javascript-typescript-expert** | Architecture decisions, performance optimization                                                   |
+| **test-automation-specialist**   | Implementing tests, designing test strategies                                                      |
+| **test-strategy-architect**      | Test pyramid design, coverage analysis, CI/CD workflows                                            |
+| **ui-ux-playwright-reviewer**    | E2E test strategy, Playwright patterns                                                             |
+| **performance-testing-expert**   | Load testing, performance regression detection                                                     |
+| **technical-debt-analyst**       | Refactoring, complexity analysis, debt reduction                                                   |
 
 ## 🔄 Git Workflow
 
-### Branch Strategy
+### Branch Strategy (trunk-based)
 
-- **Main Branch**: `master` (production-ready)
-- **Development Branch**: `dev` (active development)
-- **Feature Branches**: Created from `dev`, merged back via PR
+- **`master` is the trunk** — production-ready; every PR targets it directly
+- **Feature branches** cut from `master`, named with a CI-covered family prefix: `feat/`, `fix/`, `feature/`, `docs/`, `chore/` (these families are wired into the CI push-trigger lists — a new prefix family must be added there too, see DEVELOPER_TOOLING.md)
+- **`dev` is retired** (dormant since 2026-05-31) — do not branch from or merge to it
+- **Merge commits, never squash** — PR merges use "Create a merge commit"
+- **Never `git push` without explicit user authorization** — an approved plan authorizes only the pushes it states; pushes are additionally gated by Directive 7
 
 ### PR Requirements
 
-- All tests must pass (unit, integration, E2E)
-- Code review required
-- Coverage thresholds must be met (70%+)
-- CI/CD checks must pass
+- Required status checks (branch ruleset): **E2E Tests (Playwright)**, **Unit & Integration Tests**, **Lint & Type Check**, **Verify doc links** — plus branch up-to-date (strict policy). A PR stuck BLOCKED after "Update branch": close + reopen (see DEVELOPER_TOOLING.md § push-trigger notes)
+- Review gates (Directives 2 & 7) precede the PR; CI enforces the rest
 
 ## 📊 Data Management
 
 ### Portfolio Data
 
-- **Source**: `src/data/ma-portfolio/projects.json`
-- **Content**: 57 active projects with validated schema
-- **Fields**: id, codeName, industry, theme, summary, arr, arrNumeric, currency, growthStage, year, technologies
-- **Validation**: Unit tests covering schema integrity; auto-validated on commit via CI/CD
+- **Source**: `src/data/ma-portfolio/projects.json` — validated by schema-integrity unit tests (`npm run test:run`), which are the authoritative field list
+- **PREPEND new entries** (don't append) — the UI renders in file order with no sort; newest belongs on top
+- **Update flow**: edit → `npm run test:run` → commit. Push/PR only with user authorization (Directive 7)
 
 ## 🔍 Code Quality Standards
 
 ### Testing Standards
 
-- **Before writing or fixing E2E tests**, read [src/docs/testing/TEST_BEST_PRACTICES.md](src/docs/testing/TEST_BEST_PRACTICES.md) — it documents 25 anti-patterns that cause flaky failures
-- **Before writing new tests**, read [src/docs/testing/TEST_STRATEGY.md](src/docs/testing/TEST_STRATEGY.md) for the correct test type and patterns
-- **Unit Tests**: Fast, isolated, mocked dependencies
-- **Integration Tests**: Real dependencies, isolated data
-- **E2E Tests**: Critical user journeys only
-- **Coverage Target**: 70%+ line coverage minimum
+- **Doc pointers**: see 📚 Testing & CI/CD above — TEST_STRATEGY for what to write, TEST_BEST_PRACTICES before touching E2E
+- **Unit**: fast, isolated, mocked · **Integration**: real dependencies, isolated data · **E2E**: critical user journeys only
+- **Coverage**: 70% line threshold on the covered scopes (see `vitest.config.ts` / mcp-server config for exact include lists)
+- **Never bump a timeout to fix a failing/flaky test** — diagnose the root cause. Known benign flake: the FIRST mcp-server test run of a day can time out on workerd cold-start; rerun before investigating
+- **Pre-existing test debt is not a free pass** — small failing tests in your touched area get fixed in the current PR, not waved through
+- **Playwright: never set `permissions` at project level** in `playwright.config.ts` — desktop permissions crash mobile device contexts; grant per-test with `context.grantPermissions()` guarded by `browserName`
 
 ### CSS Styling Standards
 
-- **Before writing or modifying any CSS**, read [src/docs/styles/STYLES_GUIDE.md](src/docs/styles/STYLES_GUIDE.md) — it is the single entry point for all styling conventions and links to the other style docs when needed
-- **Before choosing any color, spacing, or typography value**, look it up in [src/docs/styles/VARIABLES_REFERENCE.md](src/docs/styles/VARIABLES_REFERENCE.md) — never guess or hardcode
-- **All colors must use CSS variables** — never hardcode color values
-- **All spacing must use the spacing scale** (`--spacing-xs` through `--spacing-3xl`)
-- **All font sizes must use typography utilities** (`.heading-*`, `.text-*`, `.label-*`) or variables
+- **Before writing or modifying any CSS**, read [src/docs/styles/STYLES_GUIDE.md](src/docs/styles/STYLES_GUIDE.md) — the single entry point for all styling conventions (tokens catalog: [VARIABLES_REFERENCE.md](src/docs/styles/VARIABLES_REFERENCE.md))
+- **All colors, spacing, font sizes, and transitions come from the design system** — CSS variables and utility classes only; never hardcode values
 - **Dark theme must work automatically** — use variables; the selector is `html.dark-theme`, not `body.dark-theme`
 - **Palette overrides** in `palettes.css` — applied to `<html>` via class (like dark-theme); see BRAND_GUIDELINES.md § Alternative Palette System
 - **Delta icons**: use `DeltaIcon.astro` component — never `<img>` tags (cannot inherit palette/theme colors via `currentColor`)
 - **Buttons include frosted-glass** by default (`backdrop-filter: blur(2px)`, semi-transparent backgrounds) — see STYLES_GUIDE.md § Frosted Glass
 - **Responsive design desktop-first** — base styles for desktop, `max-width` breakpoints for smaller screens
-- **No hardcoded transitions** — use `--transition-fast`, `--transition-normal`, or `--transition-slow`
-- **Brand decisions** (color hierarchy, semantic colors, palettes, voice, asset rules): [src/docs/styles/BRAND_GUIDELINES.md](src/docs/styles/BRAND_GUIDELINES.md)
+- **Astro `<style>` is scoped by default** — extracting markup into a sibling component silently breaks any class selector targeting it from the source file; restyle in the new component (or use `:global()` deliberately)
 
 ## 🚢 Deployment
 
-Vercel — auto-deploys on push to `master`, preview deploys for PRs. Build: `npm run build`, output: `dist`.
+- **Website**: Vercel — auto-deploys on push to `master`, preview deploys for PRs. Build `npm run build`, output `dist`. Trailing-slash canonicalization lives in `vercel.json` (`trailingSlash: true`) — NOT in `astro.config.mjs` (`'always'` breaks the dev server)
+- **MCP Worker**: fully CI/CD — **staging auto-deploys** on a green MCP test run (`deploy-mcp-staging.yml`); **production** deploys on master merges touching Worker source, gated by the `mcp-production` GitHub Environment approval, latest-wins concurrency (`deploy-mcp-production.yml`); manual rollback via `rollback-mcp.yml`. **Never instruct anyone to manually rebuild/redeploy the Worker** — merge and let the pipeline run. Details: [mcp-server/src/docs/operations/DEPLOY.md](mcp-server/src/docs/operations/DEPLOY.md)
 
 ## 💡 Common Tasks
 
@@ -352,10 +325,16 @@ Vercel — auto-deploys on push to `master`, preview deploys for PRs. Build: `np
 
 ### Updating Portfolio Data
 
-1. Edit `src/data/ma-portfolio/projects.json`
+1. Edit `src/data/ma-portfolio/projects.json` — **prepend** the new entry (see 📊 Data Management)
 2. Run: `npm run test:run` to validate schema
-3. Commit and push
+3. Commit; push/PR only with user authorization
+
+### Extending an MCP Tool
+
+1. Read the tool's `CONTRACT.md` + `USAGE.md` under `mcp-server/src/docs/tools/<tool>/` and [ARCHITECTURE.md](mcp-server/src/docs/ARCHITECTURE.md)
+2. **Tool↔prompt parity**: extending a tool's inputs must also extend its companion `gst_*` prompt (wire-shape adapters) and self-document id/enum args in `.describe()` so a cold LLM call can discover valid values
+3. Run `npm run test:mcp` (contract-parity and prompt-compat tests enforce much of this)
 
 ---
 
-**Last Updated**: July 15, 2026
+**Last Updated**: July 19, 2026 — full accuracy overhaul + review-gate directives (2 & 7) added; directives renumbered 1–15 (old 4a→6, old 5–12 → 8–15)

--- a/.claude/PERMISSIONS.md
+++ b/.claude/PERMISSIONS.md
@@ -13,7 +13,9 @@ Claude has **unrestricted edit permissions** for all files in the `.claude/tasks
 - `todo.md` - Task planning and progress tracking
 - Any future task management files
 
-> **Note**: `lessons.md` (the former learning log) was **retired 2026-07-19**. Self-improvement patterns are now captured in the persistent **memory system** (`feedback` memories + the auto-loaded `MEMORY.md` index), per CLAUDE.md Directive 3 — not in `.claude/tasks/`.
+> **Note**: `lessons.md` (the former learning log) was **retired 2026-07-19**. Self-improvement patterns are now captured in the persistent **memory system** (`feedback` memories + the auto-loaded `MEMORY.md` index), per CLAUDE.md Directive 4 — not in `.claude/tasks/`.
+>
+> `.claude/tasks/` also holds the **review-gate runtime markers** — `plan-review.json` (written by the plan-reviewer agent) and `impl-review.json` (written by the code-reviewer agent). Both are gitignored; the PreToolUse gate hooks read them. See DEVELOPER_TOOLING.md § Claude Code review gates.
 
 **Purpose**: Enable autonomous task management, progress tracking, and learning capture without requiring user approval for edits.
 
@@ -28,17 +30,12 @@ Claude has **unrestricted edit permissions** for all files in the `.claude/tasks
 
 ## Configuration Details
 
-**File**: `.claude/config.json`
+Permissions live in the gitignored, per-developer settings files (see CLAUDE.md Directive 15):
 
-```json
-{
-  "editable_paths": [".claude/tasks/**/*"],
-  "permissions": {
-    "edit_task_files": true,
-    "description": "Claude can freely edit task management files"
-  }
-}
-```
+- **`.claude/settings.local.json`** — the permission `allow` list, plus the review-gate `hooks` registration installed by `npm run setup:claude-hooks` (from the tracked source `.claude/hooks/hooks.config.json`)
+- **`.claude/settings.json`** — additional per-developer permission state written by the harness; also gitignored, never tracked
+
+(An earlier version of this doc cited a `.claude/config.json` file — that file never shipped; this section now reflects the real mechanism.)
 
 ## Why This Matters
 
@@ -67,7 +64,7 @@ Claude will automatically:
 3. Mark items complete with verification results
 4. Move tasks to completed section when done
 
-Corrections and self-improvement patterns are captured in the **memory system** (see CLAUDE.md Directive 3), not in `.claude/tasks/`.
+Corrections and self-improvement patterns are captured in the **memory system** (see CLAUDE.md Directive 4), not in `.claude/tasks/`.
 
 ## No Restrictions
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,28 +1,34 @@
 ---
 name: code-reviewer
-description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code.
-tools: Read, Grep, Glob, Bash
+description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. MUST BE USED on the diff before any git push — writes the impl-review marker the push gate requires.
+tools: Read, Grep, Glob, Bash, Write
 model: inherit
 ---
 
-You are a senior code reviewer ensuring high standards of code quality and security.
+You are a senior code reviewer ensuring high standards of code quality and security for the GST website repo (Astro website + `@gst/mcp-server` Cloudflare Worker workspace).
 
 When invoked:
 
-1. Run git diff to see recent changes
-2. Focus on modified files
+1. Run `git diff master...HEAD` (plus `git status --short` for anything uncommitted) to see the full change set under review
+2. Focus on modified files; read enough surrounding code to judge fit, not just the hunks
 3. Begin review immediately
 
-Review checklist:
+Review checklist — general:
 
-- Code is clear and readable
-- Functions and variables are well-named
-- No duplicated code
-- Proper error handling
-- No exposed secrets or API keys
-- Input validation implemented
-- Good test coverage
-- Performance considerations addressed
+- Code is clear and readable; functions and variables well-named
+- No duplicated code — and no NEW code duplicating an existing utility/component/schema/helper (hunt for reuse: `src/utils/`, `src/data/common/`, `mcp-server/src/lib/`, existing test helpers)
+- Proper error handling; input validation implemented
+- No exposed secrets or API keys; no secrets inlined in shell commands
+- Good test coverage for the change; tests assert behavior, not just presence
+
+Review checklist — repo conventions (open the doc when the diff touches its surface):
+
+- **CSS/styling** → `src/docs/styles/STYLES_GUIDE.md` + `VARIABLES_REFERENCE.md`: no hardcoded colors/spacing/transitions, dark theme via `html.dark-theme`, DeltaIcon component not `<img>`
+- **Tests** → `src/docs/testing/TEST_BEST_PRACTICES.md`: no timeout band-aids masking root causes (BLOCKER if a timeout was raised to make a test pass), no project-level Playwright permissions, no flaky-pattern reintroduction; pre-existing failing tests in touched areas are fixed, not waved through
+- **MCP server** → `mcp-server/src/docs/ARCHITECTURE.md`, relevant ADRs, per-tool `CONTRACT.md`/`USAGE.md`; extending a tool's inputs must extend its companion `gst_*` prompt (wire-shape parity)
+- **Tooling/CI/config** → `src/docs/development/DEVELOPER_TOOLING.md` must be updated in the same diff when hooks/lint/CI change
+- **Content/copy changes** → verify `tests/` was grepped for every replaced string
+- **Docs** → links/anchors must survive the docs-link-integrity guard (`npm run test:docs`)
 
 Provide feedback organized by priority:
 
@@ -31,3 +37,18 @@ Provide feedback organized by priority:
 - Suggestions (consider improving)
 
 Include specific examples of how to fix issues.
+
+## Marker (required — the push gate depends on it)
+
+After delivering your review, record the reviewed state and write `.claude/tasks/impl-review.json`:
+
+```json
+{
+  "verdict": "APPROVE | REVISE",
+  "headSha": "<output of git rev-parse HEAD at review time>",
+  "findings": { "critical": ["..."], "warnings": ["..."], "suggestions": ["..."] },
+  "reviewedAt": "<ISO 8601 timestamp>"
+}
+```
+
+Verdict `APPROVE` only when there are no unresolved critical issues. The push gate compares `headSha` to the current HEAD — if commits are added after your review, the gate forces a re-review, so review the final commit state. Never write verdict `USER_WAIVED` — that is reserved for the main agent recording an explicit user waiver (with the quoted waiver in a `waiver` field).

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -1,0 +1,60 @@
+---
+name: plan-reviewer
+description: Adversarial design/plan reviewer. MUST BE USED on every implementation plan before ExitPlanMode — verifies the plan's claims against the actual codebase and the repo's authoritative documentation, hunts unverified assumptions and missed reuse, then writes the plan-review marker the ExitPlanMode gate requires. Also usable on any design doc or spec before implementation begins.
+tools: Read, Grep, Glob, Bash, Write
+model: opus
+---
+
+You are an impartial, adversarial design reviewer for the GST website repo (Astro website + `@gst/mcp-server` Cloudflare Worker workspace). Your job is to REFUTE the plan you are given: find wrong claims, lazy assumptions, missed conventions, and missed reuse BEFORE implementation starts. You are the mechanism that prevents lazy, assumption-driven, convention-ignorant implementations from reaching the operator.
+
+You will be given the path to a plan file (usually under `~/.claude/plans/`). If no path is given, ask for it by failing loudly in your response — do not guess.
+
+## Review protocol (all six passes are mandatory)
+
+1. **Verify against reality, not against docs.** Every file, function, config key, line number, script, and behavior the plan cites must exist as described — spot-read the actual code (`Read`, `Grep`). A plan that cites `foo.ts:42` gets `foo.ts` opened. Documentation can itself be stale; when a plan claim and the code disagree, the code wins.
+2. **Convention compliance.** For each surface the plan touches, confirm the plan actually consulted (or at least conforms to) the authoritative doc:
+   - Tooling / lint / hooks / CI → `src/docs/development/DEVELOPER_TOOLING.md`
+   - Any CSS → `src/docs/styles/STYLES_GUIDE.md` + `VARIABLES_REFERENCE.md` (no hardcoded colors/spacing/transitions; `html.dark-theme`; DeltaIcon not `<img>`)
+   - Any tests → `src/docs/testing/TEST_STRATEGY.md` + `TEST_BEST_PRACTICES.md` (no timeout band-aids, no project-level Playwright permissions)
+   - Any MCP-server work → `mcp-server/src/docs/ARCHITECTURE.md`, relevant ADRs (`src/docs/adr/`), per-tool `CONTRACT.md`/`USAGE.md`, and tool↔prompt parity (extending a tool's inputs extends its companion `gst_*` prompt)
+   - Any external script/API/embed → `src/docs/security/SECURITY_HEADERS.md` (CSP allowlist in both `vercel.json` and `src/middleware.ts`)
+   - Any backlog item → its BL stanza in `src/docs/development/BACKLOG.md`
+     Name each doc you actually opened. A plan touching a surface whose doc you did not open is an incomplete review.
+3. **Reuse hunt.** Search for existing utilities, components, schemas, test helpers, and patterns the plan should use instead of writing new code. Name them with paths. New code that duplicates an existing capability is a MAJOR.
+4. **Assumption hunt.** Flag every statement presented as fact but not verified (claimed behaviors, claimed absences, "should work", unstated environment assumptions, breaking-change/risk claims made without confirming actual clients/usage).
+5. **Completeness.** Missing test plan; missing doc updates for tooling/config changes; content/copy changes without a `grep tests/` step; any "later" / "follow-up" / "deferred to next session" smell (this repo forbids deferred tech debt — flag as BLOCKER); missing verification section; PR/branch/CI implications ignored (branch families must match CI push-trigger lists).
+6. **Elegance.** Is there a materially simpler design that meets the same requirements? Say so concretely, not rhetorically.
+
+## Output contract
+
+Report findings as:
+
+- **BLOCKERS** — plan is wrong or will break something; must fix before approval
+- **MAJORS** — should fix; approving without fixing requires justification
+- **MINORS** — worth noting
+
+Each finding needs concrete evidence (file:line where applicable). Do not pad: if a pass found nothing, say what you checked and move on. An APPROVE with zero findings must still enumerate what was verified (docs opened, claims spot-read) — rubber-stamping is a protocol violation.
+
+**Verdict**: `APPROVE` (no blockers; majors either absent or explicitly accepted with reasons) or `REVISE` (blockers, or unaccepted majors).
+
+## Marker (required — the ExitPlanMode gate depends on it)
+
+After delivering your findings, write `.claude/tasks/plan-review.json` (repo-relative; the directory exists and you have unrestricted write access to it):
+
+```json
+{
+  "verdict": "APPROVE | REVISE",
+  "blockers": ["..."],
+  "majors": ["..."],
+  "minors": ["..."],
+  "reviewedPlanFile": "<absolute path of the plan file you reviewed>",
+  "planContentSha256": "<sha256 hex of the plan file's exact bytes at review time>",
+  "reviewedAt": "<ISO 8601 timestamp>"
+}
+```
+
+Compute the hash from the file you actually reviewed (e.g. `node -e` with `crypto.createHash('sha256')`, or PowerShell `Get-FileHash`). The gate compares this hash against the plan file's current content: if the plan is edited after your review, the gate forces a re-review — so review the FINAL text, and if the main agent revises the plan in response to your findings, it must send the revised plan back to you.
+
+Never write a marker with verdict `USER_WAIVED` — that verdict is reserved for the main agent recording an explicit user waiver, and it must quote the user's waiver in a `waiver` field.
+
+Your final response should contain the full findings report (the marker is machinery; the findings are the deliverable).

--- a/.claude/hooks/hooks.config.json
+++ b/.claude/hooks/hooks.config.json
@@ -1,0 +1,25 @@
+{
+  "$comment": "Canonical Claude Code review-gate hook registration (tracked). Installed into each developer's gitignored .claude/settings.local.json by `npm run setup:claude-hooks` (.claude/hooks/install.mjs) — settings.local.json is the merge target because the harness actively writes personal permission approvals into .claude/settings.json, which therefore cannot be tracked. Commands are $CLAUDE_PROJECT_DIR-absolute on purpose: a relative path would fail with exit 1 when the session cwd has drifted, and non-2 exit codes are NON-blocking, silently disarming the gate. See DEVELOPER_TOOLING.md § Claude Code review gates.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/plan-review-gate.mjs\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/push-review-gate.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/install.mjs
+++ b/.claude/hooks/install.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Installs the review-gate hooks (hooks.config.json) into this developer's
+ * .claude/settings.local.json — run via `npm run setup:claude-hooks`.
+ *
+ * Why an installer instead of a tracked settings file: the Claude Code harness
+ * actively writes personal permission approvals into .claude/settings.json, so
+ * tracking that file would leak per-developer allowlists into the repo and
+ * churn on every approval. settings.local.json is gitignored by design; this
+ * script idempotently merges ONLY the `hooks` key into it, preserving every
+ * other key (permissions, defaultMode, ...). Re-run safe. Hooks hot-reload —
+ * no Claude Code restart needed.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const CONFIG = resolve(SCRIPT_DIR, 'hooks.config.json');
+// Target overridable for tests.
+const TARGET =
+  process.env.GST_HOOK_INSTALL_TARGET || resolve(SCRIPT_DIR, '..', 'settings.local.json');
+
+const { hooks } = JSON.parse(readFileSync(CONFIG, 'utf-8'));
+if (!hooks || typeof hooks !== 'object') {
+  console.error('hooks.config.json has no "hooks" key — nothing to install.');
+  process.exit(1);
+}
+
+let settings = {};
+if (existsSync(TARGET)) {
+  try {
+    settings = JSON.parse(readFileSync(TARGET, 'utf-8'));
+  } catch (err) {
+    console.error(
+      `Refusing to overwrite ${TARGET}: existing file is not valid JSON (${err.message}). ` +
+        'Fix or remove it, then re-run.'
+    );
+    process.exit(1);
+  }
+}
+
+const before = JSON.stringify(settings.hooks ?? null);
+// Per-event append-and-dedupe: existing personal hooks are preserved; our
+// entries are added only if an identical entry isn't already present.
+settings.hooks = settings.hooks ?? {};
+for (const [event, entries] of Object.entries(hooks)) {
+  const existing = Array.isArray(settings.hooks[event]) ? settings.hooks[event] : [];
+  const have = new Set(existing.map((e) => JSON.stringify(e)));
+  settings.hooks[event] = [...existing, ...entries.filter((e) => !have.has(JSON.stringify(e)))];
+}
+const after = JSON.stringify(settings.hooks);
+
+writeFileSync(TARGET, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+
+if (before === after) {
+  console.log(`Review-gate hooks already installed in ${TARGET} — no changes.`);
+} else {
+  console.log(
+    `Review-gate hooks installed into ${TARGET} (hooks key updated; all other keys preserved).`
+  );
+  console.log(
+    'Hooks hot-reload — the gates are armed for this and future sessions on this machine.'
+  );
+}

--- a/.claude/hooks/plan-review-gate.mjs
+++ b/.claude/hooks/plan-review-gate.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PreToolUse hook — ExitPlanMode gate (Design Review Gate).
+ *
+ * Blocks ExitPlanMode unless the plan-reviewer agent has reviewed the CURRENT
+ * plan content and approved it. The handshake is a marker file written by the
+ * reviewer: .claude/tasks/plan-review.json containing the sha256 of the plan
+ * file it reviewed. Content-binding (not consumption) is the freshness check:
+ *  - user rejects the plan without edits → same hash → re-exit allowed, no
+ *    wasted re-review;
+ *  - ANY post-review edit to the plan → hash mismatch → re-review required.
+ *
+ * Exit semantics (load-bearing): exit 2 BLOCKS the tool call and feeds stderr
+ * back to Claude; exit 0 allows. Any other exit code is NON-blocking (the tool
+ * proceeds), which is why this script never intentionally exits 1 and why the
+ * hook command in hooks.config.json must be $CLAUDE_PROJECT_DIR-absolute — a
+ * "Cannot find module" from a bad relative path would exit 1 and silently
+ * fail OPEN. See DEVELOPER_TOOLING.md § Claude Code review gates.
+ *
+ * Registered via .claude/hooks/hooks.config.json (installed into
+ * .claude/settings.local.json by `npm run setup:claude-hooks`).
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+// Marker dir is env-overridable so unit tests can point at a temp dir.
+const MARKER_DIR = process.env.GST_HOOK_MARKER_DIR || resolve(SCRIPT_DIR, '..', 'tasks');
+const MARKER = resolve(MARKER_DIR, 'plan-review.json');
+
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // loose belt; the hash is the real check
+const ALLOWED_VERDICTS = new Set(['APPROVE', 'USER_WAIVED']);
+
+/** Block with a reason Claude can act on. */
+function block(reason) {
+  process.stderr.write(
+    `Design Review Gate: ${reason}\n` +
+      `To proceed: invoke the plan-reviewer agent on the CURRENT plan file — it reviews the plan ` +
+      `against repo conventions and writes ${MARKER} with the plan's content hash. ` +
+      `If (and only if) the user explicitly waived review, write the marker yourself with verdict ` +
+      `"USER_WAIVED", the user's quoted waiver in a "waiver" field, and the current plan hash.\n`
+  );
+  process.exit(2);
+}
+
+// Drain stdin (hook payload) — this gate needs no fields from it, but leaving
+// stdin unread can block the parent on some platforms.
+try {
+  readFileSync(0, 'utf-8');
+} catch {
+  /* stdin may be empty/closed — fine */
+}
+
+if (!existsSync(MARKER)) {
+  block('no plan-review marker found — the plan has not been reviewed.');
+}
+
+let marker;
+try {
+  marker = JSON.parse(readFileSync(MARKER, 'utf-8'));
+} catch {
+  block('plan-review marker is unreadable/malformed JSON (fail closed).');
+}
+
+if (!ALLOWED_VERDICTS.has(marker.verdict)) {
+  block(
+    `latest review verdict is "${marker.verdict}" — resolve the reviewer's blockers/majors, ` +
+      `revise the plan, and re-run the plan-reviewer.`
+  );
+}
+
+const age = Date.now() - Date.parse(marker.reviewedAt ?? '');
+if (!Number.isFinite(age) || age < 0 || age > MAX_AGE_MS) {
+  block(
+    'plan-review marker is stale (>24h) or has an invalid timestamp — re-run the plan-reviewer.'
+  );
+}
+
+if (!marker.reviewedPlanFile || !existsSync(marker.reviewedPlanFile)) {
+  block('marker does not reference a readable plan file (fail closed).');
+}
+
+let currentHash;
+try {
+  currentHash = createHash('sha256').update(readFileSync(marker.reviewedPlanFile)).digest('hex');
+} catch {
+  block('could not hash the referenced plan file (fail closed).');
+}
+
+if (currentHash !== marker.planContentSha256) {
+  block(
+    'the plan file has been EDITED since it was reviewed (content hash mismatch) — ' +
+      're-run the plan-reviewer on the current plan text.'
+  );
+}
+
+// All checks passed — allow ExitPlanMode.
+process.exit(0);

--- a/.claude/hooks/push-review-gate.mjs
+++ b/.claude/hooks/push-review-gate.mjs
@@ -44,7 +44,7 @@ export function isGitPush(command) {
     .replace(/"[^"]*"/g, ' ')
     .replace(/@'[\s\S]*?'@/g, ' '); // PowerShell here-strings
   const gitPush =
-    /(^|[;&|]|&&|\|\||\bthen\b|\bdo\b)\s*(?:[\w./\\:-]*[/\\])?git(?:\.exe)?\s+(?:-[cC]\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*push\b/;
+    /(^|[;&|\n]|&&|\|\||\bthen\b|\bdo\b)\s*(?:sudo\s+)?(?:[\w./\\:-]*[/\\])?git(?:\.exe)?\s+(?:-[cC]\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*push\b/;
   const m = unquoted.match(gitPush);
   if (!m) return false;
   // Exempt --dry-run (check the segment from the matched `push` onward).

--- a/.claude/hooks/push-review-gate.mjs
+++ b/.claude/hooks/push-review-gate.mjs
@@ -32,9 +32,12 @@ const ALLOWED_VERDICTS = new Set(['APPROVE', 'USER_WAIVED']);
  * Detect a real `git push` in a shell command string.
  * - Quoted segments are stripped first so `git commit -m "explain git push"`
  *   never trips the gate.
- * - `git` must appear in command position (start of string or after a shell
- *   separator), with `push` as its subcommand (allowing intervening `-C dir`
- *   or `-c key=val` style options).
+ * - The command is split on shell separators (;, &, |, &&, ||, newline,
+ *   then/do) and EACH segment is tested independently: `git` must be in
+ *   command position within its segment (optional sudo/path prefix), with
+ *   `push` as its subcommand (allowing intervening `-C dir` / `-c key=val`).
+ *   Per-segment evaluation means a real push anywhere in a compound command
+ *   gates, and a `--dry-run` in one segment cannot exempt a different one.
  * - `--dry-run` pushes are exempt (harmless by definition).
  */
 export function isGitPush(command) {
@@ -43,14 +46,11 @@ export function isGitPush(command) {
     .replace(/'[^']*'/g, ' ')
     .replace(/"[^"]*"/g, ' ')
     .replace(/@'[\s\S]*?'@/g, ' '); // PowerShell here-strings
-  const gitPush =
-    /(^|[;&|\n]|&&|\|\||\bthen\b|\bdo\b)\s*(?:sudo\s+)?(?:[\w./\\:-]*[/\\])?git(?:\.exe)?\s+(?:-[cC]\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*push\b/;
-  const m = unquoted.match(gitPush);
-  if (!m) return false;
-  // Exempt --dry-run (check the segment from the matched `push` onward).
-  const tail = unquoted.slice(unquoted.indexOf(m[0]));
-  const segmentEnd = tail.search(/[;&|]/) === -1 ? tail.length : tail.search(/[;&|]/);
-  return !tail.slice(0, segmentEnd).includes('--dry-run');
+  const pushSegment =
+    /^\s*(?:sudo\s+)?(?:[\w./\\:-]*[/\\])?git(?:\.exe)?\s+(?:-[cC]\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*push\b/;
+  return unquoted
+    .split(/&&|\|\||[;&|\n]|\bthen\b|\bdo\b/)
+    .some((segment) => pushSegment.test(segment) && !segment.includes('--dry-run'));
 }
 
 function block(reason) {

--- a/.claude/hooks/push-review-gate.mjs
+++ b/.claude/hooks/push-review-gate.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PreToolUse hook — git-push gate (Implementation Review Gate).
+ *
+ * Fires on every Bash/PowerShell tool call; fast-exits 0 unless the command is
+ * a real `git push`. On a push, requires a fresh impl-review marker written by
+ * the code-reviewer agent (.claude/tasks/impl-review.json) whose recorded
+ * headSha matches the repo's CURRENT HEAD — so yesterday's review cannot
+ * approve today's unrelated commits, new commits after review force re-review,
+ * and a failed push retries without burning the review (SHA-binding, no
+ * consumption).
+ *
+ * Exit semantics: exit 2 BLOCKS (stderr fed to Claude); exit 0 allows; any
+ * other exit is NON-blocking (fail-open) — hence the $CLAUDE_PROJECT_DIR-
+ * absolute command registration and the fail-closed error handling below.
+ * See DEVELOPER_TOOLING.md § Claude Code review gates.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, '..', '..');
+const MARKER_DIR = process.env.GST_HOOK_MARKER_DIR || resolve(SCRIPT_DIR, '..', 'tasks');
+const MARKER = resolve(MARKER_DIR, 'impl-review.json');
+
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // loose belt; the SHA is the real check
+const ALLOWED_VERDICTS = new Set(['APPROVE', 'USER_WAIVED']);
+
+/**
+ * Detect a real `git push` in a shell command string.
+ * - Quoted segments are stripped first so `git commit -m "explain git push"`
+ *   never trips the gate.
+ * - `git` must appear in command position (start of string or after a shell
+ *   separator), with `push` as its subcommand (allowing intervening `-C dir`
+ *   or `-c key=val` style options).
+ * - `--dry-run` pushes are exempt (harmless by definition).
+ */
+export function isGitPush(command) {
+  if (typeof command !== 'string' || command.length === 0) return false;
+  const unquoted = command
+    .replace(/'[^']*'/g, ' ')
+    .replace(/"[^"]*"/g, ' ')
+    .replace(/@'[\s\S]*?'@/g, ' '); // PowerShell here-strings
+  const gitPush =
+    /(^|[;&|]|&&|\|\||\bthen\b|\bdo\b)\s*(?:[\w./\\:-]*[/\\])?git(?:\.exe)?\s+(?:-[cC]\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*push\b/;
+  const m = unquoted.match(gitPush);
+  if (!m) return false;
+  // Exempt --dry-run (check the segment from the matched `push` onward).
+  const tail = unquoted.slice(unquoted.indexOf(m[0]));
+  const segmentEnd = tail.search(/[;&|]/) === -1 ? tail.length : tail.search(/[;&|]/);
+  return !tail.slice(0, segmentEnd).includes('--dry-run');
+}
+
+function block(reason) {
+  process.stderr.write(
+    `Implementation Review Gate: ${reason}\n` +
+      `To proceed: invoke the code-reviewer agent on the current diff (it reviews against repo ` +
+      `conventions, records the HEAD sha, and writes ${MARKER}). ` +
+      `If (and only if) the user explicitly authorized pushing without review (e.g. a trivial ` +
+      `docs-only diff), write the marker yourself with verdict "USER_WAIVED", the user's quoted ` +
+      `waiver in a "waiver" field, and the current HEAD sha.\n`
+  );
+  process.exit(2);
+}
+
+// Only run the gate when executed as a hook (not when imported by tests).
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  let payload = {};
+  try {
+    payload = JSON.parse(readFileSync(0, 'utf-8'));
+  } catch {
+    /* no/invalid stdin: not a recognizable tool call — stay inert */
+  }
+
+  const command = payload?.tool_input?.command ?? '';
+  if (!isGitPush(command)) {
+    process.exit(0); // fast path: not a push — inert for all other traffic
+  }
+
+  if (!existsSync(MARKER)) {
+    block('no impl-review marker found — the diff has not been code-reviewed.');
+  }
+
+  let marker;
+  try {
+    marker = JSON.parse(readFileSync(MARKER, 'utf-8'));
+  } catch {
+    block('impl-review marker is unreadable/malformed JSON (fail closed).');
+  }
+
+  if (!ALLOWED_VERDICTS.has(marker.verdict)) {
+    block(`latest code-review verdict is "${marker.verdict}" — fix the findings and re-review.`);
+  }
+
+  const age = Date.now() - Date.parse(marker.reviewedAt ?? '');
+  if (!Number.isFinite(age) || age < 0 || age > MAX_AGE_MS) {
+    block('impl-review marker is stale or has an invalid timestamp — re-run the code-reviewer.');
+  }
+
+  let head;
+  try {
+    head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: process.env.GST_HOOK_REPO_DIR || REPO_ROOT,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    block('could not resolve current git HEAD (fail closed).');
+  }
+
+  if (marker.headSha !== head) {
+    block(
+      `impl-review marker was written for HEAD ${String(marker.headSha).slice(0, 12)} but current ` +
+        `HEAD is ${head.slice(0, 12)} — new commits exist since the review; re-run the code-reviewer.`
+    );
+  }
+
+  process.exit(0);
+}

--- a/.claude/tasks/todo.md
+++ b/.claude/tasks/todo.md
@@ -150,4 +150,4 @@ _Add summary of what was accomplished._
 - **Plan Mode Trigger**: 3+ steps OR architectural decisions
 - **Verification**: Always run `npm run test:all` before marking done
 - **Documentation**: Update this file as work progresses
-- **Lessons**: Capture correction patterns in the memory system (`feedback` memories + `MEMORY.md`), per CLAUDE.md Directive 3 — `lessons.md` retired 2026-07-19
+- **Lessons**: Capture correction patterns in the memory system (`feedback` memories + `MEMORY.md`), per CLAUDE.md Directive 4 — `lessons.md` retired 2026-07-19

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ pnpm-debug.log*
 .claude/settings.local.json
 # claude scheduled-tasks runtime lock (per-session)
 .claude/scheduled_tasks.lock
+# claude review-gate runtime markers (per-session; written by plan-reviewer / code-reviewer agents)
+.claude/tasks/plan-review.json
+.claude/tasks/impl-review.json
 
 # playwright test results and reports
 test-results/

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:a11y": "playwright test tests/e2e/accessibility.test.ts --project=chromium",
     "test:mcp": "npm -w @gst/mcp-server run test",
     "test:docs": "vitest run tests/integration/docs-link-integrity.test.ts",
+    "setup:claude-hooks": "node .claude/hooks/install.mjs",
     "test:all": "npm run test:run && npm run test:e2e && npm run test:mcp",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -360,6 +360,7 @@ The diligence engine takes structured enum inputs only — low risk. The portfol
 **Open contingent items**:
 
 - [ ] Library content-source convergence (single source of truth for `gst://library/*` article bodies) — contingent, re-verified still-deferred 2026-07-02; execute if/when the library surface is next touched
+- [ ] **Dead `npm run radar:seed` instruction in live surfaces** (discovered 2026-07-19 during the CLAUDE.md accuracy audit): commit `606f4848` (BL-032.8 Phase B) deliberately removed the `radar:seed`/`radar:unseed` root scripts with the retired BL-039 fallback, but ~15 files still instruct users to run the deleted command — including RUNTIME text: `SNAPSHOT_MISSING_MESSAGE` in `mcp-server/src/content/radar-snapshot.ts:136`, the `gst_radar_brief_today` prompt body (`radar-brief-today.ts:76`), `radar-offline.ts` tool description, resources/radar.ts messages, plus ARCHITECTURE.md:205, radar CONTRACT/USAGE, resources/README, root README.md:77, RADAR.md:113, ADR-0004:27, and two tests asserting the message (`radar-offline.test.ts:126`, `radar-offline-handler.test.ts:151`). Needs a product decision — restore a seed script for the stdio offline tier, or replace every instruction with the current seeding story — then a coordinated sweep (messages + goldens + tests together). CLAUDE.md's own dead references were removed 2026-07-19
 
 ---
 
@@ -393,7 +394,7 @@ The diligence engine takes structured enum inputs only — low risk. The portfol
   - [x] Resolves every `#anchor` on a link to a `.md` file to a real heading (GitHub slug rules; skips external URLs, images, fenced + inline code)
   - [x] Resolves the load-bearing **code → doc-anchor** citations by scanning source for `*.md#anchor` (auto-covers `inoreader-egress.ts` + `_local-only.ts`); path-only citations (e.g. `eslint.config.mjs` → ADR-0004) covered by an explicit list
 - [x] Excludes `_archive/` docs as scan **sources** (frozen-verbatim policy) while still verifying links/anchors that point **into** the archive
-- [x] Wired into local validation (`test:run`) and CI (dedicated `docs-integrity.yml`, documented in `DEVELOPER_TOOLING.md` per Directive 11)
+- [x] Wired into local validation (`test:run`) and CI (dedicated `docs-integrity.yml`, documented in `DEVELOPER_TOOLING.md` per Directive 14 — the developer-tooling directive, numbered 11 at ship time)
 - [x] A `mkdtemp` fixture proves the guard fails on a broken file + broken anchor and passes valid/external/fenced cases (red-then-green)
 
 #### Notes

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -15,6 +15,7 @@ Project-specific reference for the quality tooling installed during Phase 2 of t
 | Run unit and integration tests (watch) | `npm run test`                                                               |
 | Run tests with coverage                | `npm run test:coverage`                                                      |
 | Check documentation links & anchors    | `npm run test:docs`                                                          |
+| Arm the Claude review gates (once/machine) | `npm run setup:claude-hooks` (see § Claude Code review gates)            |
 | Run E2E tests                          | `npm run test:e2e` (Chromium only: `npm run test:e2e -- --project=chromium`) |
 | Run accessibility scan (axe-core)      | `npm run test:a11y`                                                          |
 | Type-check the whole project           | `npx astro check`                                                            |
@@ -261,6 +262,8 @@ concurrency:
 | [.github/workflows/prettier-drift-check.yml](../../../.github/workflows/prettier-drift-check.yml) | Weekly cron + manual `workflow_dispatch` — runs `prettier --check .` repo-wide; opens a `tech-debt` Issue if drift accumulates (counter-pressure for the diff-scoped PR check; see § Prettier idempotency + drift) |
 | [.github/workflows/docs-integrity.yml](../../../.github/workflows/docs-integrity.yml) | Runs `npm run test:docs` (the BL-089 doc link & anchor guard) on every PR + push to `master`. Exists as its own workflow because `test.yml`'s `changes` gate skips docs-only diffs — the exact case the guard must fire on. Not a required check by default; add "Verify doc links" to branch protection to make it blocking |
 | [.github/dependabot.yml](../../../.github/dependabot.yml)                         | Automated dependency updates (npm + GitHub Actions)                                             |
+| [.claude/hooks/hooks.config.json](../../../.claude/hooks/hooks.config.json)       | Tracked registration source for the Claude review-gate hooks (installed per-machine via `npm run setup:claude-hooks`; see § Claude Code review gates) |
+| [.claude/hooks/](../../../.claude/hooks/)                                         | Gate scripts (`plan-review-gate.mjs`, `push-review-gate.mjs`) + installer (`install.mjs`) — unit-tested in `tests/unit/claude-hooks.test.ts` |
 
 ---
 
@@ -626,6 +629,39 @@ Moved here from the main Test Suite (2026-05-31): the audit result is a function
 - `@lhci/cli → { tmp: 0.2.7, uuid: 11.1.1 }` (scoped, added 2026-07-15) — `@lhci/cli@0.15.1` (latest) still pins `tmp@0.1.0`/`0.0.33` (`GHSA-52f5-9888-hmc6` + `GHSA-ph9p-34f9-6g65`, high) and `uuid@8.3.2` (`GHSA-w5hq-g745-h8pq`, moderate); npm audit's only suggested "fix" is a destructive downgrade to `@lhci/cli@0.1.0`. The scoped override forces the patched transitive versions inside lhci's subtree only, which also clears the dependent `external-editor`/`inquirer` advisories. Verified via `npx lhci healthcheck` + the CI lighthouse job. Remove when `@lhci/cli` ships with `tmp >=0.2.6` and `uuid >=11.1.1` (check with `npm ls tmp uuid --all` after a Dependabot lhci bump, then delete the override and re-run `npm audit`).
 
 **Automated dependency updates** — [Dependabot](../../../.github/dependabot.yml) opens PRs weekly for npm and GitHub Actions version bumps. When reviewing Dependabot PRs that update `@astrojs/vercel` or `@vercel/routing-utils`, check whether the `path-to-regexp` override can be removed by running `npm audit --omit=dev` after deleting the `overrides` block.
+
+---
+
+## Claude Code review gates
+
+Two Claude Code PreToolUse hooks mechanically enforce the review directives in [CLAUDE.md](../../../.claude/CLAUDE.md) (Directives 2 and 7), so a session cannot lazily skip design or code review:
+
+| Gate                          | Blocks                     | Requires                                                                                                                                                                     | Reviewer agent  |
+| ----------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| **Design Review Gate**        | `ExitPlanMode` (plan exit) | `.claude/tasks/plan-review.json` — verdict `APPROVE`/`USER_WAIVED`, `planContentSha256` matching the CURRENT plan-file bytes, `reviewedAt` < 24 h                             | `plan-reviewer` |
+| **Implementation Review Gate** | any real `git push`        | `.claude/tasks/impl-review.json` — verdict `APPROVE`/`USER_WAIVED`, `headSha` equal to current `git rev-parse HEAD`                                                          | `code-reviewer` |
+
+### Setup (once per machine/clone)
+
+```bash
+npm run setup:claude-hooks
+```
+
+This runs [.claude/hooks/install.mjs](../../../.claude/hooks/install.mjs), which idempotently merges the tracked registration source [.claude/hooks/hooks.config.json](../../../.claude/hooks/hooks.config.json) into your gitignored `.claude/settings.local.json` (preserving all other keys and any personal hooks). Hooks hot-reload — no restart. **Why an installer instead of a tracked settings file**: the harness actively writes personal permission approvals into `.claude/settings.json`, so neither settings file can be tracked without leaking per-developer allowlists; the tracked config + installer keeps the registration in the repo and the personal state out of it.
+
+### How the handshake works
+
+- **Content/SHA binding, not consumption**: the plan marker stores a sha256 of the plan file it reviewed; the push marker stores the HEAD sha it reviewed. Editing the plan (or adding commits) after review invalidates the marker automatically — and a user *rejection* without edits, or a *failed push retry*, does NOT burn the review.
+- **Fail-open pitfall (load-bearing)**: for PreToolUse hooks, only **exit 2 blocks** — any other non-zero exit is a non-blocking error and the tool call PROCEEDS. This is why the registered commands are `$CLAUDE_PROJECT_DIR`-absolute (a relative path would "Cannot find module"-exit-1 whenever the session has `cd`'d, silently disarming the gate) and why the scripts fail CLOSED (exit 2) on missing/malformed/stale markers. Unit coverage: [tests/unit/claude-hooks.test.ts](../../../tests/unit/claude-hooks.test.ts).
+- **Waivers**: only the user can waive a gate. The main agent then writes the marker with verdict `USER_WAIVED`, a `waiver` field quoting the user, and the current plan-hash/HEAD-sha. Agents must never hand-write an `APPROVE`.
+- The push gate ignores everything that isn't a real push: quoted mentions (`git commit -m "about git push"`), `git stash push`, `git push --dry-run`, and all non-git traffic fast-exit clean.
+
+### Troubleshooting
+
+- **"Design Review Gate: … EDITED since it was reviewed"** — expected after revising a plan; send the revised plan back to `plan-reviewer`.
+- **"Implementation Review Gate: … new commits exist since the review"** — expected after adding commits; re-run `code-reviewer` on the final state.
+- **Gate blocks something it shouldn't** — inspect the marker (`.claude/tasks/*.json`), fix or delete it, re-run the reviewer. Markers are gitignored runtime state; deleting them is always safe (the next review recreates them).
+- **Gates not firing at all** — `npm run setup:claude-hooks` hasn't been run on this machine, or `settings.local.json` was replaced; re-run the installer.
 
 ---
 

--- a/tests/unit/claude-hooks.test.ts
+++ b/tests/unit/claude-hooks.test.ts
@@ -143,6 +143,9 @@ describe('push-review-gate: isGitPush command detection', () => {
     ['git.exe push', true],
     ['echo done\ngit push', true], // newline-separated multi-line command
     ['sudo git push', true],
+    ['git push\necho --dry-run', true], // --dry-run in a LATER segment must not exempt a real push
+    ['git push --dry-run\ngit push', true], // second, real push after an exempt one
+    ['cd x; git push --dry-run', false], // chained dry-run is still exempt (per-segment eval)
     // NOT pushes:
     ['git commit -m "docs: explain the git push gate"', false], // push inside quotes
     ["git commit -m 'mention git push here'", false],

--- a/tests/unit/claude-hooks.test.ts
+++ b/tests/unit/claude-hooks.test.ts
@@ -141,6 +141,8 @@ describe('push-review-gate: isGitPush command detection', () => {
     ['cd mcp-server; git push', true],
     ['npm run test:run && git push -u origin feat/x', true],
     ['git.exe push', true],
+    ['echo done\ngit push', true], // newline-separated multi-line command
+    ['sudo git push', true],
     // NOT pushes:
     ['git commit -m "docs: explain the git push gate"', false], // push inside quotes
     ["git commit -m 'mention git push here'", false],

--- a/tests/unit/claude-hooks.test.ts
+++ b/tests/unit/claude-hooks.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the Claude Code review-gate hooks (Design Review Gate +
+ * Implementation Review Gate) and their installer.
+ *
+ * The gates are PreToolUse hook scripts whose exit codes are load-bearing:
+ * exit 2 BLOCKS the tool call, exit 0 allows, anything else is NON-blocking
+ * (fail-open) — so these tests assert exact exit codes, including the
+ * fail-closed paths (missing/malformed/stale markers must exit 2, never 1).
+ *
+ * See DEVELOPER_TOOLING.md § Claude Code review gates.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+
+// Hook script lives outside src/ by design (.claude/hooks/); imported directly for unit tests.
+import { isGitPush } from '../../.claude/hooks/push-review-gate.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const PLAN_GATE = resolve(REPO_ROOT, '.claude/hooks/plan-review-gate.mjs');
+const PUSH_GATE = resolve(REPO_ROOT, '.claude/hooks/push-review-gate.mjs');
+const INSTALLER = resolve(REPO_ROOT, '.claude/hooks/install.mjs');
+
+/** Run a hook script with fixture stdin + env; return {status, stderr}. */
+function runHook(
+  script: string,
+  stdin: object,
+  env: Record<string, string>
+): { status: number; stderr: string } {
+  try {
+    execFileSync(process.execPath, [script], {
+      input: JSON.stringify(stdin),
+      env: { ...process.env, ...env },
+      encoding: 'utf-8',
+    });
+    return { status: 0, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number | null; stderr: string };
+    return { status: e.status ?? -1, stderr: String(e.stderr ?? '') };
+  }
+}
+
+const sha256 = (buf: Buffer | string) => createHash('sha256').update(buf).digest('hex');
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'gst-hooks-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('plan-review-gate (Design Review Gate)', () => {
+  const env = () => ({ GST_HOOK_MARKER_DIR: dir });
+
+  function writePlanAndMarker(
+    overrides: Record<string, unknown> = {},
+    planText = '# The Plan\n\ndo things\n'
+  ) {
+    const planFile = join(dir, 'plan.md');
+    writeFileSync(planFile, planText, 'utf-8');
+    const marker = {
+      verdict: 'APPROVE',
+      blockers: [],
+      majors: [],
+      minors: [],
+      reviewedPlanFile: planFile,
+      planContentSha256: sha256(readFileSync(planFile)),
+      reviewedAt: new Date().toISOString(),
+      ...overrides,
+    };
+    writeFileSync(join(dir, 'plan-review.json'), JSON.stringify(marker), 'utf-8');
+    return planFile;
+  }
+
+  it('blocks (exit 2) when no marker exists', () => {
+    const r = runHook(PLAN_GATE, {}, env());
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Design Review Gate');
+  });
+
+  it('allows (exit 0) on fresh APPROVE with matching plan hash', () => {
+    writePlanAndMarker();
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(0);
+  });
+
+  it('re-allows without re-review when the plan is unchanged (no consumption)', () => {
+    writePlanAndMarker();
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(0);
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(0); // user rejected, agent re-exits same plan
+  });
+
+  it('blocks when the plan was edited after review (hash mismatch)', () => {
+    const planFile = writePlanAndMarker();
+    writeFileSync(planFile, '# The Plan\n\ndo DIFFERENT things\n', 'utf-8');
+    const r = runHook(PLAN_GATE, {}, env());
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('EDITED');
+  });
+
+  it('blocks on REVISE verdict', () => {
+    writePlanAndMarker({ verdict: 'REVISE' });
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(2);
+  });
+
+  it('allows USER_WAIVED with matching hash', () => {
+    writePlanAndMarker({ verdict: 'USER_WAIVED', waiver: 'user said: skip review' });
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(0);
+  });
+
+  it('blocks a stale (>24h) marker', () => {
+    writePlanAndMarker({ reviewedAt: new Date(Date.now() - 25 * 3600_000).toISOString() });
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(2);
+  });
+
+  it('fails CLOSED (exit 2, not 1) on malformed marker JSON', () => {
+    writeFileSync(join(dir, 'plan-review.json'), '{not json', 'utf-8');
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(2);
+  });
+
+  it('fails CLOSED when the referenced plan file is missing', () => {
+    writePlanAndMarker({ reviewedPlanFile: join(dir, 'gone.md') });
+    expect(runHook(PLAN_GATE, {}, env()).status).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('push-review-gate: isGitPush command detection', () => {
+  it.each([
+    ['git push', true],
+    ['git push origin master', true],
+    ['git -C c:/Code/gst-website push', true],
+    ['cd mcp-server; git push', true],
+    ['npm run test:run && git push -u origin feat/x', true],
+    ['git.exe push', true],
+    // NOT pushes:
+    ['git commit -m "docs: explain the git push gate"', false], // push inside quotes
+    ["git commit -m 'mention git push here'", false],
+    ['git push --dry-run', false], // harmless by definition
+    ['git stash push', false], // different subcommand
+    ['echo git push', false], // not in command position
+    ['gh pr create --title "x"', false],
+    ['npm run build', false],
+    ['', false],
+  ])('%j → %s', (cmd, expected) => {
+    expect(isGitPush(cmd as string)).toBe(expected);
+  });
+});
+
+describe('push-review-gate (Implementation Review Gate)', () => {
+  const env = () => ({ GST_HOOK_MARKER_DIR: dir, GST_HOOK_REPO_DIR: REPO_ROOT });
+  const payload = (command: string) => ({ tool_name: 'Bash', tool_input: { command } });
+
+  const currentHead = () =>
+    execFileSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT, encoding: 'utf-8' }).trim();
+
+  function writeMarker(overrides: Record<string, unknown> = {}) {
+    writeFileSync(
+      join(dir, 'impl-review.json'),
+      JSON.stringify({
+        verdict: 'APPROVE',
+        headSha: currentHead(),
+        findings: { critical: [], warnings: [], suggestions: [] },
+        reviewedAt: new Date().toISOString(),
+        ...overrides,
+      }),
+      'utf-8'
+    );
+  }
+
+  it('fast-allows non-push commands without needing any marker', () => {
+    expect(runHook(PUSH_GATE, payload('npm run test:run'), env()).status).toBe(0);
+  });
+
+  it('is inert on missing/empty stdin (subagent or malformed traffic)', () => {
+    const r = runHook(PUSH_GATE, {}, env());
+    expect(r.status).toBe(0);
+  });
+
+  it('blocks a push with no marker', () => {
+    const r = runHook(PUSH_GATE, payload('git push -u origin feat/x'), env());
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Implementation Review Gate');
+  });
+
+  it('allows a push with APPROVE marker bound to current HEAD', () => {
+    writeMarker();
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(0);
+  });
+
+  it('does not consume the marker — a failed push can retry', () => {
+    writeMarker();
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(0);
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(0);
+  });
+
+  it('blocks when marker HEAD differs from current HEAD (new commits since review)', () => {
+    writeMarker({ headSha: 'a'.repeat(40) });
+    const r = runHook(PUSH_GATE, payload('git push'), env());
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('new commits');
+  });
+
+  it('blocks on REVISE verdict', () => {
+    writeMarker({ verdict: 'REVISE' });
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(2);
+  });
+
+  it('allows USER_WAIVED bound to current HEAD', () => {
+    writeMarker({ verdict: 'USER_WAIVED', waiver: 'user said: push the docs fix without review' });
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(0);
+  });
+
+  it('fails CLOSED on malformed marker JSON', () => {
+    writeFileSync(join(dir, 'impl-review.json'), '{oops', 'utf-8');
+    expect(runHook(PUSH_GATE, payload('git push'), env()).status).toBe(2);
+  });
+
+  it('does not gate a quoted mention of git push even with no marker present', () => {
+    const r = runHook(PUSH_GATE, payload('git commit -m "feat: add the git push gate"'), env());
+    expect(r.status).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('install.mjs (hook registration installer)', () => {
+  function runInstaller(target: string): string {
+    return execFileSync(process.execPath, [INSTALLER], {
+      env: { ...process.env, GST_HOOK_INSTALL_TARGET: target },
+      encoding: 'utf-8',
+    });
+  }
+
+  it('creates settings.local.json with the hooks when absent', () => {
+    const target = join(dir, 'settings.local.json');
+    runInstaller(target);
+    expect(existsSync(target)).toBe(true);
+    const settings = JSON.parse(readFileSync(target, 'utf-8'));
+    const matchers = settings.hooks.PreToolUse.map((e: { matcher: string }) => e.matcher);
+    expect(matchers).toContain('ExitPlanMode');
+    expect(matchers).toContain('Bash|PowerShell');
+  });
+
+  it('preserves existing keys and existing custom hooks', () => {
+    const target = join(dir, 'settings.local.json');
+    const custom = { matcher: 'WebFetch', hooks: [{ type: 'command', command: 'echo hi' }] };
+    writeFileSync(
+      target,
+      JSON.stringify({ permissions: { allow: ['Bash(git *)'] }, hooks: { PreToolUse: [custom] } }),
+      'utf-8'
+    );
+    runInstaller(target);
+    const settings = JSON.parse(readFileSync(target, 'utf-8'));
+    expect(settings.permissions.allow).toEqual(['Bash(git *)']); // untouched
+    const matchers = settings.hooks.PreToolUse.map((e: { matcher: string }) => e.matcher);
+    expect(matchers).toEqual(
+      expect.arrayContaining(['WebFetch', 'ExitPlanMode', 'Bash|PowerShell'])
+    );
+  });
+
+  it('is idempotent — double-run adds nothing', () => {
+    const target = join(dir, 'settings.local.json');
+    runInstaller(target);
+    const first = readFileSync(target, 'utf-8');
+    const secondOutput = runInstaller(target);
+    expect(readFileSync(target, 'utf-8')).toBe(first);
+    expect(secondOutput).toContain('no changes');
+  });
+
+  it('refuses to clobber an invalid-JSON target', () => {
+    const target = join(dir, 'settings.local.json');
+    writeFileSync(target, '{broken', 'utf-8');
+    expect(() => runInstaller(target)).toThrow();
+    expect(readFileSync(target, 'utf-8')).toBe('{broken'); // untouched
+  });
+});


### PR DESCRIPTION
## Why

Two linked problems, one root cause:

1. **CLAUDE.md had drifted from reality** — a three-agent audit found factually wrong claims (Astro "6.x" → 7.x; `radar:seed`/`radar:unseed` commands that no longer exist), stale counts everywhere, the retired `dev`-branch workflow still presented as current, and the `mcp-server/` workspace (~half the codebase) entirely absent from the structure tree.
2. **Design/implementation review was folklore, not infrastructure** — the "impartial audit before implementation" practice lived in prose and one operator's private session memory, invisible to other sessions. Result: lazy implementations, unverified assumptions, and work that ignored existing docs/conventions.

## What this adds

### Enforced review gates (the new capability)

| Gate | Blocks | Until |
|---|---|---|
| **Design Review Gate** (Directive 2) | `ExitPlanMode` | `plan-reviewer` agent (NEW, `model: opus`) has reviewed the CURRENT plan bytes — content-hash-bound marker |
| **Implementation Review Gate** (Directive 7) | any real `git push` | `code-reviewer` agent has reviewed the diff at the CURRENT HEAD — SHA-bound marker |

- Two PreToolUse hook scripts (Node, cross-platform, **fail-closed**: only exit 2 blocks, so every error path exits 2; commands are `$CLAUDE_PROJECT_DIR`-absolute because a bad relative path would exit-1 → silently fail OPEN).
- **Hash/SHA binding, not consumption**: a user rejection without plan edits doesn't burn the review; any plan edit or new commit forces re-review automatically; failed pushes retry free.
- Registration ships as tracked `hooks.config.json` + idempotent installer (`npm run setup:claude-hooks`) merging into gitignored `settings.local.json` — deliberately NOT a tracked settings file, because the harness actively writes personal permission approvals into `.claude/settings.json` (adversarial-audit finding; tracking it would leak allowlists).
- **42 unit tests**: exit-code matrix incl. fail-closed paths, hash/SHA binding, quoted-string false-positives, per-segment `--dry-run` scoping, installer idempotency/key-preservation.

### CLAUDE.md full restructure

- Truth-passed every audited claim; brittle counts dropped entirely (the #1 rot source).
- Directives renumbered 1–15 (gates at 2 and 7); live cross-refs updated (PERMISSIONS.md, todo.md, BACKLOG.md).
- Git Workflow rewritten for the real trunk model (feature→master, merge commits never squash, required checks enumerated, `dev` retired).
- `mcp-server/` first-class in the structure tree; Deployment covers the MCP Worker CI/CD pipeline.
- Codified conventions previously trapped in private memory: portfolio prepend, no timeout band-aids, workerd first-run flake, pre-existing test debt, Playwright project-level permissions, Astro scoped-CSS gotcha, MCP tool↔prompt parity, secrets never inline, trailing-slash via vercel.json.
- DEVELOPER_TOOLING.md gains **§ Claude Code review gates**; PERMISSIONS.md's fictional `.claude/config.json` block replaced with the real mechanism.

### Discovered defect, filed not fixed (needs a product decision)

~15 live surfaces (runtime error messages, the `gst_radar_brief_today` prompt body, tool descriptions, docs) still instruct users to run `npm run radar:seed` — deliberately deleted in `606f4848` (BL-032.8). Filed under BL-034 with full evidence; needs a decision (restore the script vs. coordinated message sweep) before touching goldens/tests.

## Dogfooding proof (the gates work — live)

This PR's own delivery exercised the full loop:

1. The plan was **adversarially reviewed pre-approval** (3 blockers + 5 majors found: fail-open hook path, missing Write tool, settings-churn leak risk, marker-binding design — all incorporated).
2. First `git push` → **blocked live** by the new hook ("no impl-review marker").
3. code-reviewer APPROVE'd → two regex hardening rounds (its own findings) → each new commit **re-blocked the push** (SHA mismatch) until re-reviewed.
4. Final push passed the gate with a validated marker.

## Verification

- `test:run` 1222/1222 (45 files, incl. 42 hook tests) · `test:docs` 11/11 · `astro check` clean · `lint` + `lint:css` clean
- Installer run live; registration confirmed (both matchers, permissions untouched)
- Both hook block-paths and the allow-path verified live in-session

## Post-merge operator note

Gates are armed on this machine already. Any other clone: one-time `npm run setup:claude-hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
