### PR TITLE
feat(mcp-rate-limit): BL-033 Slice 5 — per-client rate-limiting tiers, RateLimit-Policy, 80% soft-limit notification

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gst/mcp-server",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Local stdio MCP server exposing the GST Hub surface (diligence, portfolio, ICG, TechPar, Tech Debt, Regulations, Radar) and Library + Regulation + Radar Resources.",
   "type": "module",
   "private": true,

--- a/mcp-server/src/admin/oauth-clients.ts
+++ b/mcp-server/src/admin/oauth-clients.ts
@@ -37,6 +37,7 @@ import {
   listM2mClients,
   type M2mJwk,
 } from '../oauth/m2m-clients';
+import { ASSIGNABLE_TIERS, isAssignableTier } from '../ratelimit/tiers';
 import type { Env } from '../worker';
 
 type EnvWithHelpers = Env & { OAUTH_PROVIDER: OAuthHelpers };
@@ -189,6 +190,19 @@ export async function handleAdminM2mClients(request: Request, env: Env): Promise
       if (!body.name || !Array.isArray(body.allowedScopes) || body.allowedScopes.length === 0) {
         return json(
           { error: 'bad-request', message: 'name and non-empty allowedScopes[] required' },
+          400
+        );
+      }
+      // BL-033 Slice 5: reject a mistyped tier up front. Without this a typo
+      // resolves fail-generous to `internal` (60/1000) — LOOSER than
+      // `free-pilot` — silently defeating abuse containment. Omitting `tier`
+      // is fine; it defaults to `free-pilot` in `createM2mClient`.
+      if (body.tier !== undefined && !isAssignableTier(body.tier)) {
+        return json(
+          {
+            error: 'bad-request',
+            message: `tier must be one of ${ASSIGNABLE_TIERS.join(', ')} (or omitted → free-pilot)`,
+          },
           400
         );
       }

--- a/mcp-server/src/auth/bearer.ts
+++ b/mcp-server/src/auth/bearer.ts
@@ -39,6 +39,16 @@ export interface AuthSuccess {
    * Handlers gate access via `assertScope(auth.scopes, required)`.
    */
   readonly scopes: readonly string[];
+  /**
+   * BL-033 Slice 5 — the client's rate-limit tier, carried on the M2M
+   * token claim and resolved to per-client ceilings via
+   * `resolveTierLimits(auth.tier)` at the request boundary. **Left unset**
+   * for static `MCP_KEY_*` keys and the OAuth human-consent path — both
+   * are internal-team identities that resolve to the generous `internal`
+   * tier (the pre-Slice-5 default), so omitting it is the no-regression
+   * behavior, not a gap.
+   */
+  readonly tier?: string;
 }
 
 /**

--- a/mcp-server/src/docs/ARCHITECTURE.md
+++ b/mcp-server/src/docs/ARCHITECTURE.md
@@ -116,16 +116,18 @@ The Worker does **not** inherit the website's Content-Security-Policy (the `verc
 
 ## Rate limiting & Inoreader budget
 
-Deep rationale for the numbers below is deferred to a future ADR; this section records what ships and where.
+Rationale for the tier design + the soft-limit transport: [ADR-0010](../../../src/docs/adr/0010-per-client-rate-limit-tiers.md). This section records what ships and where.
 
-### Per-key sliding windows (Q7)
+### Per-key sliding windows (Q7), tier-aware (BL-033 Slice 5)
 
 `src/ratelimit/limiter.ts` uses `@upstash/ratelimit` (`Ratelimit.slidingWindow`, per Q7's "use the library" resolution) against the MCP Upstash DB, keyed by `keyOwner` under the `mcp:ratelimit:*` prefix. Two tool classes:
 
-- **general** — 60/min + 1000/day, checked on every authenticated request
-- **radar** (`search_radar`, `get_latest_insights`; BL-038) — an _additional_ 5/min + 50/day pair, checked on top of the general buckets (additive — radar calls consume from all four)
+- **general** — checked on every authenticated request
+- **radar** (`search_radar`, `get_latest_insights`; BL-038) — an _additional_ pair, checked on top of the general buckets (additive — radar calls consume from all four)
 
-The binding tier (whichever bucket exhausted, or has fewest remaining) drives the 429 envelope's `RateLimit-*` / `Retry-After` headers (`src/ratelimit/headers.ts`), so agents can distinguish "slow my radar polling" from "slow everything." When Upstash credentials aren't bound, the limiter fails open with a `ratelimit.skipped` warning — local `wrangler dev` works without setup; production must have credentials wired. Contract details: [`operations/RATE_LIMITS.md`](operations/RATE_LIMITS.md).
+The four ceilings are **per-client tier-aware** (`src/ratelimit/tiers.ts`, `resolveTierLimits(auth.tier)` → `createLimiter(env, limits)`). The tier (`free-pilot`/`paid`/`enterprise`) is carried on the M2M token claim — not re-fetched from KV — so the limiter reads it locally with no eventual-consistency hazard (the ADR-0008 corollary; ADR-0010 §1). Static `MCP_KEY_*` keys and OAuth human-consent carry no tier → the generous `internal` tier (= the pre-Slice-5 60/1000/5/50, so no regression).
+
+The binding tier (whichever bucket exhausted, or has fewest remaining) drives the 429 envelope's `RateLimit-*` / `Retry-After` headers (`src/ratelimit/headers.ts`); every authenticated response (200 and 429) also carries **`RateLimit-Policy`** advertising the tier ceilings. When any bucket is ≥80% consumed (`CheckResult.minRemainingRatio`), the tool-metrics wrapper (`src/metrics/with-metrics.ts`) emits a best-effort **`notifications/message`** soft-limit warning on the request's SSE stream — which requires the server to declare the `logging` capability (`src/server.ts`); the always-present headers are the guaranteed fallback (ADR-0010 §2). When Upstash credentials aren't bound, the limiter fails open with a `ratelimit.skipped` warning — local `wrangler dev` works without setup; production must have credentials wired. Contract details: [`operations/RATE_LIMITS.md`](operations/RATE_LIMITS.md).
 
 ### Inoreader budget
 

--- a/mcp-server/src/docs/operations/DEPLOY.md
+++ b/mcp-server/src/docs/operations/DEPLOY.md
@@ -12,7 +12,7 @@
 >
 > - [`AUTH.md`](./AUTH.md) — bearer-token model, key issuance/rotation/revocation commands
 > - [`REMOTE_CLIENT_SETUP.md`](./REMOTE_CLIENT_SETUP.md) — what team-members do to connect their Claude / Cursor / etc. clients
-> - [`RATE_LIMITS.md`](./RATE_LIMITS.md) — per-key budgets, RFC 9331 headers, circuit-breaker semantics
+> - [`RATE_LIMITS.md`](./RATE_LIMITS.md) — per-key budgets, RateLimit response headers, circuit-breaker semantics
 > - [`SENTRY_MANUAL_SETUP.md` § MCP Worker](../../../../src/docs/development/SENTRY_MANUAL_SETUP.md) — Sentry project setup specifics
 > - [`ARCHITECTURE.md`](../ARCHITECTURE.md) — the maintained architecture reference (Q1–Q13 initiative history archived at `src/docs/development/_archive/MCP_SERVER_REMOTE_BL-032.md`)
 

--- a/mcp-server/src/docs/operations/RATE_LIMITS.md
+++ b/mcp-server/src/docs/operations/RATE_LIMITS.md
@@ -40,7 +40,7 @@ An external pilot's tier is set on its M2M client record (`tier`: `free-pilot` /
 
 ---
 
-## Response headers (RFC 9331)
+## Response headers (IETF RateLimit fields)
 
 Every authenticated response (200 OR 429) carries:
 

--- a/mcp-server/src/docs/operations/RATE_LIMITS.md
+++ b/mcp-server/src/docs/operations/RATE_LIMITS.md
@@ -1,16 +1,18 @@
 # MCP Server Rate Limits
 
-> **Audience**: team-member consumers + operators. Consumers want to know "what budgets do I have, what do response headers tell me, what do I do when rate-limited?" Operators additionally want "how do I tune the limits, where's the Upstash quota envelope, when does the circuit-breaker open?"
+> **Audience**: team-member + external-pilot consumers, and operators. Consumers want to know "what budgets do I have, what do response headers tell me, what do I do when rate-limited?" Operators additionally want "how do I tune the limits, where's the Upstash quota envelope, when does the circuit-breaker open?"
 >
-> **Status**: BL-032 Phase 3 — substrate in place; full enforcement validated in Phase 6 against staging Upstash.
+> **Status**: BL-032 Phase 3 substrate + BL-038 radar tier + **BL-033 Slice 5 per-client tiers** (2026-07-26). Full sliding-window enforcement is validated against staging Upstash (not CI — no live Redis in unit runs).
 >
-> **Architecture & rationale**: [`ARCHITECTURE.md` § Rate limiting & Inoreader budget](../ARCHITECTURE.md#rate-limiting--inoreader-budget).
+> **Architecture & rationale**: [`ARCHITECTURE.md` § Rate limiting & Inoreader budget](../ARCHITECTURE.md#rate-limiting--inoreader-budget) · [ADR-0010](../../../../src/docs/adr/0010-per-client-rate-limit-tiers.md) (tier design + soft-limit transport).
 
 ---
 
 ## Per-key budgets
 
-Every authenticated request consumes one token from the budgets below. Buckets are **per `keyOwner`** (see [`AUTH.md`](./AUTH.md) — your `MCP_KEY_<INITIALS>` suffix is the bucket identifier). Two team members hammering tools at the same time get independent budgets; one team member can't deny service to another.
+Every authenticated request consumes one token from the budgets below. Buckets are **per `keyOwner`** (see [`AUTH.md`](./AUTH.md) — your `MCP_KEY_<INITIALS>` suffix, or an M2M client's `M2M:<NAME>`, is the bucket identifier). Two callers hammering tools at the same time get independent budgets; one can't deny service to another.
+
+The ceilings depend on the caller's **tier** (below). The table shows the **`internal`** tier — the budget for team `MCP_KEY_*` keys and OAuth human-consent sessions, unchanged since BL-032/BL-038:
 
 | Tool family       | Per-minute (sliding) | Per-day (sliding) | Status                           |
 | ----------------- | -------------------- | ----------------- | -------------------------------- |
@@ -19,7 +21,22 @@ Every authenticated request consumes one token from the budgets below. Buckets a
 
 **Sliding window** (vs. fixed-bucket): the budget rolls continuously — the 60th request in the past 60 seconds tips you over, regardless of when the prior 59 happened. No "burst at the top of every minute" exploit.
 
-**Why two tiers?** The website's Inoreader account has a 200 req/day budget. The website ISR consumes ~28/day; BL-032.5's Cron-driven snapshot refresh will consume ~24/day. That leaves ~150/day for MCP — split across however many team members use radar tools. The 50/day per-key cap means up to 3 active analysts can run radar tools without anyone hitting the budget alone.
+### Per-client tiers (BL-033 Slice 5)
+
+An external pilot's tier is set on its M2M client record (`tier`: `free-pilot` / `paid` / `enterprise`) and carried in the access-token claim, so the limiter reads it locally with no KV round-trip (see [ADR-0010](../../../../src/docs/adr/0010-per-client-rate-limit-tiers.md)). Callers with no tier — static `MCP_KEY_*` keys, OAuth human-consent — resolve to `internal`.
+
+| Tier         | General /min | General /day | Radar /min | Radar /day |
+| ------------ | ------------ | ------------ | ---------- | ---------- |
+| `free-pilot` | 30           | 300          | 3          | 20         |
+| `paid`       | 60           | 2000         | 5          | 50         |
+| `enterprise` | 120          | 10000        | 10         | 150        |
+| `internal`   | 60           | 1000         | 5          | 50         |
+
+> **These are tunable, non-contractual capability ceilings — NOT ratified SLA quotas.** They are abuse/capacity limits. `free-pilot` is deliberately tighter than `internal` (abuse containment for an unvetted pilot), not a promised allowance. No pilot rate SLA is contractually committed.
+
+**Changing a tier** takes effect on the next window evaluation — the limiter reuses the same per-`keyOwner` Redis keys, so there's no migration; the new ceiling simply applies going forward (a client mid-window keeps whatever tokens it already consumed).
+
+**Why a separate radar cap?** Radar tool calls are ~99% Upstash cache hits — **zero** Inoreader spend. Only a cold/expired-cache miss falls through to a live Inoreader fetch, and the global **circuit breaker** (below) is the real guard on the shared ~150/day Inoreader headroom. The per-client radar caps are therefore **per-client fairness + thin cache-cold defense-in-depth**, not the upstream-budget control. (Website ISR ~28/day + the Cron snapshot refresh ~24/day are the steady Inoreader consumers; see [ADR-0006](../../../../src/docs/adr/0006-inoreader-zone1-budget-protection.md).)
 
 ---
 
@@ -27,11 +44,12 @@ Every authenticated request consumes one token from the budgets below. Buckets a
 
 Every authenticated response (200 OR 429) carries:
 
-| Header                | Meaning                                                                      |
-| --------------------- | ---------------------------------------------------------------------------- |
-| `RateLimit-Limit`     | Maximum requests in the active window (60 for general, 1000 for daily, etc.) |
-| `RateLimit-Remaining` | Requests left in the active window                                           |
-| `RateLimit-Reset`     | Seconds until the active window resets                                       |
+| Header                | Meaning                                                                                                                                                                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RateLimit-Limit`     | Maximum requests in the active window (the binding bucket's limit)                                                                                                                                                                                   |
+| `RateLimit-Remaining` | Requests left in the active window                                                                                                                                                                                                                   |
+| `RateLimit-Reset`     | Seconds until the active window resets                                                                                                                                                                                                               |
+| `RateLimit-Policy`    | The caller's tier ceilings, quoted-policy form — e.g. `"general-min";q=30;w=60, "general-day";q=300;w=86400` (radar calls append the `radar-min`/`radar-day` members). Lets client engineers self-diagnose their budget without hitting a 429 first. |
 
 429 responses additionally carry:
 
@@ -56,6 +74,29 @@ The 429 response body adds a structured JSON envelope:
 
 The `tier` field tells you which bucket triggered. With BL-038's radar-tier activation it can now be one of `"minute"`, `"day"`, `"radar-minute"`, or `"radar-day"`. The `reason` field carries a stable string designed for agent-side classification — values are `rate-limit-per-minute`, `rate-limit-per-day`, `radar-rate-limit-per-minute`, `radar-rate-limit-per-day`. Use `reason` to distinguish "slow my radar polling specifically" (`radar-rate-limit-*`) from "slow everything" (the general `rate-limit-*`). For a per-day cap hit, `retryAfterSeconds` can be many hours — sleep until tomorrow.
 
+### Soft-limit warning at 80% (BL-033 Slice 5)
+
+Before the hard 429, when any bucket is ≥80% consumed the server emits an MCP `notifications/message` (level `warning`, logger `ratelimit`) on the request's stream so an agent can throttle itself proactively:
+
+```json
+{
+  "method": "notifications/message",
+  "params": {
+    "level": "warning",
+    "logger": "ratelimit",
+    "data": {
+      "message": "Approaching rate limit …",
+      "tier": "day",
+      "limit": 300,
+      "remaining": 45,
+      "resetSeconds": 51200
+    }
+  }
+}
+```
+
+This is **best-effort**: it's delivered on the streamable-HTTP SSE response, so a client that only reads the terminal result frame won't see it. That's fine — the `RateLimit-Remaining` / `RateLimit-Policy` **headers on every response are the guaranteed signal**; the notification is a convenience for clients that consume interim frames. A failure to deliver it never affects the tool call.
+
 ---
 
 ## Circuit breaker (radar-tool-only protection)
@@ -69,7 +110,7 @@ Independent of the per-key rate limit, the radar tools share a **global circuit 
 
 **Why 6 hours?** Inoreader's daily budget resets on a rolling 24h window; 6h is a conservative back-off that avoids burning the next day's budget by retrying too aggressively. It also matches the website's ISR cache window — both surfaces converge on the same "stop hammering Inoreader" semantics.
 
-**Phase 3 status**: the read-side check + 503 envelope is wired (every request inspects the breaker before it can hit a radar tool). The write-side trigger (Inoreader 429 → set the flag) lands in Phase 4 when radar tools come online.
+**Status**: both sides are wired. The read-side check + 503 envelope run before any radar tool can hit Inoreader, and the **write-side trigger is live in the radar tool path** — a live-fetch Inoreader 429 routes through `handleInoreaderFailure` → `openCircuit` (from both the tool-call path and the refresh cron). (An earlier revision of this doc said the write-side "lands in Phase 4"; that's stale — it shipped with the radar-live tools.)
 
 503 response body:
 
@@ -107,16 +148,20 @@ Independent of the per-key rate limit, the radar tools share a **global circuit 
 
 ### Tuning the limits
 
-Per-key budgets live in [`mcp-server/src/ratelimit/limiter.ts`](../../ratelimit/limiter.ts) as named constants:
+Per-tier ceilings live in [`mcp-server/src/ratelimit/tiers.ts`](../../ratelimit/tiers.ts) as the `TIER_LIMITS` map (plus `INTERNAL_TIER`, the no-regression anchor consumed as `createLimiter`'s default):
 
 ```typescript
-const PERMINUTE_LIMIT = 60;
-const PERDAY_LIMIT = 1000;
+export const TIER_LIMITS: Record<string, TierLimits> = {
+  'free-pilot': { perMinute: 30, perDay: 300, radarPerMinute: 3, radarPerDay: 20 },
+  paid: { perMinute: 60, perDay: 2000, radarPerMinute: 5, radarPerDay: 50 },
+  enterprise: { perMinute: 120, perDay: 10000, radarPerMinute: 10, radarPerDay: 150 },
+  internal: INTERNAL_TIER, // 60 / 1000 / 5 / 50 — the pre-Slice-5 constants
+};
 ```
 
-To adjust: update the constants, redeploy. The change takes effect on the next isolate cold-start (or via `wrangler deploy --env <env>` to force fresh isolates).
+To adjust: update the map, redeploy. The change takes effect on the next isolate cold-start (or via `wrangler deploy --env <env>` to force fresh isolates). These are **tunable capability ceilings, not SLA quotas** — don't publish them as contractual commitments.
 
-**When to consider raising**: a team member doing legitimate analytical work hits 429s repeatedly. **When to consider lowering**: cost / abuse signals (Phase 5 observability dashboards will surface these).
+**When to consider raising**: a caller doing legitimate work hits 429s repeatedly. **When to consider lowering**: cost / abuse signals (observability dashboards surface these).
 
 ### Upstash quota envelope
 

--- a/mcp-server/src/docs/operations/REMOTE_CLIENT_SETUP.md
+++ b/mcp-server/src/docs/operations/REMOTE_CLIENT_SETUP.md
@@ -310,7 +310,7 @@ Expect Claude's opening sentence to explicitly name `search_portfolio` and `sear
 
 ## Rate-limit etiquette
 
-Full reference — per-key budget table, RFC 9331 response-header guide, circuit-breaker semantics, "what to do when 429'd" decision tree — lives in [`RATE_LIMITS.md`](./RATE_LIMITS.md). Skim it once during setup; it pays for itself the first time you see a 429.
+Full reference — per-key budget table, RateLimit response-header guide, circuit-breaker semantics, "what to do when 429'd" decision tree — lives in [`RATE_LIMITS.md`](./RATE_LIMITS.md). Skim it once during setup; it pays for itself the first time you see a 429.
 
 Quick-reference summary:
 

--- a/mcp-server/src/metrics/with-metrics.ts
+++ b/mcp-server/src/metrics/with-metrics.ts
@@ -88,6 +88,28 @@ export interface MetricsContext {
    * `AUDIT_QUEUE` binding is absent (→ no-op). Gated to tools this slice.
    */
   readonly audit?: AuditContext;
