### PR TITLE
docs(readme): truth-pass — Astro 7.x, mcp-server workspace, countless phrasing

### DIFF
--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -12,9 +12,8 @@ name: Docs link integrity
 # could break) plus pushes to master. Default `pull_request` types include
 # `synchronize`, so every push to a PR re-runs it (no push-branch-list gap).
 #
-# To make this blocking, add "Verify doc links" to the branch-protection
-# required-status-checks list (repo Settings → Rules). It is not required by
-# default.
+# "Verify doc links" IS a required status check on the master ruleset
+# (added by the operator 2026-07-19) — a broken doc link/anchor blocks merge.
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ gst-website/
 │   │   ├── common/             # Shared taxonomies (funding stages, stage adapters)
 │   │   ├── diligence-machine/  # Questions, attention areas, wizard config
 │   │   ├── infrastructure-cost-governance/
-│   │   └── techpar/            # Industry notes, recommendations, stages
+│   │   ├── techpar/            # Industry notes, recommendations, stages
+│   │   └── irl/ library/ …     # IRL request definitions, library article digests
 │   ├── docs/                   # Project documentation (see below)
 │   ├── layouts/                # BaseLayout.astro (header, footer, palette panel)
 │   ├── middleware.ts           # SSR security headers (CSP, HSTS, etc.)
 │   ├── pages/                  # Routes (auto-routed): index, brand, services, about,
-│   │                           #   ma-portfolio, privacy, terms + hub/{tools,radar,library}
+│   │                           #   ma-portfolio, hub/{tools,radar,library}, …
 │   ├── schemas/                # Zod input schemas (shared with the MCP tools)
 │   ├── scripts/                # Client-side modules (palette-manager)
 │   ├── styles/                 # Global CSS (variables, palettes, typography, interactions)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Global Strategic Technologies — Website
+# Global Strategic Technologies — Website & MCP Server
 
-A high-performance website for GST built with Astro 6 and deployed to Vercel. Tech brutalist design with dark mode, 6 alternative color palettes, and 5 interactive hub tools.
+A high-performance website for GST built with Astro and deployed to Vercel — tech brutalist design with dark mode, alternative color palettes, and a suite of interactive hub tools — plus the **GST MCP server** (`mcp-server/` workspace) that exposes the same hub capabilities to LLM clients, deployed as a Cloudflare Worker at `mcp.globalstrategic.tech`.
 
 ## Quick Start
 
@@ -11,70 +11,64 @@ npm run dev            # http://localhost:4321
 
 ## Architecture
 
