### PR TITLE
chore(observability): Verify-AeEmission -Detailed inoreader_call breakdown + docs

### DIFF
--- a/mcp-server/observability/runbooks/inoreader-budget-exhausted.md
+++ b/mcp-server/observability/runbooks/inoreader-budget-exhausted.md
@@ -1,6 +1,6 @@
 # Runbook — `inoreader-budget-exhausted`
 
-lastReviewedAt: 2026-07-14
+lastReviewedAt: 2026-07-25
 
 **Trigger**: today's Zone-1 Inoreader spend ≥ 70% (ticket) / ≥ 90% (page) of the 100/day hard cap (`ZONE1_DAILY_HARD_CAP`, `src/lib/inoreader-egress.ts`). Threshold provenance: `observability/slo-baselines.md` § Proposed SLO targets (signed off 2026-07-14 — baseline utilization is ~14%, so any firing is a real anomaly, not noise).
 
@@ -11,7 +11,7 @@ lastReviewedAt: 2026-07-14
 1. Open `https://mcp.globalstrategic.tech/status` — the budget row shows spend/cap and the per-category picture is on `/health` (`inoreaderSpend.byCategory`).
 2. Identify the burning category:
    - `cron-radar` high → cron runaway (should be ~4 calls per 6h firing; check for repeated firings in `wrangler tail` / Cloudflare cron dashboard).
-   - `live-radar` / `http-radar-snapshot` high → a client (or the website SSR) is hammering the radar surface — check per-key AE traffic (`Verify-AeEmission.ps1 -Env production -WindowHours 6`).
+   - `live-radar` / `http-radar-snapshot` high → a client (or the website SSR) is hammering the radar surface — check per-key AE traffic (`Verify-AeEmission.ps1 -Env production -WindowHours 6`; add `-Detailed` for the per-status-code / Zone-1 breakdown of the `inoreader_call` egress — which calls are burning budget and with what outcomes).
    - `401-retry` high → auth churn; see `oauth-refresh-failure-rate` runbook.
 3. Check the Sentry issue's `extra` for the observed totals at evaluation time.
 

--- a/mcp-server/scripts/Verify-AeEmission.ps1
+++ b/mcp-server/scripts/Verify-AeEmission.ps1
@@ -21,6 +21,13 @@
 .PARAMETER WindowHours
     Lookback window in hours. Defaults to 24.
 
+.PARAMETER Detailed
+    Additionally print an `inoreader_call` breakdown grouped by
+    (name, outcome, status_code, zone1) — the blob2/blob4/blob6/blob7
+    columns. Use when characterizing Inoreader-egress anomalies (which
+    calls, what outcomes/status codes, Zone-1 vs not); referenced from the
+    `inoreader-budget-exhausted` runbook.
+
 .EXAMPLE
     PS> $env:CF_AE_TOKEN = '<token>'
     PS> $env:CLOUDFLARE_ACCOUNT_ID = '<account id>'
@@ -28,6 +35,10 @@
 
 .EXAMPLE
     PS> .\scripts\Verify-AeEmission.ps1 -Env production -WindowHours 6
+
+.EXAMPLE
+    # Per-status/Zone-1 breakdown of the Inoreader egress (budget triage)
+    PS> .\scripts\Verify-AeEmission.ps1 -Env production -WindowHours 6 -Detailed
 
 .NOTES
     Requires `$env:CF_AE_TOKEN` (Account | Account Analytics | Read) and
@@ -41,7 +52,12 @@ param(
     [string]$Env = 'both',
 
     [ValidateRange(1, 168)]
-    [int]$WindowHours = 24
+    [int]$WindowHours = 24,
+
+    # When set, additionally print an inoreader_call breakdown grouped by
+    # (name, outcome, status_code, zone1) — useful for Phase 1 Step 6
+    # post-deploy verification of the blob6/blob7 emission.
+    [switch]$Detailed
 )
 
 $ErrorActionPreference = 'Stop'
@@ -102,4 +118,29 @@ FORMAT JSON
     $response.data |
         Select-Object event_type, name, outcome, @{Name='n'; Expression={[int]$_.n}} |
         Format-Table -AutoSize
+
+    if ($Detailed) {
+        Write-Host "  --- inoreader_call detail (name, outcome, status_code, zone1) ---" -ForegroundColor DarkCyan
+        $detailSql = @"
+SELECT blob2 AS name, blob4 AS outcome, blob6 AS status_code, blob7 AS zone1, count() AS n
+FROM $dataset
+WHERE blob1 = 'inoreader_call' AND timestamp > NOW() - INTERVAL '$WindowHours' HOUR
+GROUP BY blob2, blob4, blob6, blob7
+ORDER BY n DESC
+FORMAT JSON
+"@
+        try {
+            $detail = Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -Body $detailSql
+        } catch {
+            Write-Host "  Detail query failed: $_" -ForegroundColor Red
+            continue
+        }
+        if (-not $detail.data -or $detail.data.Count -eq 0) {
+            Write-Host "  (no inoreader_call rows in window)" -ForegroundColor Yellow
+        } else {
+            $detail.data |
+                Select-Object name, outcome, status_code, zone1, @{Name='n'; Expression={[int]$_.n}} |
+                Format-Table -AutoSize
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `-Detailed` switch to `mcp-server/scripts/Verify-AeEmission.ps1` (the read-only Analytics Engine emission-verification diagnostic) and — the point of the PR — **documents it so it's discoverable** rather than an invisible checked-in flag.

`-Detailed` prints a per-env `inoreader_call` breakdown grouped by `(name, outcome, status_code, zone1)` (the `blob2`/`blob4`/`blob6`/`blob7` columns), for characterizing Inoreader-egress anomalies during budget triage: *which* calls are burning Zone-1 budget and with *what* outcomes/status codes.

## Discoverability (why this isn't just a code comment)

- **Comment-based help**: adds `.PARAMETER Detailed` + a `.EXAMPLE`, so `Get-Help Verify-AeEmission.ps1` surfaces it.
- **Runbook**: the `inoreader-budget-exhausted` runbook — the natural point of use — now points at `-Detailed` in its egress-triage step (`lastReviewedAt` bumped 2026-07-14 → 2026-07-25).

## Verification

- PowerShell `Parser::ParseFile` → 0 errors.
- `npm run test:docs` → 11/11 (runbook links/anchors intact).
- Code-reviewer APPROVE — AE column mapping cross-checked against `src/metrics/_schema.ts` (matches the corrected `blob2/4/6/7` mapping, not the historical `blob3/5` bug); PowerShell scope/guards/secret-safety confirmed.

Read-only script; no behavior change without the flag. Two files, one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