+  /**
+   * BL-033 Slice 5 — the boundary's rate-limit result for this request.
+   * When some bucket is ≥80% consumed (`minRemainingRatio <= 0.20`),
+   * `withMetricsCore` emits a best-effort `notifications/message` warning on
+   * the request's SSE stream so a compliant agent can throttle itself before
+   * the hard 429. Undefined for stdio / tests / graceful-skip (→ no warning).
+   * The always-present `RateLimit-*` headers are the guaranteed fallback.
+   */
+  readonly rateLimit?: RateLimitCheck;
+}
+
+/**
+ * Minimal shape of a rate-limit `CheckResult` this module needs for the
+ * soft-limit warning — mirrored locally to avoid importing the limiter
+ * (and its `@upstash/ratelimit` dependency) into the metrics module.
+ */
+export interface RateLimitCheck {
+  readonly tier: string;
+  readonly limit: number;
+  readonly remaining: number;
+  readonly resetAt: number;
+  readonly minRemainingRatio?: number;
 }
 
 /**
@@ -173,6 +195,69 @@ function detectCounterOutcome<TResult>(
   return 'success';
 }
 
+/** Minimal view of the MCP `RequestHandlerExtra` fields we use here. */
+interface McpNotifier {
+  sendNotification?: (notification: unknown) => unknown;
+}
+
+/**
+ * Locate the MCP `RequestHandlerExtra` among a tool handler's args — the
+ * object exposing `sendNotification`. `McpServer` invokes tool callbacks as
+ * `(args, extra)` for tools with an input schema and `(extra)` for zero-arg
+ * tools, so scan for the first arg carrying a `sendNotification` function
+ * rather than assuming a fixed position. Returns `undefined` when none is
+ * present (stdio, tests, or a transport without a notification channel).
+ */
+function findMcpExtra(args: readonly unknown[]): McpNotifier | undefined {
+  for (const a of args) {
+    if (a && typeof a === 'object' && typeof (a as McpNotifier).sendNotification === 'function') {
+      return a as McpNotifier;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * BL-033 Slice 5 — emit the 80%-consumed soft-limit warning, best-effort.
+ * When some rate-limit bucket is ≥80% spent (`minRemainingRatio <= 0.20`),
+ * write a `notifications/message` onto this request's SSE stream so a
+ * compliant agent can throttle itself before the hard 429. NEVER throws:
+ * a missing `logging` capability, a non-SSE client, or an aborted request is
+ * a visibility loss, not a tool-call failure. The always-present
+ * `RateLimit-*` headers are the guaranteed fallback for clients that don't
+ * consume interim notifications.
+ */
+function maybeWarnSoftLimit(rl: RateLimitCheck | undefined, args: readonly unknown[]): void {
+  if (!rl || rl.minRemainingRatio == null || rl.minRemainingRatio > 0.2) return;
+  const extra = findMcpExtra(args);
+  if (!extra?.sendNotification) return;
+  try {
+    const resetSeconds = Math.max(0, Math.ceil((rl.resetAt - Date.now()) / 1000));
+    void Promise.resolve(
+      extra.sendNotification({
+        method: 'notifications/message',
+        params: {
+          level: 'warning',
+          logger: 'ratelimit',
+          data: {
+            message:
+              `Approaching rate limit (tier ${rl.tier}): ${rl.remaining} of ` +
+              `${rl.limit} remaining in the active window, resets in ${resetSeconds}s.`,
+            tier: rl.tier,
+            limit: rl.limit,
+            remaining: rl.remaining,
+            resetSeconds,
+          },
+        },
+      })
+    ).catch(() => {
+      /* best-effort — notification delivery failure never breaks the call */
+    });
+  } catch {
+    /* best-effort — never break the tool call */
+  }
+}
+
 /**
  * Generic core. Wraps an async function; emits one event of the given type
  * with outcome derived from the result (or `error` on throw).
@@ -245,8 +330,12 @@ export function withMetricsCore<TArgs extends readonly unknown[], TResult>(
     // BL-071 — record `attempted` BEFORE inner runs so the envelope tool's
     // own snapshot includes its own in-flight attempt. Only meaningful for
     // tool_invocation; resource/prompt counters not in scope today.
+    // BL-033 Slice 5 — same gate emits the soft-limit warning at wrap entry
+    // (the ratio is already known from the boundary; deterministic, before
+    // any tool work).
     if (eventType === 'tool_invocation') {
       ctx.counters?.record(name, 'attempted');
+      maybeWarnSoftLimit(ctx.rateLimit, args);
     }
     try {
       const result = await inner(...args);

--- a/mcp-server/src/metrics/with-metrics.ts
+++ b/mcp-server/src/metrics/with-metrics.ts
@@ -110,6 +110,19 @@ export interface RateLimitCheck {
   readonly remaining: number;
   readonly resetAt: number;
   readonly minRemainingRatio?: number;
+  /**
+   * The bucket that owns `minRemainingRatio` (the proportional-closest to its
+   * cliff) — which may differ from the binding bucket named by the fields
+   * above. The soft-limit warning reports THIS bucket so the agent throttles
+   * the window that is actually under pressure. Falls back to the top-level
+   * fields when absent (fixtures / legacy callers).
+   */
+  readonly nearestLimit?: {
+    readonly tier: string;
+    readonly limit: number;
+    readonly remaining: number;
+    readonly resetAt: number;
+  };
 }
 
 /**
@@ -231,8 +244,13 @@ function maybeWarnSoftLimit(rl: RateLimitCheck | undefined, args: readonly unkno
   if (!rl || rl.minRemainingRatio == null || rl.minRemainingRatio > 0.2) return;
   const extra = findMcpExtra(args);
   if (!extra?.sendNotification) return;
+  // Report the bucket that TRIPPED the ratio (`nearestLimit`), not the binding
+  // bucket in the top-level fields — they can differ (binding = absolute-fewest;
+  // ratio = proportional-fewest), and the agent should throttle the window that
+  // is actually under pressure. Fall back to the top-level fields if absent.
+  const b = rl.nearestLimit ?? rl;
   try {
-    const resetSeconds = Math.max(0, Math.ceil((rl.resetAt - Date.now()) / 1000));
+    const resetSeconds = Math.max(0, Math.ceil((b.resetAt - Date.now()) / 1000));
     void Promise.resolve(
       extra.sendNotification({
         method: 'notifications/message',
@@ -241,11 +259,11 @@ function maybeWarnSoftLimit(rl: RateLimitCheck | undefined, args: readonly unkno
           logger: 'ratelimit',
           data: {
             message:
-              `Approaching rate limit (tier ${rl.tier}): ${rl.remaining} of ` +
-              `${rl.limit} remaining in the active window, resets in ${resetSeconds}s.`,
-            tier: rl.tier,
-            limit: rl.limit,
-            remaining: rl.remaining,
+              `Approaching rate limit (tier ${b.tier}): ${b.remaining} of ` +
+              `${b.limit} remaining in the active window, resets in ${resetSeconds}s.`,
+            tier: b.tier,
+            limit: b.limit,
+            remaining: b.remaining,
             resetSeconds,
           },
         },

--- a/mcp-server/src/oauth/m2m-token.ts
+++ b/mcp-server/src/oauth/m2m-token.ts
@@ -92,6 +92,17 @@ export interface M2mTokenClaims {
   exp: number;
   iat: number;
   jti: string;
+  /**
+   * BL-033 Slice 5 — the client's rate-limit tier, minted from
+   * `record.tier`. Travels IN the self-contained token (not re-fetched from
+   * the KV record on the hot path) precisely so the limiter never
+   * reintroduces the ~60s cross-colo eventual-consistency hazard the
+   * self-contained-JWT design eliminated (see the module docstring above +
+   * ADR-0008/ADR-0010). Optional on the type so a legacy ≤1h token minted
+   * before this shipped still verifies — its absent `tier` resolves to the
+   * generous `internal` tier and self-heals on the next re-exchange.
+   */
+  tier?: string;
 }
 
 /** Sign the self-contained M2M access token. Exported for unit tests. */
@@ -161,6 +172,7 @@ export async function verifyM2mToken(
     ok: true,
     keyOwner: claims.keyOwner,
     scopes: claims.scope.split(' ').filter(Boolean),
+    tier: claims.tier,
   };
 }
 