-- **Framework**: Astro 6.x (static + SSR hybrid)
-- **Build**: Vite with LightningCSS transformer
-- **Deploy**: Vercel (static pages + ISR for Radar)
-- **Testing**: Vitest (unit/integration) + Playwright (E2E) + axe-core (accessibility)
-- **Error Monitoring**: Sentry (`@sentry/astro`, privacy-first config)
-- **Analytics**: Google Analytics 4 with 50+ tracked events across 5 hub tools
+- **Website**: Astro 7.x (static + SSR hybrid), Vite with LightningCSS transformer, deployed to Vercel (static pages + ISR for Radar)
+- **MCP server** (`@gst/mcp-server` npm workspace): TypeScript MCP server — stdio locally, Cloudflare Worker remotely (staging + production); Upstash Redis for caching/rate-limiting; maintained system reference at [mcp-server/src/docs/ARCHITECTURE.md](mcp-server/src/docs/ARCHITECTURE.md)
+- **Testing**: Vitest (unit/integration, both workspaces) + Playwright (E2E) + axe-core (accessibility)
+- **Error Monitoring**: Sentry (privacy-first config, both surfaces)
+- **Analytics**: Google Analytics 4 with per-tool event tracking across the hub
 
 ## Project Structure
 
 ```
 gst-website/
 ├── public/                     # Static assets, favicons, manifest
-│   └── data/                   # Runtime-fetched geodata (TopoJSON)
-├── src/
-│   ├── components/             # 18 root + 4 subdirectories
-│   │   ├── brand/              # Brand page specimens (9 components)
-│   │   ├── hub/                # Hub header + regulatory-map sub-components
-│   │   ├── portfolio/          # Grid, modal, filters, sticky controls
-│   │   └── radar/              # Feed items, category filter, skeleton
+├── src/                        # WEBSITE workspace
+│   ├── components/             # Root components + brand/ hub/ portfolio/ radar/ techpar/
 │   ├── content.config.ts       # Astro content collection (regulatory-map)
 │   ├── data/                   # Structured data sources
-│   │   ├── ma-portfolio/       # 57 validated projects (projects.json)
-│   │   ├── regulatory-map/     # 120 regulation JSON files
+│   │   ├── ma-portfolio/       # Portfolio engagements (projects.json, schema-validated)
+│   │   ├── regulatory-map/     # Per-regulation JSON files
+│   │   ├── common/             # Shared taxonomies (funding stages, stage adapters)
 │   │   ├── diligence-machine/  # Questions, attention areas, wizard config
 │   │   ├── infrastructure-cost-governance/
 │   │   └── techpar/            # Industry notes, recommendations, stages
 │   ├── docs/                   # Project documentation (see below)
 │   ├── layouts/                # BaseLayout.astro (header, footer, palette panel)
 │   ├── middleware.ts           # SSR security headers (CSP, HSTS, etc.)
-│   ├── pages/                  # 23 routes (auto-routed)
-│   ├── schemas/                # Zod schemas for all 6 data sources
+│   ├── pages/                  # Routes (auto-routed): index, brand, services, about,
+│   │                           #   ma-portfolio, privacy, terms + hub/{tools,radar,library}
+│   ├── schemas/                # Zod input schemas (shared with the MCP tools)
 │   ├── scripts/                # Client-side modules (palette-manager)
 │   ├── styles/                 # Global CSS (variables, palettes, typography, interactions)
 │   └── utils/                  # Engine modules (techpar, ICG, diligence, tech-debt)
-├── tests/
-│   ├── unit/                   # Vitest unit tests
-│   ├── integration/            # Vitest integration tests
-│   └── e2e/                    # Playwright E2E tests
+├── mcp-server/                 # MCP SERVER workspace (@gst/mcp-server)
+│   ├── src/                    # tools/ prompts/ resources/ schemas/ lib/ observability/
+│   ├── src/docs/               # Server doc tree (ARCHITECTURE.md, per-tool CONTRACT/USAGE)
+│   ├── tests/                  # Server unit + integration suites
+│   └── wrangler.toml           # Worker config (staging + production envs)
+├── tests/                      # Website unit/ integration/ e2e/ suites
 ├── astro.config.mjs            # Astro + Sentry + sitemap + Vercel adapter
-├── eslint.config.mjs           # ESLint flat config (typescript-eslint + astro)
-├── .prettierrc.json            # Prettier config (single quotes, trailing commas)
-├── .stylelintrc.json           # Stylelint config (CSS + .astro scoped styles)
-├── vitest.config.ts            # Unit/integration test config
-├── playwright.config.ts        # E2E test config (3 browsers)
-├── sentry.client.config.ts     # Sentry client (error-only, no PII)
-├── sentry.server.config.ts     # Sentry server (error-only)
 ├── vercel.json                 # Security headers (CSP, HSTS, X-Frame-Options)
-└── package.json                # Scripts, dependencies, browserslist
+└── package.json                # Scripts, workspaces, browserslist, lint-staged
 ```
 
 ## Commands
 
