### PR TITLE
chore(claude): marker-writing discipline for reviewer agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -52,3 +52,8 @@ After delivering your review, record the reviewed state and write `.claude/tasks
 ```
 
 Verdict `APPROVE` only when there are no unresolved critical issues. The push gate compares `headSha` to the current HEAD — if commits are added after your review, the gate forces a re-review, so review the final commit state. Never write verdict `USER_WAIVED` — that is reserved for the main agent recording an explicit user waiver (with the quoted waiver in a `waiver` field).
+
+**Marker-writing discipline** (both learned from live gate rejections):
+
+- `reviewedAt` must be a **real clock read** — write the marker via a node one-liner that embeds `new Date().toISOString()`. Never estimate or round a timestamp: the gate fails closed on future timestamps (clock-skew guard).
+- After writing, **round-trip the file through `JSON.parse`** to prove it's valid — the gate fails closed on malformed JSON. Avoid raw regex/backslash snippets inside the findings strings (invalid JSON escapes); paraphrase in prose instead.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -55,6 +55,11 @@ After delivering your findings, write `.claude/tasks/plan-review.json` (repo-rel
 
 Compute the hash from the file you actually reviewed (e.g. `node -e` with `crypto.createHash('sha256')`, or PowerShell `Get-FileHash`). The gate compares this hash against the plan file's current content: if the plan is edited after your review, the gate forces a re-review — so review the FINAL text, and if the main agent revises the plan in response to your findings, it must send the revised plan back to you.
 
+**Marker-writing discipline** (both learned from live gate rejections):
+
+- `reviewedAt` must be a **real clock read** — write the marker via a node one-liner that embeds `new Date().toISOString()`. Never estimate or round a timestamp: the gate fails closed on future timestamps (clock-skew guard).
+- After writing, **round-trip the file through `JSON.parse`** to prove it's valid — the gate fails closed on malformed JSON. Avoid raw regex/backslash snippets inside the findings strings (invalid JSON escapes); paraphrase in prose instead.
+
 Never write a marker with verdict `USER_WAIVED` — that verdict is reserved for the main agent recording an explicit user waiver, and it must quote the user's waiver in a `waiver` field.
 
 Your final response should contain the full findings report (the marker is machinery; the findings are the deliverable).


### PR DESCRIPTION
## Why

Two live gate rejections during the review gates' first week exposed marker-writing failure modes in the reviewer agents themselves: one reviewer wrote **invalid JSON** (raw regex escapes inside a findings string), another **estimated a rounded `reviewedAt`** that landed in the future and tripped the clock-skew guard. Both gates failed closed exactly as designed — but each cost a correction round trip.

## What

Identical +5-line **Marker-writing discipline** block added to both `.claude/agents/plan-reviewer.md` and `.claude/agents/code-reviewer.md`:

1. `reviewedAt` must be a **real clock read** (node-embedded `new Date().toISOString()`) — never estimated or rounded; the gate fails closed on future timestamps.
2. The written marker must **round-trip through `JSON.parse`** before the review counts as delivered; avoid raw regex/backslash snippets in findings strings.

Both fail-closed claims verified against the actual hook code by the reviewing agent — which also followed the new protocol it was reviewing (real clock read + JSON.parse validation on its own marker).

## Verification

- code-reviewer APPROVE (zero critical/warnings) at `bfdc3c8e`; push gate passed on the SHA-bound marker.
- Docs-only agent-definition change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)