@@ -367,6 +379,7 @@ export async function handleClientCredentialsToken(request: Request, env: Env): 
       exp: now + M2M_TOKEN_TTL_S,
       iat: now,
       jti: crypto.randomUUID(),
+      tier: record.tier,
     },
     env.OAUTH_M2M_SIGNING_KEY
   );

--- a/mcp-server/src/observability/health.ts
+++ b/mcp-server/src/observability/health.ts
@@ -72,7 +72,7 @@ import type { Env } from '../worker';
 // deployed `/health` no longer drifts. This literal is used only when unbound
 // (wrangler dev / tests); keep it roughly current but it is no longer
 // load-bearing for prod/staging.
-const VERSION = '0.40.0';
+const VERSION = '0.41.0';
 
 /** Upstash key written by `radar-live-store.ts` (and refreshed every 6h by `cron/radar-refresh.ts`). */
 const RADAR_FYI_CACHE_KEY = 'mcp:radar:cache:fyi';

--- a/mcp-server/src/pipeline/handle-authenticated.ts
+++ b/mcp-server/src/pipeline/handle-authenticated.ts
@@ -22,7 +22,13 @@ import { withCors } from '../auth/cors';
 import { safeLog } from '../auth/safe-logger';
 import { hasScope } from '../auth/scopes';
 import { createLimiter } from '../ratelimit/limiter';
-import { reasonForTier, tooManyRequestsResponse, withRateLimitHeaders } from '../ratelimit/headers';
+import { resolveTierLimits } from '../ratelimit/tiers';
+import {
+  reasonForTier,
+  rateLimitPolicyHeader,
+  tooManyRequestsResponse,
+  withRateLimitHeaders,
+} from '../ratelimit/headers';
 import { extractToolName, toolClassFor } from '../dispatch/extract-tool-name';
 import { tagRequest } from '../observability/sentry';
 import { AnalyticsEngineSink } from '../metrics/_index';
@@ -54,7 +60,15 @@ export async function handleAuthenticated(
   // failures fail-safe to `'general'`.
   const toolName = await extractToolName(request);
   const toolClass = toolClassFor(toolName);
-  const limiter = createLimiter(env);
+  // BL-033 Slice 5: the client's tier (carried on the M2M token claim;
+  // undefined for static keys + OAuth human-consent) selects the four
+  // sliding-window ceilings. `RateLimit-Policy` advertises those ceilings
+  // on every authenticated response (200 and 429) — the transport-agnostic
+  // throttle signal, guaranteed even for clients that don't parse the SSE
+  // soft-limit notification.
+  const limits = resolveTierLimits(auth.tier);
+  const rlPolicy = rateLimitPolicyHeader(limits, toolClass);
+  const limiter = createLimiter(env, limits);
   let rlResult = null;
   if (limiter) {
     rlResult = await limiter.check(auth.keyOwner, toolClass);
@@ -68,7 +82,7 @@ export async function handleAuthenticated(
         success: false,
         errorCode: 'rate-limit',
       });
-      return withCors(tooManyRequestsResponse(rlResult), origin);
+      return withCors(tooManyRequestsResponse(rlResult, rlPolicy), origin);
     }
   } else {
     safeLog({
@@ -112,7 +126,7 @@ export async function handleAuthenticated(
         status: 403,
         headers: { 'Content-Type': 'application/json' },
       });
-      const withRl = rlResult ? withRateLimitHeaders(resp, rlResult) : resp;
+      const withRl = rlResult ? withRateLimitHeaders(resp, rlResult, rlPolicy) : resp;
       return withCors(withRl, origin);
     }
     // BL-032.75 Phase 0: tag this SSR endpoint's egress separately from
@@ -140,7 +154,7 @@ export async function handleAuthenticated(
       durationMs,
       success: true,
     });
-    const withRl = rlResult ? withRateLimitHeaders(resp, rlResult) : resp;
+    const withRl = rlResult ? withRateLimitHeaders(resp, rlResult, rlPolicy) : resp;
     return withCors(withRl, origin);
   }
 
@@ -190,6 +204,11 @@ export async function handleAuthenticated(
       metricsSink,
       keyOwner: auth.keyOwner,
       audit,
+      // BL-033 Slice 5: hand the boundary's already-computed rate-limit
+      // result to the tool wrapper so it can emit the 80%-consumed soft-limit
+      // notification WITHOUT a second Upstash round-trip. `null` (graceful
+      // skip) → undefined (the optional field), so no warning fires.
+      rateLimit: rlResult ?? undefined,
     })
   );
   const response = await mcp(request, env, ctx);
@@ -205,6 +224,6 @@ export async function handleAuthenticated(
     success: response.status < 400,
   });
 
-  const withRl = rlResult ? withRateLimitHeaders(response, rlResult) : response;
+  const withRl = rlResult ? withRateLimitHeaders(response, rlResult, rlPolicy) : response;
   return withCors(withRl, origin);
 }