-| Command                 | Action                                                                             |
-| :---------------------- | :--------------------------------------------------------------------------------- |
-| `npm run dev`           | Start dev server at `http://localhost:4321`                                        |
-| `npm run build`         | Build production site to `./dist/`                                                 |
-| `npm run preview`       | Preview production build locally                                                   |
-| `npm run test:run`      | Run unit + integration tests once                                                  |
-| `npm run test:e2e`      | Run E2E tests (all browsers)                                                       |
-| `npm run test:all`      | Run everything (unit + integration + E2E)                                          |
-| `npm run test:coverage` | Run with coverage report                                                           |
-| `npm run lint`          | ESLint                                                                             |
-| `npm run lint:css`      | Stylelint (CSS + .astro scoped styles)                                             |
-| `npm run radar:seed`    | Populate the local stdio MCP radar snapshot with mock data (`radar:unseed` clears) |
+| Command                      | Action                                                                             |
+| :--------------------------- | :--------------------------------------------------------------------------------- |
+| `npm run dev`                | Start dev server at `http://localhost:4321`                                        |
+| `npm run build`              | Build production site to `./dist/`                                                 |
+| `npm run preview`            | Preview production build locally                                                   |
+| `npm run test:run`           | Run website unit + integration tests once                                          |
+| `npm run test:mcp`           | Run the MCP server suite (delegates to the workspace)                              |
+| `npm run test:docs`          | Documentation link & anchor integrity guard (required CI check)                    |
+| `npm run test:e2e`           | Run E2E tests (all browsers)                                                       |
+| `npm run test:all`           | Run everything (unit + integration + E2E + MCP)                                    |
+| `npm run test:coverage`      | Run with coverage report                                                           |
+| `npm run lint`               | ESLint                                                                             |
+| `npm run lint:css`           | Stylelint (CSS + .astro scoped styles)                                             |
+| `npm run radar:seed`         | Populate the local stdio MCP radar snapshot with mock data (`radar:unseed` clears) |
+| `npm run setup:claude-hooks` | One-time per machine: arm the Claude Code review-gate hooks                        |
 
 ### Local Validation (matches CI)
 
@@ -84,25 +78,26 @@ npx astro check && npm run lint && npm run lint:css && npm run test:run
 
 ## Configuration Entry Points
 
-| File                      | Purpose                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| `astro.config.mjs`        | Astro integrations (Sentry, sitemap), Vercel adapter, LightningCSS, env schema |
-| `vercel.json`             | Security headers for static routes (CSP, HSTS, X-Frame-Options)                |
-| `src/middleware.ts`       | Security headers for SSR routes (mirrors vercel.json)                          |
-| `sentry.client.config.ts` | Client-side error monitoring (privacy-first, no PII)                           |
-| `sentry.server.config.ts` | Server-side error monitoring                                                   |
-| `src/content.config.ts`   | Astro content collection for regulatory-map data                               |
-| `eslint.config.mjs`       | ESLint flat config with typescript-eslint and astro plugin                     |
-| `.prettierrc.json`        | Code formatting (single quotes, 100 char width, trailing commas)               |
-| `.stylelintrc.json`       | CSS linting with .astro scoped style support                                   |
-| `vitest.config.ts`        | Unit/integration test config, path aliases, coverage thresholds                |
-| `playwright.config.ts`    | E2E test config (Chromium, Firefox, WebKit)                                    |
-| `.husky/pre-commit`       | Pre-commit hook: lint-staged runs ESLint, stylelint, Prettier                  |
-| `package.json`            | Scripts, browserslist (LightningCSS targets), lint-staged config               |
+| File                       | Purpose                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `astro.config.mjs`         | Astro integrations (Sentry, sitemap), Vercel adapter, LightningCSS, env schema |
+| `vercel.json`              | Security headers for static routes (CSP, HSTS, X-Frame-Options)                |
+| `src/middleware.ts`        | Security headers for SSR routes (mirrors vercel.json)                          |
+| `sentry.client.config.ts`  | Client-side error monitoring (privacy-first, no PII)                           |
+| `sentry.server.config.ts`  | Server-side error monitoring                                                   |
+| `src/content.config.ts`    | Astro content collection for regulatory-map data                               |
+| `mcp-server/wrangler.toml` | Cloudflare Worker config (staging + production environments)                   |
+| `eslint.config.mjs`        | ESLint flat config with typescript-eslint and astro plugin                     |
+| `.prettierrc.json`         | Code formatting (single quotes, 100 char width, trailing commas)               |
+| `.stylelintrc.json`        | CSS linting with .astro scoped style support                                   |
+| `vitest.config.ts`         | Website unit/integration test config, path aliases, coverage thresholds        |
+| `playwright.config.ts`     | E2E test config (Chromium, Firefox, WebKit)                                    |
+| `.husky/pre-commit`        | Pre-commit hook: lint-staged runs ESLint, stylelint, Prettier                  |
+| `package.json`             | Scripts, workspaces, browserslist (LightningCSS targets), lint-staged config   |
 
 ## Design System
 