--- a/mcp-server/src/ratelimit/headers.ts
+++ b/mcp-server/src/ratelimit/headers.ts
@@ -1,13 +1,19 @@
 /**
- * RFC 9331 RateLimit-* header builder + 429 response envelope (BL-032 Phase 3).
+ * RateLimit-* header builder + 429 response envelope (BL-032 Phase 3).
  *
- * RFC 9331 (the "RateLimit Header Fields for HTTP" RFC) standardizes:
+ * Implements the IETF "RateLimit header fields for HTTP" spec
+ * (draft-ietf-httpapi-ratelimit-headers), which standardizes:
  *   - RateLimit-Limit:     max requests in the active window
  *   - RateLimit-Remaining: requests left
  *   - RateLimit-Reset:     seconds until the active window resets
+ *   - RateLimit-Policy:    the quota policy in force (BL-033 Slice 5)
+ *
+ * (Earlier revisions of this file cited "RFC 9331" for these fields — that
+ * is wrong: RFC 9331 is L4S ECN. The RateLimit fields are the httpapi draft
+ * above; corrected 2026-07-26.)
  *
  * On 429 responses we additionally emit `Retry-After` (RFC 7231) — older
- * clients that don't read the RFC 9331 fields can still honor it. Both
+ * clients that don't read the RateLimit fields can still honor it. Both
  * headers carry the same value (seconds until reset).
  *
  * These are pure functions over a `CheckResult` from `./limiter.ts`. No
@@ -37,7 +43,7 @@ export function reasonForTier(tier: CheckResult['tier']): string {
 }
 
 /**
- * Build the RFC 9331 `RateLimit-Policy` header value describing the client's
+ * Build the `RateLimit-Policy` header value describing the client's
  * tier ceilings (BL-033 Slice 5). Unlike the `RateLimit-*` counters, this is
  * a static description of the *policy* — the windows that apply to this
  * request — so client engineers can self-diagnose which budget they're
@@ -63,7 +69,7 @@ export function rateLimitPolicyHeader(limits: TierLimits, toolClass: 'general' |
 }
 
 /**
- * Build RFC 9331 headers from a check result. Round-up to whole seconds —
+ * Build the RateLimit-* headers from a check result. Round-up to whole seconds —
  * the spec requires an integer; floor would tell clients to retry slightly
  * before the window actually resets.
  */
@@ -78,7 +84,7 @@ export function rateLimitHeaders(result: CheckResult): Record<string, string> {
 }
 
 /**
- * Build a 429 Response from a denied check result. Carries the RFC 9331
+ * Build a 429 Response from a denied check result. Carries the RateLimit-*
  * headers above plus `Retry-After` (RFC 7231) and a structured JSON body
  * naming the binding tier so clients can format a useful error message.
  */
@@ -108,7 +114,7 @@ export function tooManyRequestsResponse(result: CheckResult, policy?: string): R
 }
 
 /**
- * Add RFC 9331 headers to an already-constructed allowed response. Always
+ * Add the RateLimit-* headers to an already-constructed allowed response. Always
  * returns a new Response (Workers' Response.headers can be immutable). When
  * `policy` is supplied (BL-033 Slice 5), also emit `RateLimit-Policy` so the
  * tier ceilings ride on every authenticated 200, not just 429s.

--- a/mcp-server/src/ratelimit/headers.ts
+++ b/mcp-server/src/ratelimit/headers.ts
@@ -15,6 +15,7 @@
  */
 
 import type { CheckResult } from './limiter';
+import type { TierLimits } from './tiers';
 
 /**
  * Map the binding tier to a stable `reason` string for the 429 JSON body
@@ -33,6 +34,32 @@ export function reasonForTier(tier: CheckResult['tier']): string {
     case 'radar-day':
       return 'radar-rate-limit-per-day';
   }
+}
+
+/**
+ * Build the RFC 9331 `RateLimit-Policy` header value describing the client's
+ * tier ceilings (BL-033 Slice 5). Unlike the `RateLimit-*` counters, this is
+ * a static description of the *policy* — the windows that apply to this
+ * request — so client engineers can self-diagnose which budget they're
+ * pacing against without hitting a 429 first.
+ *
+ * Syntax (draft-ietf-httpapi-ratelimit-headers quoted-policy form): one
+ * comma-separated member per bucket, each `"<name>";q=<quota>;w=<window-s>`.
+ * A `general` call advertises the two general buckets; a `radar` call
+ * additionally advertises the stricter radar pair it also consumes.
+ */
+export function rateLimitPolicyHeader(limits: TierLimits, toolClass: 'general' | 'radar'): string {
+  const members = [
+    `"general-min";q=${limits.perMinute};w=60`,
+    `"general-day";q=${limits.perDay};w=86400`,
+  ];
+  if (toolClass === 'radar') {
+    members.push(
+      `"radar-min";q=${limits.radarPerMinute};w=60`,
+      `"radar-day";q=${limits.radarPerDay};w=86400`
+    );
+  }
+  return members.join(', ');
 }
 
 /**
@@ -55,7 +82,7 @@ export function rateLimitHeaders(result: CheckResult): Record<string, string> {
  * headers above plus `Retry-After` (RFC 7231) and a structured JSON body
  * naming the binding tier so clients can format a useful error message.
  */
-export function tooManyRequestsResponse(result: CheckResult): Response {
+export function tooManyRequestsResponse(result: CheckResult, policy?: string): Response {
   if (result.allowed) {
     throw new Error('tooManyRequestsResponse called with allowed=true; programmer error');
   }
@@ -73,6 +100,7 @@ export function tooManyRequestsResponse(result: CheckResult): Response {
     status: 429,
     headers: {
       ...headers,
+      ...(policy ? { 'RateLimit-Policy': policy } : {}),
       'Retry-After': retryAfter,
       'Content-Type': 'application/json',
     },
@@ -81,13 +109,20 @@ export function tooManyRequestsResponse(result: CheckResult): Response {
 
 /**
  * Add RFC 9331 headers to an already-constructed allowed response. Always
- * returns a new Response (Workers' Response.headers can be immutable).
+ * returns a new Response (Workers' Response.headers can be immutable). When
+ * `policy` is supplied (BL-033 Slice 5), also emit `RateLimit-Policy` so the
+ * tier ceilings ride on every authenticated 200, not just 429s.
  */
-export function withRateLimitHeaders(response: Response, result: CheckResult): Response {
+export function withRateLimitHeaders(
+  response: Response,
+  result: CheckResult,
+  policy?: string
+): Response {
   const newHeaders = new Headers(response.headers);
   for (const [key, value] of Object.entries(rateLimitHeaders(result))) {
     newHeaders.set(key, value);
   }
+  if (policy) newHeaders.set('RateLimit-Policy', policy);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/mcp-server/src/ratelimit/limiter.ts
+++ b/mcp-server/src/ratelimit/limiter.ts
@@ -50,7 +50,7 @@ interface RatelimitResponse {
 export interface CheckResult {
   /** Whether the request is allowed through. */
   readonly allowed: boolean;
-  /** RFC 9331-compatible window limit (max requests in the active window). */
+  /** RateLimit-header window limit (max requests in the active window). */
   readonly limit: number;
   /** Requests remaining in the active window. */
   readonly remaining: number;
@@ -77,6 +77,21 @@ export interface CheckResult {
    * soft-limit emit guards with `!= null` so an absent value never warns.
    */
   readonly minRemainingRatio?: number;
+  /**
+   * BL-033 Slice 5 — the bucket that OWNS `minRemainingRatio` (the
+   * proportional-closest to its cliff), which is NOT necessarily the binding
+   * bucket above (binding = absolute-fewest-remaining; e.g. minute 50/60 can
+   * be binding while day 100/1000 is proportionally closer). The soft-limit
+   * warning reports THIS bucket so the agent throttles the right window
+   * rather than the one the top-level `tier`/`limit`/`remaining` name.
+   * Populated alongside `minRemainingRatio` by `pickBindingTier`.
+   */
+  readonly nearestLimit?: {
+    readonly tier: 'minute' | 'day' | 'radar-minute' | 'radar-day';
+    readonly limit: number;
+    readonly remaining: number;
+    readonly resetAt: number;
+  };
 }
 
 /** Limiter handle — `null` when Upstash isn't reachable (graceful skip). */
@@ -179,12 +194,23 @@ interface TaggedBucket {
  *     Tie-break: lower `allPassPriority` wins (closest-cliff first).
  */
 function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
-  // Smallest headroom fraction across EVERY checked bucket (not just the
-  // binding one) — drives the 80%-consumed soft-limit warning. Guard the
-  // divide against a pathological limit of 0.
-  const minRemainingRatio = Math.min(
-    ...buckets.map((b) => (b.res.limit > 0 ? b.res.remaining / b.res.limit : 0))
-  );
+  // Proportional headroom per bucket — guard the divide against limit 0.
+  const ratioOf = (b: TaggedBucket): number =>
+    b.res.limit > 0 ? b.res.remaining / b.res.limit : 0;
+  // The proportional-closest bucket across EVERY checked bucket (not just the
+  // binding one). Drives the 80%-consumed soft-limit warning AND names the
+  // bucket the agent should actually throttle (`nearestLimit`).
+  let nearest = buckets[0]!;
+  for (const b of buckets) {
+    if (ratioOf(b) < ratioOf(nearest)) nearest = b;
+  }
+  const minRemainingRatio = ratioOf(nearest);
+  const nearestLimit = {
+    tier: nearest.tier,
+    limit: nearest.res.limit,
+    remaining: nearest.res.remaining,
+    resetAt: nearest.res.reset,
+  };
   const denied = buckets.filter((b) => !b.res.success);
   if (denied.length > 0) {
     const sorted = [...denied].sort((a, b) => {
@@ -199,6 +225,7 @@ function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
       resetAt: chosen.res.reset,
       tier: chosen.tier,
       minRemainingRatio,
+      nearestLimit,
     };
   }
   const sorted = [...buckets].sort((a, b) => {
@@ -213,6 +240,7 @@ function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
     resetAt: chosen.res.reset,
     tier: chosen.tier,
     minRemainingRatio,
+    nearestLimit,
   };
 }
 

--- a/mcp-server/src/ratelimit/limiter.ts
+++ b/mcp-server/src/ratelimit/limiter.ts
@@ -31,6 +31,7 @@
 
 import { Ratelimit } from '@upstash/ratelimit';
 import { createMcpClient } from '../lib/upstash-clients';
+import { INTERNAL_TIER, type TierLimits } from './tiers';
 import type { Env } from '../worker';
 
 /**
@@ -64,6 +65,18 @@ export interface CheckResult {
    * everything."
    */
   readonly tier: 'minute' | 'day' | 'radar-minute' | 'radar-day';
+  /**
+   * BL-033 Slice 5 — the smallest `remaining / limit` ratio across ALL
+   * buckets checked for this request (not just the binding one). Drives the
+   * 80%-consumed soft-limit `notifications/message` warning at the tool
+   * wrapper: `minRemainingRatio <= 0.20` means some bucket is ≥80% spent.
+   *
+   * Optional because callers that construct a `CheckResult` literal
+   * directly (test fixtures, and any future direct use) needn't supply it —
+   * `pickBindingTier` always populates it for real limiter results. The
+   * soft-limit emit guards with `!= null` so an absent value never warns.
+   */
+  readonly minRemainingRatio?: number;
 }
 
 /** Limiter handle — `null` when Upstash isn't reachable (graceful skip). */
@@ -78,45 +91,49 @@ export interface Limiter {
   check: (keyOwner: string, toolClass: 'general' | 'radar') => Promise<CheckResult>;
 }
 
-const PERMINUTE_LIMIT = 60;
-const PERDAY_LIMIT = 1000;
-const PERRADARMINUTE_LIMIT = 5;
-const PERRADARDAY_LIMIT = 50;
 const KEY_PREFIX = 'mcp:ratelimit';
 
 /**
  * Build a limiter from the Worker's env bindings, or return `null` if
  * Upstash credentials aren't present. Callers should treat `null` as
  * "fail open" with a safeLog warning.
+ *
+ * BL-033 Slice 5: `limits` selects the four sliding-window ceilings by the
+ * caller's tier (`resolveTierLimits(auth.tier)` at the request boundary).
+ * The default is `INTERNAL_TIER` (the pre-Slice-5 60/1000/5/50 constants),
+ * so every existing `createLimiter(env)` caller and test keeps identical
+ * behavior with no regression. The Redis key prefixes are tier-independent
+ * — a client whose tier changes reuses the same keys, and the new ceiling
+ * simply applies on the next window evaluation.
  */
-export function createLimiter(env: Env): Limiter | null {
+export function createLimiter(env: Env, limits: TierLimits = INTERNAL_TIER): Limiter | null {
   const redis = createMcpClient(env);
   if (!redis) return null;
 
   const perMinute = new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(PERMINUTE_LIMIT, '60 s'),
+    limiter: Ratelimit.slidingWindow(limits.perMinute, '60 s'),
     prefix: `${KEY_PREFIX}:gen:min`,
     analytics: false,
   });
 
   const perDay = new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(PERDAY_LIMIT, '1 d'),
+    limiter: Ratelimit.slidingWindow(limits.perDay, '1 d'),
     prefix: `${KEY_PREFIX}:gen:day`,
     analytics: false,
   });
 
   const perRadarMinute = new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(PERRADARMINUTE_LIMIT, '60 s'),
+    limiter: Ratelimit.slidingWindow(limits.radarPerMinute, '60 s'),
     prefix: `${KEY_PREFIX}:radar:min`,
     analytics: false,
   });
 
   const perRadarDay = new Ratelimit({
     redis,
-    limiter: Ratelimit.slidingWindow(PERRADARDAY_LIMIT, '1 d'),
+    limiter: Ratelimit.slidingWindow(limits.radarPerDay, '1 d'),
     prefix: `${KEY_PREFIX}:radar:day`,
     analytics: false,
   });
@@ -162,6 +179,12 @@ interface TaggedBucket {
  *     Tie-break: lower `allPassPriority` wins (closest-cliff first).
  */
 function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
+  // Smallest headroom fraction across EVERY checked bucket (not just the
+  // binding one) — drives the 80%-consumed soft-limit warning. Guard the
+  // divide against a pathological limit of 0.
+  const minRemainingRatio = Math.min(
+    ...buckets.map((b) => (b.res.limit > 0 ? b.res.remaining / b.res.limit : 0))
+  );
   const denied = buckets.filter((b) => !b.res.success);
   if (denied.length > 0) {
     const sorted = [...denied].sort((a, b) => {
@@ -175,6 +198,7 @@ function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
       remaining: chosen.res.remaining,
       resetAt: chosen.res.reset,
       tier: chosen.tier,
+      minRemainingRatio,
     };
   }
   const sorted = [...buckets].sort((a, b) => {
@@ -188,6 +212,7 @@ function pickBindingTier(buckets: readonly TaggedBucket[]): CheckResult {
     remaining: chosen.res.remaining,
     resetAt: chosen.res.reset,
     tier: chosen.tier,
+    minRemainingRatio,
   };
 }
 

--- a/mcp-server/src/ratelimit/tiers.ts
+++ b/mcp-server/src/ratelimit/tiers.ts
@@ -55,6 +55,20 @@ export const TIER_LIMITS: Record<string, TierLimits> = {
 /** The tier applied when a request carries no (or an unrecognized) tier. */
 export const DEFAULT_TIER = 'internal';
 
+/**
+ * The tiers an operator may assign at provisioning. Excludes `internal` —
+ * that is the implicit default for callers WITHOUT a tier (static keys,
+ * OAuth human-consent), not something you hand to an external pilot. Used by
+ * the admin endpoint to reject a mistyped `tier` up front rather than let it
+ * fail generous to `internal` (60/1000, looser than `free-pilot`).
+ */
+export const ASSIGNABLE_TIERS = ['free-pilot', 'paid', 'enterprise'] as const;
+
+/** Whether `tier` is an operator-assignable tier (see `ASSIGNABLE_TIERS`). */
+export function isAssignableTier(tier: string): boolean {
+  return (ASSIGNABLE_TIERS as readonly string[]).includes(tier);
+}
+
 // Log an unknown non-empty tier at most once per distinct value, so a
 // misconfigured client record surfaces in `wrangler tail` without spamming
 // the log on every request.

--- a/mcp-server/src/ratelimit/tiers.ts
+++ b/mcp-server/src/ratelimit/tiers.ts
@@ -1,0 +1,80 @@
+/**
+ * Per-client rate-limit tiers (BL-033 Slice 5).
+ *
+ * Maps a client's `tier` (stored on the M2M client record, carried in the
+ * self-contained M2M token claim — see ADR-0008/ADR-0010) to the four
+ * sliding-window ceilings the limiter enforces. Making the ceilings
+ * tier-aware is the whole point of this slice: before it, `limiter.ts`
+ * used flat hardcoded constants and the stored `tier` field was inert.
+ *
+ * **These numbers are tunable, non-contractual capability config — NOT
+ * ratified SLA quotas.** They are abuse/capacity ceilings (Directive: build
+ * capability, don't ratify SLA numbers). `free-pilot` is deliberately
+ * tighter than `internal` — abuse containment for an unvetted external
+ * pilot, not a promised allowance.
+ *
+ * **Radar caps** (`radarPerMinute`/`radarPerDay`) are per-client FAIRNESS +
+ * thin cache-cold defense-in-depth, NOT the Inoreader-budget control. Radar
+ * tool calls are ~99% Upstash cache hits (zero Inoreader spend); only a
+ * cold/expired-cache miss falls through to a live fetch, and the global
+ * circuit breaker (`circuit-breaker.ts`) is the real upstream-budget guard.
+ * See `RATE_LIMITS.md` § Per-client tiers + ADR-0006.
+ */
+
+import { safeLog } from '../auth/safe-logger';
+
+/** The four sliding-window ceilings a tier grants. All per-`keyOwner`. */
+export interface TierLimits {
+  readonly perMinute: number;
+  readonly perDay: number;
+  readonly radarPerMinute: number;
+  readonly radarPerDay: number;
+}
+
+/**
+ * The pre-Slice-5 hardcoded limits, verbatim. This is the **no-regression
+ * anchor**: static `MCP_KEY_*` keys and the OAuth human-consent path carry
+ * no tier (`AuthSuccess.tier === undefined`) and resolve here, so they keep
+ * the exact 60/1000/5/50 budgets they had before this slice.
+ */
+export const INTERNAL_TIER: TierLimits = {
+  perMinute: 60,
+  perDay: 1000,
+  radarPerMinute: 5,
+  radarPerDay: 50,
+};
+
+/** Known tier → ceilings. Keys match the M2M record's `tier` taxonomy. */
+export const TIER_LIMITS: Record<string, TierLimits> = {
+  'free-pilot': { perMinute: 30, perDay: 300, radarPerMinute: 3, radarPerDay: 20 },
+  paid: { perMinute: 60, perDay: 2000, radarPerMinute: 5, radarPerDay: 50 },
+  enterprise: { perMinute: 120, perDay: 10000, radarPerMinute: 10, radarPerDay: 150 },
+  internal: INTERNAL_TIER,
+};
+
+/** The tier applied when a request carries no (or an unrecognized) tier. */
+export const DEFAULT_TIER = 'internal';
+
+// Log an unknown non-empty tier at most once per distinct value, so a
+// misconfigured client record surfaces in `wrangler tail` without spamming
+// the log on every request.
+const warnedTiers = new Set<string>();
+
+/**
+ * Resolve a client's tier string to its ceilings. `undefined` (static /
+ * OAuth-human / legacy pre-Slice-5 M2M token) and any unrecognized string
+ * both fall back to `INTERNAL_TIER` — fail-generous, since an unknown tier
+ * is an operator misconfiguration, not a hostile signal, and the flat
+ * internal ceilings are already the safe default the server ran on before.
+ */
+export function resolveTierLimits(tier: string | undefined): TierLimits {
+  if (tier && tier in TIER_LIMITS) return TIER_LIMITS[tier]!;
+  if (tier && !warnedTiers.has(tier)) {
+    warnedTiers.add(tier);
+    safeLog({
+      event: 'ratelimit.tier-unknown',
+      reason: `unknown-tier=${tier}; falling back to ${DEFAULT_TIER}`,
+    });
+  }
+  return INTERNAL_TIER;
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -109,6 +109,15 @@ export interface ServerContext {
    * (input params must never reach AE / Sentry / ops logs; ADR-0009).
    */
   audit?: import('./audit/_index').AuditContext;
+
+  /**
+   * BL-033 Slice 5 — the boundary's already-computed rate-limit result for
+   * this request. Threaded into `MetricsContext.rateLimit` so the
+   * `withMetricsCore` chokepoint can emit the 80%-consumed soft-limit
+   * `notifications/message` warning without a second Upstash round-trip.
+   * Omitted for stdio / tests / graceful-skip (→ no warning).
+   */
+  rateLimit?: import('./ratelimit/limiter').CheckResult;
 }
 
 /**
@@ -124,10 +133,18 @@ export interface ServerContext {
  * Inoreader creds aren't bound at the runtime level.
  */
 export function createServer(env: Env = {}, ctx: ServerContext = {}): McpServer {
-  const server = new McpServer({
-    name: 'gst-mcp',
-    version: '0.1.0',
-  });
+  const server = new McpServer(
+    {
+      name: 'gst-mcp',
+      version: '0.1.0',
+    },
+    // BL-033 Slice 5: declare the `logging` capability so a tool handler may
+    // emit the 80%-consumed soft-limit `notifications/message` via
+    // `extra.sendNotification`. Without it the SDK's
+    // `assertNotificationCapability` throws "Server does not support logging",
+    // which would turn a best-effort soft warning into a failed tool call.
+    { capabilities: { logging: {} } }
+  );
   const scopes = ctx.scopes ?? DEFAULT_SCOPES;
 
   // BL-032.75 Phase 1: build the per-request MetricsContext once and thread
@@ -178,6 +195,7 @@ export function createServer(env: Env = {}, ctx: ServerContext = {}): McpServer 
           counters: new InMemoryToolCallCounters(),
           irlBodyCache,
           audit: ctx.audit,
+          rateLimit: ctx.rateLimit,
         }
       : {
           sink: ctx.metricsSink,
@@ -185,6 +203,7 @@ export function createServer(env: Env = {}, ctx: ServerContext = {}): McpServer 
           counters: new InMemoryToolCallCounters(),
           irlBodyCache,
           audit: ctx.audit,
+          rateLimit: ctx.rateLimit,
         };
 
   // Tools (transport-portable)

--- a/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
+++ b/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
@@ -68,16 +68,17 @@ describe('withMetricsCore soft-limit warning', () => {
   });
 
   it('reports the ratio-tripping bucket (nearestLimit), not the binding bucket', async () => {
-    // Binding bucket is the minute tier (absolute-fewest remaining, 5/60), but the
-    // day bucket is proportionally closer to its cliff (100/1000 = 0.10) and is what
-    // tripped the warning. The agent must be told to throttle the DAY window.
+    // Binding bucket is the minute tier (absolute-fewest remaining, 50 < 100), but
+    // the day bucket is proportionally closer to its cliff (100/1000 = 0.10 vs the
+    // minute's 50/60 = 0.83) and is what tripped the warning. The agent must be told
+    // to throttle the DAY window — this is exactly what the real picker produces.
     const extra = extraWith(() => Promise.resolve());
     const ctx: MetricsContext = {
       sink: new NoopSink(),
       rateLimit: {
-        tier: 'minute', // binding
+        tier: 'minute', // binding (absolute-fewest remaining)
         limit: 60,
-        remaining: 5,
+        remaining: 50,
         resetAt: Date.now() + 30_000,
         minRemainingRatio: 0.1,
         nearestLimit: { tier: 'day', limit: 1000, remaining: 100, resetAt: Date.now() + 3_600_000 },

--- a/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
+++ b/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * BL-033 Slice 5 — the 80%-consumed soft-limit `notifications/message` emit
+ * inside `withMetricsCore`.
+ *
+ * The wrapper reads the boundary's already-computed rate-limit result from
+ * `MetricsContext.rateLimit` and, when some bucket is ≥80% spent, writes a
+ * best-effort warning onto the request's SSE stream via `extra.sendNotification`.
+ * These tests pin: fires at/under the 0.20 threshold, silent above it, never
+ * throws when the notifier is absent or rejects, and is gated to tool calls.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  withMetricsCore,
+  type MetricsContext,
+  type RateLimitCheck,
+} from '../../../src/metrics/with-metrics';
+import { NoopSink } from '../../../src/metrics/_index';
+
+const baseCtx = (rateLimit?: RateLimitCheck): MetricsContext => ({
+  sink: new NoopSink(),
+  rateLimit,
+});
+
+const rl = (minRemainingRatio: number): RateLimitCheck => ({
+  tier: 'minute',
+  limit: 30,
+  remaining: Math.round(30 * minRemainingRatio),
+  resetAt: Date.now() + 30_000,
+  minRemainingRatio,
+});
+
+/** A tool-handler `extra` carrying a `sendNotification` spy. */
+const extraWith = (send: (n: unknown) => unknown) => ({ sendNotification: vi.fn(send) });
+
+// Mirrors an MCP tool callback's `(args, extra)` arity so `withMetricsCore`
+// infers a 2-arg wrapper the tests can invoke with an `extra`.
+const ok = async (_input?: unknown, _extra?: unknown) => ({
+  content: [{ type: 'text', text: 'ok' }],
+});
+
+describe('withMetricsCore soft-limit warning', () => {
+  it('emits notifications/message when a bucket is ≥80% consumed (ratio ≤ 0.20)', async () => {
+    const extra = extraWith(() => Promise.resolve());
+    const wrapped = withMetricsCore(
+      'tool_invocation',
+      'search_portfolio',
+      baseCtx(rl(0.1)),
+      () => 'success',
+      ok
+    );
+
+    await wrapped({ q: 'x' }, extra);
+
+    expect(extra.sendNotification).toHaveBeenCalledTimes(1);
+    const notif = extra.sendNotification.mock.calls[0]![0] as {
+      method: string;
+      params: {
+        level: string;
+        logger: string;
+        data: { tier: string; remaining: number; limit: number };
+      };
+    };
+    expect(notif.method).toBe('notifications/message');
+    expect(notif.params.level).toBe('warning');
+    expect(notif.params.logger).toBe('ratelimit');
+    expect(notif.params.data.tier).toBe('minute');
+    expect(notif.params.data.limit).toBe(30);
+  });
+
+  it('fires exactly at the 0.20 threshold boundary', async () => {
+    const extra = extraWith(() => Promise.resolve());
+    const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.2)), () => 'success', ok);
+    await wrapped({}, extra);
+    expect(extra.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT emit when headroom is above 20% remaining', async () => {
+    const extra = extraWith(() => Promise.resolve());
+    const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.5)), () => 'success', ok);
+    await wrapped({}, extra);
+    expect(extra.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit when no rateLimit context is present (stdio / graceful-skip)', async () => {
+    const extra = extraWith(() => Promise.resolve());
+    const wrapped = withMetricsCore(
+      'tool_invocation',
+      't',
+      baseCtx(undefined),
+      () => 'success',
+      ok
+    );
+    await wrapped({}, extra);
+    expect(extra.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('is gated to tool_invocation — a resource_read never warns', async () => {
+    const extra = extraWith(() => Promise.resolve());
+    const wrapped = withMetricsCore(
+      'resource_read',
+      'gst://x',
+      baseCtx(rl(0.05)),
+      () => 'success',
+      ok
+    );
+    await wrapped({}, extra);
+    expect(extra.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the handler exposes no sendNotification (non-SSE / zero-arg)', async () => {
+    const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.05)), () => 'success', ok);
+    // Only a plain input arg, no extra with sendNotification.
+    await expect(wrapped({ q: 'x' })).resolves.toEqual({ content: [{ type: 'text', text: 'ok' }] });
+  });
+
+  it('never breaks the tool call when sendNotification rejects', async () => {
+    const extra = extraWith(() => Promise.reject(new Error('stream closed')));
+    const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.05)), () => 'success', ok);
+    await expect(wrapped({}, extra)).resolves.toEqual({ content: [{ type: 'text', text: 'ok' }] });
+    expect(extra.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('never breaks the tool call when sendNotification throws synchronously', async () => {
+    const extra = extraWith(() => {
+      throw new Error('boom');
+    });
+    const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.05)), () => 'success', ok);
+    await expect(wrapped({}, extra)).resolves.toEqual({ content: [{ type: 'text', text: 'ok' }] });
+  });
+});

--- a/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
+++ b/mcp-server/tests/unit/metrics/with-metrics-softlimit.test.ts
@@ -67,6 +67,33 @@ describe('withMetricsCore soft-limit warning', () => {
     expect(notif.params.data.limit).toBe(30);
   });
 
+  it('reports the ratio-tripping bucket (nearestLimit), not the binding bucket', async () => {
+    // Binding bucket is the minute tier (absolute-fewest remaining, 5/60), but the
+    // day bucket is proportionally closer to its cliff (100/1000 = 0.10) and is what
+    // tripped the warning. The agent must be told to throttle the DAY window.
+    const extra = extraWith(() => Promise.resolve());
+    const ctx: MetricsContext = {
+      sink: new NoopSink(),
+      rateLimit: {
+        tier: 'minute', // binding
+        limit: 60,
+        remaining: 5,
+        resetAt: Date.now() + 30_000,
+        minRemainingRatio: 0.1,
+        nearestLimit: { tier: 'day', limit: 1000, remaining: 100, resetAt: Date.now() + 3_600_000 },
+      },
+    };
+    const wrapped = withMetricsCore('tool_invocation', 't', ctx, () => 'success', ok);
+    await wrapped({}, extra);
+
+    const data = (
+      extra.sendNotification.mock.calls[0]![0] as { params: { data: Record<string, unknown> } }
+    ).params.data;
+    expect(data.tier).toBe('day');
+    expect(data.limit).toBe(1000);
+    expect(data.remaining).toBe(100);
+  });
+
   it('fires exactly at the 0.20 threshold boundary', async () => {
     const extra = extraWith(() => Promise.resolve());
     const wrapped = withMetricsCore('tool_invocation', 't', baseCtx(rl(0.2)), () => 'success', ok);

--- a/mcp-server/tests/unit/oauth/m2m-token.test.ts
+++ b/mcp-server/tests/unit/oauth/m2m-token.test.ts
@@ -13,10 +13,12 @@ import {
   canonicalAudience,
   signM2mToken,
   verifyClientAssertion,
+  verifyM2mToken,
   verifyM2mTokenClaims,
   M2M_TOKEN_PREFIX,
   type M2mTokenClaims,
 } from '../../../src/oauth/m2m-token';
+import type { Env } from '../../../src/worker';
 import { sha256Hex, verifyM2mSecret, type M2mClientRecord } from '../../../src/oauth/m2m-clients';
 
 const SIGNING_KEY = 'unit-test-signing-key-32-bytes-xx';
@@ -76,6 +78,33 @@ describe('M2M self-contained token', () => {
     expect(canonicalAudience('https://mcp.globalstrategic.tech')).toBe(
       'https://mcp.globalstrategic.tech/mcp'
     );
+  });
+
+  // BL-033 Slice 5 — the tier claim rides on the self-contained token so the
+  // limiter reads it locally (no KV re-fetch on the hot path; ADR-0010).
+  it('round-trips the tier claim (sign → verify)', async () => {
+    const token = await signM2mToken(claims({ tier: 'paid' }), SIGNING_KEY);
+    const verified = await verifyM2mTokenClaims(token, SIGNING_KEY, AUD);
+    expect(verified!.tier).toBe('paid');
+  });
+
+  it('verifyM2mToken surfaces the tier into the AuthSuccess result', async () => {
+    const token = await signM2mToken(claims({ tier: 'enterprise' }), SIGNING_KEY);
+    const env = { OAUTH_M2M_SIGNING_KEY: SIGNING_KEY } as unknown as Env;
+    const auth = await verifyM2mToken(token, env, 'https://mcp.test');
+    expect(auth).not.toBeNull();
+    expect(auth!.keyOwner).toBe('M2M:ACME');
+    expect(auth!.tier).toBe('enterprise');
+  });
+
+  it('a legacy token minted without a tier verifies with tier undefined (self-heals to internal)', async () => {
+    const legacy = claims();
+    delete (legacy as Partial<M2mTokenClaims>).tier;
+    const token = await signM2mToken(legacy, SIGNING_KEY);
+    const env = { OAUTH_M2M_SIGNING_KEY: SIGNING_KEY } as unknown as Env;
+    const auth = await verifyM2mToken(token, env, 'https://mcp.test');
+    expect(auth).not.toBeNull();
+    expect(auth!.tier).toBeUndefined();
   });
 });
 

--- a/mcp-server/tests/unit/ratelimit-headers.test.ts
+++ b/mcp-server/tests/unit/ratelimit-headers.test.ts
@@ -9,11 +9,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   rateLimitHeaders,
+  rateLimitPolicyHeader,
   reasonForTier,
   tooManyRequestsResponse,
   withRateLimitHeaders,
 } from '../../src/ratelimit/headers';
 import { chooseBindingTier, type CheckResult } from '../../src/ratelimit/limiter';
+import { TIER_LIMITS } from '../../src/ratelimit/tiers';
 
 const FIXED_NOW = 1_715_000_000_000; // arbitrary stable timestamp
 
@@ -270,5 +272,74 @@ describe('reasonForTier (BL-038)', () => {
     expect(reasonForTier('day')).toBe('rate-limit-per-day');
     expect(reasonForTier('radar-minute')).toBe('radar-rate-limit-per-minute');
     expect(reasonForTier('radar-day')).toBe('radar-rate-limit-per-day');
+  });
+});
+
+describe('rateLimitPolicyHeader (BL-033 Slice 5)', () => {
+  it('advertises the two general buckets for a general call', () => {
+    const policy = rateLimitPolicyHeader(TIER_LIMITS['free-pilot']!, 'general');
+    expect(policy).toBe('"general-min";q=30;w=60, "general-day";q=300;w=86400');
+  });
+
+  it('additionally advertises the radar pair for a radar call', () => {
+    const policy = rateLimitPolicyHeader(TIER_LIMITS['free-pilot']!, 'radar');
+    expect(policy).toBe(
+      '"general-min";q=30;w=60, "general-day";q=300;w=86400, ' +
+        '"radar-min";q=3;w=60, "radar-day";q=20;w=86400'
+    );
+  });
+
+  it('reflects the tier ceilings (enterprise vs free-pilot differ)', () => {
+    const ent = rateLimitPolicyHeader(TIER_LIMITS['enterprise']!, 'general');
+    expect(ent).toBe('"general-min";q=120;w=60, "general-day";q=10000;w=86400');
+  });
+});
+
+describe('RateLimit-Policy on responses (BL-033 Slice 5)', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('tooManyRequestsResponse sets RateLimit-Policy when a policy is supplied', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const result: CheckResult = {
+      allowed: false,
+      limit: 30,
+      remaining: 0,
+      resetAt: FIXED_NOW + 30_000,
+      tier: 'minute',
+    };
+    const policy = rateLimitPolicyHeader(TIER_LIMITS['free-pilot']!, 'general');
+    const res = tooManyRequestsResponse(result, policy);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('ratelimit-policy')).toBe(policy);
+  });
+
+  it('tooManyRequestsResponse omits RateLimit-Policy when no policy is supplied', () => {
+    const result: CheckResult = {
+      allowed: false,
+      limit: 30,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      tier: 'minute',
+    };
+    const res = tooManyRequestsResponse(result);
+    expect(res.headers.get('ratelimit-policy')).toBeNull();
+  });
+
+  it('withRateLimitHeaders sets RateLimit-Policy on an allowed 200 response', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const upstream = new Response('ok', { status: 200 });
+    const result: CheckResult = {
+      allowed: true,
+      limit: 60,
+      remaining: 50,
+      resetAt: FIXED_NOW + 30_000,
+      tier: 'minute',
+    };
+    const policy = rateLimitPolicyHeader(TIER_LIMITS['paid']!, 'general');
+    const wrapped = withRateLimitHeaders(upstream, result, policy);
+    expect(wrapped.status).toBe(200);
+    expect(wrapped.headers.get('ratelimit-policy')).toBe(policy);
   });
 });