-Desktop-first responsive design with tech brutalist aesthetic. Dark mode via `html.dark-theme` class. 6 alternative color palettes via `html.palette-N` classes.
+Desktop-first responsive design with tech brutalist aesthetic. Dark mode via `html.dark-theme` class; alternative color palettes via `html.palette-N` classes.
 
 - **Tokens**: `src/styles/variables.css` (colors, spacing, typography, transitions, z-index)
 - **Conventions**: [src/docs/styles/STYLES_GUIDE.md](src/docs/styles/STYLES_GUIDE.md)
@@ -112,25 +107,28 @@ Desktop-first responsive design with tech brutalist aesthetic. Dark mode via `ht
 
 ## Documentation
 
-All project documentation lives in `src/docs/` with a master index:
+Website documentation lives in `src/docs/` with a master index; the MCP server maintains its own doc tree.
 
-**[src/docs/README.md](src/docs/README.md)** — start here for any documentation need.
+**[src/docs/README.md](src/docs/README.md)** — start here for any website-side documentation need.
+**[mcp-server/src/docs/README.md](mcp-server/src/docs/README.md)** — the MCP server docs home (architecture, tools, resources, prompts, operations).
 
-| Directory      | Content                                   |
-| -------------- | ----------------------------------------- |
-| `analytics/`   | GA4 integration, event tracking           |
-| `development/` | Roadmap, tooling, initiatives             |
-| `hub/`         | Hub tool technical docs                   |
-| `security/`    | Headers, CSP, privacy, compliance         |
-| `seo/`         | SEO implementation, JSON-LD, credentials  |
-| `styles/`      | CSS conventions, tokens, brand guidelines |
-| `testing/`     | Test strategy, CI/CD, troubleshooting     |
+| Directory      | Content                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| `adr/`         | Architecture Decision Records (distilled from closed initiatives) |
+| `analytics/`   | GA4 integration, event tracking                                   |
+| `development/` | Roadmap (BACKLOG.md), tooling, runbooks                           |
+| `hub/`         | Hub tool technical docs                                           |
+| `operations/`  | Secrets inventory                                                 |
+| `security/`    | Headers, CSP, privacy, compliance                                 |
+| `seo/`         | SEO implementation, JSON-LD, credentials                          |
+| `styles/`      | CSS conventions, tokens, brand guidelines                         |
+| `testing/`     | Test strategy, CI/CD, troubleshooting                             |
 
 ## Data Management
 
 ### Portfolio Data
 
-57 projects in `src/data/ma-portfolio/projects.json`, validated by Zod schemas at build time and by unit tests in CI.
+Portfolio engagements live in `src/data/ma-portfolio/projects.json`, validated by Zod schemas at build time and by unit tests in CI. **Prepend** new entries — the UI renders in file order.
 
 ```bash
 # Edit projects.json, then validate
@@ -139,28 +137,23 @@ npm run test:run
 
 ### Regulatory Map
 
-120 regulations in `src/data/regulatory-map/`, loaded via Astro content collections with Zod schema validation.
+Per-regulation JSON files in `src/data/regulatory-map/`, loaded via Astro content collections with Zod schema validation (and served as MCP Resources by the server).
 
 ## CI/CD
 