--- a/mcp-server/tests/unit/ratelimit/limiter.test.ts
+++ b/mcp-server/tests/unit/ratelimit/limiter.test.ts
@@ -13,7 +13,13 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { chooseBindingTier4 } from '../../../src/ratelimit/limiter';
+import {
+  chooseBindingTier,
+  chooseBindingTier4,
+  createLimiter,
+} from '../../../src/ratelimit/limiter';
+import { TIER_LIMITS } from '../../../src/ratelimit/tiers';
+import type { Env } from '../../../src/worker';
 
 // Helper to build minimal Ratelimit-shape responses.
 const r = (success: boolean, remaining: number, reset: number, limit: number) => ({
@@ -124,5 +130,60 @@ describe('chooseBindingTier4 — denied', () => {
     const result = chooseBindingTier4(minute, day, radarMin, radarDay);
     expect(result.allowed).toBe(false);
     expect(result.tier).toBe('minute');
+  });
+});
+
+describe('createLimiter tier param (BL-033 Slice 5)', () => {
+  // Full enforcement of the tier ceilings requires a live Upstash project
+  // and is verified against staging Upstash (the same Phase-6 deferral the
+  // integration suite documents). What we CAN pin without a network hop is
+  // that the new `limits` param never disturbs the graceful-skip contract:
+  // no Upstash creds → null, regardless of tier.
+  it('returns null (graceful skip) when Upstash is unbound, with an explicit tier', () => {
+    expect(createLimiter({} as Env, TIER_LIMITS['free-pilot'])).toBeNull();
+  });
+
+  it('returns null (graceful skip) when Upstash is unbound, with the default (internal) tier', () => {
+    expect(createLimiter({} as Env)).toBeNull();
+  });
+});
+
+describe('minRemainingRatio (BL-033 Slice 5 — soft-limit signal)', () => {
+  it('is the SMALLEST remaining/limit ratio across all checked buckets, not the binding one', () => {
+    // Binding tier (fewest ABSOLUTE remaining) is radar-minute (1 token), but the
+    // smallest PROPORTIONAL headroom is the day bucket: 100/1000 = 0.10 vs 1/5 = 0.20.
+    const minute = r(true, 50, 30_000, 60);
+    const day = r(true, 100, 86_400_000, 1000);
+    const radarMin = r(true, 1, 30_000, 5);
+    const radarDay = r(true, 40, 86_400_000, 50);
+    const result = chooseBindingTier4(minute, day, radarMin, radarDay);
+    expect(result.tier).toBe('radar-minute'); // binding = absolute-fewest
+    expect(result.minRemainingRatio).toBeCloseTo(0.1); // soft-limit = proportional-fewest
+  });
+
+  it('crosses the 0.20 soft-limit threshold when any bucket is ≥80% consumed', () => {
+    // radar-minute at 1/5 = 0.20 (exactly the threshold); everything else has headroom.
+    const minute = r(true, 60, 30_000, 60);
+    const day = r(true, 1000, 86_400_000, 1000);
+    const radarMin = r(true, 1, 30_000, 5);
+    const radarDay = r(true, 50, 86_400_000, 50);
+    const result = chooseBindingTier4(minute, day, radarMin, radarDay);
+    expect(result.minRemainingRatio).toBeCloseTo(0.2);
+    expect(result.minRemainingRatio! <= 0.2).toBe(true);
+  });
+
+  it('is populated on the 2-bucket general path too', () => {
+    const minute = r(true, 6, 30_000, 60); // 0.10
+    const day = r(true, 900, 86_400_000, 1000); // 0.90
+    const result = chooseBindingTier(minute, day);
+    expect(result.minRemainingRatio).toBeCloseTo(0.1);
+  });
+
+  it('is populated on a denied result', () => {
+    const minute = r(false, 0, 30_000, 60); // 0.0
+    const day = r(true, 700, 86_400_000, 1000);
+    const result = chooseBindingTier(minute, day);
+    expect(result.allowed).toBe(false);
+    expect(result.minRemainingRatio).toBe(0);
   });
 });

--- a/mcp-server/tests/unit/ratelimit/tiers.test.ts
+++ b/mcp-server/tests/unit/ratelimit/tiers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the per-client rate-limit tier config (BL-033 Slice 5).
+ *
+ * The load-bearing assertion is the **no-regression pin**: `INTERNAL_TIER`
+ * (the tier resolved for static `MCP_KEY_*` keys and the OAuth human-consent
+ * path, both of which carry no `tier`) must exactly equal the pre-Slice-5
+ * hardcoded limiter constants (60/1000/5/50). Any drift there silently
+ * changes the budgets internal team keys have run on since BL-032/BL-038.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  INTERNAL_TIER,
+  TIER_LIMITS,
+  DEFAULT_TIER,
+  resolveTierLimits,
+} from '../../../src/ratelimit/tiers';
+
+describe('INTERNAL_TIER (no-regression anchor)', () => {
+  it('equals the pre-Slice-5 hardcoded limiter constants exactly', () => {
+    expect(INTERNAL_TIER).toEqual({
+      perMinute: 60,
+      perDay: 1000,
+      radarPerMinute: 5,
+      radarPerDay: 50,
+    });
+  });
+
+  it('is the value keyed under the "internal" tier', () => {
+    expect(TIER_LIMITS.internal).toBe(INTERNAL_TIER);
+    expect(DEFAULT_TIER).toBe('internal');
+  });
+});
+
+describe('resolveTierLimits', () => {
+  it('resolves each known tier to its own ceilings', () => {
+    expect(resolveTierLimits('free-pilot')).toEqual({
+      perMinute: 30,
+      perDay: 300,
+      radarPerMinute: 3,
+      radarPerDay: 20,
+    });
+    expect(resolveTierLimits('paid')).toEqual({
+      perMinute: 60,
+      perDay: 2000,
+      radarPerMinute: 5,
+      radarPerDay: 50,
+    });
+    expect(resolveTierLimits('enterprise')).toEqual({
+      perMinute: 120,
+      perDay: 10000,
+      radarPerMinute: 10,
+      radarPerDay: 150,
+    });
+    expect(resolveTierLimits('internal')).toBe(INTERNAL_TIER);
+  });
+
+  it('falls back to INTERNAL_TIER for undefined tier (static / OAuth-human / legacy token)', () => {
+    expect(resolveTierLimits(undefined)).toBe(INTERNAL_TIER);
+  });
+
+  it('falls back to INTERNAL_TIER for an unrecognized tier string (misconfig fails generous)', () => {
+    expect(resolveTierLimits('platinum')).toBe(INTERNAL_TIER);
+    expect(resolveTierLimits('')).toBe(INTERNAL_TIER);
+  });
+
+  it('free-pilot is strictly tighter than internal (abuse containment default)', () => {
+    const fp = resolveTierLimits('free-pilot');
+    expect(fp.perMinute).toBeLessThan(INTERNAL_TIER.perMinute);
+    expect(fp.perDay).toBeLessThan(INTERNAL_TIER.perDay);
+  });
+});