-Three-job parallel-then-gate pipeline in `.github/workflows/test.yml`:
+Website pipeline (`.github/workflows/test.yml`) is a parallel-then-gate design; the MCP server suite runs in its own workflow (`test-mcp-server.yml`) in parallel:
 
 ```
-Lint & Type Check (~1 min)  ──┐
-                               ├──> E2E Tests + axe (~17 min)
-Unit & Integration (~15s)   ──┘
+Lint & Type Check  ──┐
+                      ├──> E2E Tests + axe
+Unit & Integration ──┘        (docs-integrity + MCP suite run in parallel workflows)
 ```
 
-- Docs-only changes skip expensive jobs (via `dorny/paths-filter`)
+- Docs-only changes skip the expensive website jobs (via `dorny/paths-filter`); the docs-integrity workflow always runs
 - Pre-commit hooks enforce formatting locally
-- Branch protection requires all three jobs to pass
+- Branch protection requires: **E2E Tests (Playwright)**, **Unit & Integration Tests**, **Lint & Type Check**, **Verify doc links**
 
 ## Deployment
 
-Vercel auto-deploys on push to `master`. Preview deploys for PRs.
-
-- **Build**: `npm run build`
-- **Output**: `dist/`
-- **SSR**: Radar page uses ISR (Incremental Static Regeneration)
-- **Security headers**: Applied to all routes via `vercel.json` + `src/middleware.ts`
-- **Environment variables**: `PUBLIC_SENTRY_DSN` (client), `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` (build-time source maps)
+- **Website**: Vercel auto-deploys on push to `master`; preview deploys for PRs. Build `npm run build`, output `dist/`. Radar page uses ISR. Security headers via `vercel.json` + `src/middleware.ts`. Env vars: `PUBLIC_SENTRY_DSN` (client), `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` (build-time source maps)
+- **MCP Worker**: fully CI/CD — staging auto-deploys on a green MCP test run; production deploys gated by the `mcp-production` GitHub Environment approval; manual rollback workflow. See [mcp-server/src/docs/operations/DEPLOY.md](mcp-server/src/docs/operations/DEPLOY.md)


### PR DESCRIPTION
> **Stacked on #336** (`feat/restore-radar-seed`) — GitHub will auto-retarget this PR to `master` when #336 merges; the diff here shows only the README truth-pass commits.

## Why

The root `README.md` — the repo's shop window — carried the same rot class the CLAUDE.md audit found: **Astro "6.x"** (actual `^7.0.7`), "57 validated projects" (65+), "120 regulation JSON files" (123), "5 interactive hub tools" (6), "23 routes" (25), stale component counts, a docs table missing `adr/` and `operations/`, a CI section claiming **three** required checks (four since BL-089), and — most significantly — **zero mention of the `mcp-server` workspace anywhere**.

## What

- **Two-workspace framing throughout**: title, intro, Architecture, structure tree (`mcp-server/` first-class), commands (`test:mcp`, `test:docs`, `setup:claude-hooks`), config table (`wrangler.toml`), Documentation section (MCP docs home linked), Deployment (Worker CI/CD pipeline).
- **Brittle counts eliminated** — countless phrasing throughout (the #1 rot source identified by the CLAUDE.md audit); every claim that remains was fact-checked against the repo by the reviewer, including verifying the required-checks list against the live GitHub ruleset.
- Docs table gains `adr/` + `operations/`; portfolio **prepend** rule surfaced; CI section shows the real four required checks and the parallel MCP/docs-integrity workflows.
- **Sibling rot found by the reviewer, fixed in-pass**: `docs-integrity.yml`'s header still said "Verify doc links … is not required by default" — it has been a required check since 2026-07-19 (verified against the ruleset's `updated_at`).

## Review-gate provenance

code-reviewer APPROVE twice (initial + suggestion-folds). Bonus: the push gate rejected the reviewer's own first marker for carrying a rounded, slightly-future timestamp — the fail-closed clock-skew guard working as designed; the marker was rewritten with a genuine clock read.

## Verification

`test:docs` 11/11 (README is a scan source of the link guard) · lint clean · every listed command exists in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