--- a/src/docs/adr/0010-per-client-rate-limit-tiers.md
+++ b/src/docs/adr/0010-per-client-rate-limit-tiers.md
@@ -1,0 +1,47 @@
+# ADR-0010: Per-client rate-limit tiers carried in the token claim; soft-limit warnings over the SSE notification channel
+
+- **Status**: Accepted 2026-07-26 (0.41.0)
+- **Source initiative**: BL-033 External Pilot (Phase 3), Slice 5 — the "Rate limiting (per-client, contractual)" AC block ([BACKLOG.md § BL-033](../development/BACKLOG.md#bl-033-mcp-server--external-pilot-phase-3)). Builds on [ADR-0008](0008-mcp-oauth-embedded-authorization-server.md) (self-contained M2M tokens) and [ADR-0006](0006-inoreader-zone1-budget-protection.md) (Inoreader Zone-1 budget / circuit breaker).
+
+## Context
+
+The sliding-window per-client limiter shipped in BL-032 Phase 3 + BL-038 and enforces in production, but with **flat, hardcoded ceilings** (`mcp-server/src/ratelimit/limiter.ts` — 60/min, 1000/day general; 5/min, 50/day radar). BL-033 requires the ceilings to vary **per client tier**. The tier (`free-pilot` / `paid` / `enterprise`) was already stored on the M2M client record (`mcp-server/src/oauth/m2m-clients.ts`, in Cloudflare KV) but was **inert** — never read on the enforcement path. Two decisions had non-obvious rejected alternatives worth recording.
+
+Ceilings here are **capability/abuse config, not ratified SLA quotas** (BL-033 operator directive: build capability, don't ratify SLA numbers). The numbers are tunable defaults, not contractual commitments.
+
+## Decision
+
+### 1. The tier travels IN the self-contained token claim — not re-fetched from KV at the limiter
+
+The M2M access token (`M2mTokenClaims`, `mcp-server/src/oauth/m2m-token.ts`) gains a `tier` claim, minted from `record.tier` at token issuance and surfaced onto `AuthSuccess.tier` (`mcp-server/src/auth/bearer.ts`). The request boundary resolves it to ceilings via `resolveTierLimits(auth.tier)` (`mcp-server/src/ratelimit/tiers.ts`) and passes them to `createLimiter(env, limits)`.
+
+**Rejected: re-fetch the client record from KV at the limiter to read `tier`.** That reintroduces exactly the ~60s cross-colo eventual-consistency hazard that ADR-0008 eliminated by making M2M tokens self-contained — a KV read on the hot path, on every request, for a value that is already cryptographically bound into the token. The token is the authoritative carrier of the client's grant; tier belongs there with scope and keyOwner.
+
+**No-regression default.** Static `MCP_KEY_*` team keys and the OAuth human-consent path carry no tier (`AuthSuccess.tier === undefined`); `resolveTierLimits(undefined)` returns `INTERNAL_TIER`, which equals the pre-Slice-5 constants bit-for-bit (60/1000/5/50). Unknown tier strings (operator misconfiguration) also fail generous to `INTERNAL_TIER` and log once. A legacy ≤1h M2M token minted before this shipped has no `tier` claim → resolves to `internal` and self-heals on the next re-exchange.
+
+### 2. The 80%-consumed soft-limit warning is an MCP `notifications/message` over the request's SSE stream — best-effort, with headers as the guaranteed fallback
+
+At ≤20% remaining in any bucket (`CheckResult.minRemainingRatio`), the tool-metrics wrapper (`mcp-server/src/metrics/with-metrics.ts`) emits a `notifications/message` (level `warning`, logger `ratelimit`) via `extra.sendNotification`, so a compliant agent can throttle itself before the hard 429.
+
+Transport analysis that made this feasible (verified against the installed `agents` + `@modelcontextprotocol/sdk` packages):
+
+- `createMcpHandler` passes no transport options, so the SDK's `enableJsonResponse` stays off and **every `tools/call` POST is answered with `text/event-stream`** (`webStandardStreamableHttp.js:464`). A spec-compliant MCP client MUST accept SSE, so the notification channel exists on the same response.
+- A request handler's `extra.sendNotification` routes onto that request's own stream via `relatedRequestId` (`protocol.js:322-326`).
+- The server MUST declare the `logging` capability or `notifications/message` throws `"Server does not support logging"` (`server/index.js:173-177`) — so `createServer` now constructs `new McpServer(info, { capabilities: { logging: {} } })`.
+
+**Best-effort by design.** A client that sends the mandatory `Accept` header but only parses the terminal `result` frame ignores interim notifications; delivery can also no-op on an aborted request. That is acceptable because the **always-present `RateLimit-*` + `RateLimit-Policy` headers on every authenticated response (200 and 429)** are the transport-agnostic, guaranteed throttle signal. The emit is wrapped so a missing capability, non-SSE consumer, or rejected send is a visibility loss, never a tool-call failure.
+
+**Rejected: emit at the Worker boundary.** The rate-limit gate runs before `createMcpHandler` builds the server, so there is no MCP server/notification channel there — the emit must live at the tool wrapper, which owns the per-request `extra`.
+
+### Radar ceilings — decoupled from the Inoreader budget
+
+Per-client radar caps are **per-client fairness + thin cache-cold defense-in-depth**, NOT the Inoreader-budget control. Radar tool calls are ~99% Upstash cache hits (zero Inoreader spend); only a cold/expired-cache miss falls through to a live fetch (`mcp-server/src/content/radar-live-store.ts`), and the global **circuit breaker** (ADR-0006) — wired into the radar tool path — is the real upstream-budget guard.
+
+## Consequences
+
+- **Cites this ADR**: `mcp-server/src/ratelimit/tiers.ts`, `limiter.ts`, `mcp-server/src/oauth/m2m-token.ts`, `mcp-server/src/metrics/with-metrics.ts`, `mcp-server/src/docs/operations/RATE_LIMITS.md`, `mcp-server/src/docs/ARCHITECTURE.md § Rate limiting & Inoreader budget`.
+- **AC-1 deviation (recorded)**: the AC says tier is "stored in Redis"; it is actually stored in **Cloudflare KV** (the M2M record's substrate per ADR-0008). The limiter counters remain in Upstash Redis.
+- **Tuning**: ceilings live in `TIER_LIMITS` (`tiers.ts`); change + redeploy. They are tunable, non-contractual — do not publish as SLA quotas.
+- **Tier change semantics**: a client whose tier changes reuses the same Redis limiter keys; the new ceiling applies on the next window evaluation (no key migration).
+- **Enforcement testing**: tier-ceiling enforcement (like the base limiter) is validated against staging Upstash, not in CI (no live Redis in unit runs); unit tests pin the tier config, the `minRemainingRatio` signal, the header/claim shapes, and the soft-limit emit contract.
+- **Revisit triggers**: a pilot contracting a genuinely committed rate SLA (promotes ceilings from capability config to a ratified quota — out of scope per directive); a client requiring guaranteed (not best-effort) soft-limit delivery (would need an ack'd backpressure channel the MCP spec doesn't define today); per-tool (vs per-tool-class) ceilings if a single tool needs independent budgeting.

--- a/src/docs/adr/README.md
+++ b/src/docs/adr/README.md
@@ -19,5 +19,6 @@ Lightweight, maintained records of load-bearing design decisions that span the w
 | [0007](0007-registered-prompt-pattern.md)                | Registered prompts as the consultant-workflow surface (+ maturity bar)                     | Accepted 2026-05-01                                                       |
 | [0008](0008-mcp-oauth-embedded-authorization-server.md)  | OAuth 2.1 as an embedded authorization server on the MCP Worker (dual-auth, M2M JWTs)      | Accepted 2026-07-24                                                       |
 | [0009](0009-compliance-audit-log-hash-chain.md)          | Compliance audit log — hash-chained, R2-immutable, Upstash-sequenced (best-effort enqueue) | Accepted 2026-07-26                                                       |
+| [0010](0010-per-client-rate-limit-tiers.md)              | Per-client rate-limit tiers in the token claim; soft-limit warnings over the SSE channel   | Accepted 2026-07-26 (0.41.0)                                              |
 
 _Established 2026-07-17 under BL-088 (development-docs distillation)._

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -252,10 +252,12 @@ None of these are currently load-bearing for active partners. Revisit when (a) C
 
 **Rate limiting (per-client, contractual)**
 
-- [ ] Per-client tier (`free-pilot` / `paid` / `enterprise`) gates the limit ceilings; tier stored in Redis client record
-- [ ] Sliding-window limits applied per-tool per-client — radar tools share the global Inoreader budget circuit breaker introduced in BL-032
-- [ ] Quota exhaustion returns `429` with `Retry-After` header + a structured `RateLimit-Policy` header (RFC 9331) describing the limit so client engineers can self-diagnose
-- [ ] Soft-limit warning at 80% of quota emitted as an MCP-spec `notifications/message` so the calling agent can throttle itself before hitting the hard limit
+> ✅ **This AC block shipped 2026-07-26 as BL-033 Slice 5** (per-client tier-aware ceilings, `RateLimit-Policy` header, 80% soft-limit `notifications/message`). Decision record incl. tier-in-token vs KV re-fetch + the SSE notification-transport analysis: [ADR-0010](../adr/0010-per-client-rate-limit-tiers.md). Contract: [`RATE_LIMITS.md`](../../../mcp-server/src/docs/operations/RATE_LIMITS.md). Per-AC dispositions below.
+
+- [x] Per-client tier (`free-pilot` / `paid` / `enterprise`) gates the limit ceilings; tier stored in Redis client record — ✅ **with a recorded deviation**: the ceilings are now tier-aware (`ratelimit/tiers.ts` → `resolveTierLimits(auth.tier)` → `createLimiter(env, limits)`), but the `tier` field is stored in **Cloudflare KV** (the M2M client record's substrate per ADR-0008), NOT Redis, and travels in the self-contained token claim so the limiter reads it with no KV round-trip on the hot path (ADR-0010 §1). Static `MCP_KEY_*` + OAuth human-consent carry no tier → the `internal` default = the pre-Slice-5 60/1000/5/50 (no regression). **Numbers are tunable, non-contractual capability ceilings, not SLA quotas** (operator directive)
+- [x] Sliding-window limits applied per-tool per-client — radar tools share the global Inoreader budget circuit breaker introduced in BL-032 — ✅ shipped BL-032 Phase 3 + BL-038; Slice 5 makes the ceilings tier-aware. (Radar caps are per-client fairness + cache-cold defense-in-depth; the circuit breaker — wired into the radar tool path — is the real Inoreader-budget guard, since radar calls are ~99% cache hits)
+- [x] Quota exhaustion returns `429` with `Retry-After` header + a structured `RateLimit-Policy` header (RFC 9331) describing the limit so client engineers can self-diagnose — ✅ `Retry-After` shipped in Phase 3; `RateLimit-Policy` added in Slice 5 (quoted-policy form, on every authenticated 200 AND 429 — the transport-agnostic throttle signal)
+- [x] Soft-limit warning at 80% of quota emitted as an MCP-spec `notifications/message` so the calling agent can throttle itself before hitting the hard limit — ✅ emitted from the tool-metrics wrapper on the request's SSE stream when any bucket is ≥80% consumed. **Best-effort** (a client that doesn't parse interim SSE frames won't see it; the `RateLimit-*`/`RateLimit-Policy` headers are the guaranteed fallback) — requires the `logging` server capability (now declared). Transport analysis: ADR-0010 §2
 
 **Audit logging (compliance-grade)**
 


### PR DESCRIPTION
## BL-033 Slice 5 — Per-client rate-limiting tiers

Advances the **"Rate limiting (per-client, contractual)"** AC block of BL-033 (External Pilot Phase 3). The sliding-window limiter already enforced in prod with flat hardcoded ceilings; this slice makes it **tier-aware** and closes all four ACs — while honoring the operator directive: tier numbers are **tunable, non-contractual capability config, NOT SLA quotas**.

### What ships
- **Tier-aware ceilings** (`ratelimit/tiers.ts`): `free-pilot` / `paid` / `enterprise` / `internal`. `internal` = the pre-Slice-5 60/1000/5/50 constants, so static `MCP_KEY_*` keys + OAuth human-consent (no tier) keep identical budgets — **no regression**.
- **Tier travels in the self-contained M2M token claim** → `AuthSuccess.tier` → `resolveTierLimits` → `createLimiter(env, limits)`. No KV re-fetch on the hot path (the ADR-0008 eventual-consistency corollary).
- **`RateLimit-Policy`** (IETF RateLimit-header fields) on every authenticated **200 and 429** — the transport-agnostic throttle signal.
- **80%-consumed soft-limit `notifications/message`** — best-effort on the request's SSE stream from the tool-metrics wrapper (required declaring the `logging` server capability); reports the bucket actually under pressure; `RateLimit-*` headers are the guaranteed fallback.
- **Radar caps reframed** as per-client fairness + cache-cold defense-in-depth (radar is ~99% cache hits; the circuit breaker is the real Inoreader-budget guard). Fixed the stale `RATE_LIMITS.md` "Phase 4" note; corrected the repo's "RFC 9331" mislabel (it's L4S ECN) in the load-bearing surface.
- **Provisioning guard**: unknown `tier` at `POST /admin/oauth/m2m-clients` now 400s instead of fail-generous to `internal`.
- Version 0.40.0 → 0.41.0.

### Decisions
[ADR-0010](../blob/feat/bl033-rate-limit-tiers/src/docs/adr/0010-per-client-rate-limit-tiers.md) records (1) tier-in-token-claim vs KV re-fetch and (2) the SSE notification-transport analysis.

### AC dispositions
All four rate-limiting ACs checked off in `BACKLOG.md` with recorded deviations (tier stored in **KV** not Redis; internal/OAuth-human default tier; AC-4 emission best-effort with documented client-side-consumption caveat).

### Verification
`npm run test:mcp` **1843 passing** · `npx astro check` 0 errors · `npm run lint` clean · `npm run test:docs` 11 passing. Two independent `code-reviewer` passes → APPROVE.

### Review gates
plan-reviewer ✅ (hash-bound) · code-reviewer ✅ (SHA-bound to HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
