### PR TITLE
docs(mcp): retire the last live-tense references to the destroyed gst-radar-tokens DB

### DIFF
--- a/mcp-server/src/docs/operations/RATE_LIMITS.md
+++ b/mcp-server/src/docs/operations/RATE_LIMITS.md
@@ -211,9 +211,9 @@ In practice usage is far below the per-key caps (analytical sessions, not bot lo
 The breaker auto-closes after 6 hours via TTL. Because nothing repopulates the radar cache while it is open (BL-091 — every read surface is cache-only, and the cron skips), **manual reset is the only way to recover before the TTL expires** if Inoreader comes back early. Check `/status` (or `/health`'s `circuitOpen`) to confirm the breaker is what's holding radar on stale data:
 
 ```bash
-# Connect to Upstash via the CLI or REST API and delete the key. Path 2:
-# the circuit-breaker flag lives in the MCP DB (mcp:* namespace), so use
-# the MCP-DB credentials, NOT the Inoreader-DB Read-Only token.
+# Connect to Upstash via the CLI or REST API and delete the key. The
+# circuit-breaker flag lives in the sole MCP DB (`gst-mcp`, mcp:* namespace) —
+# use the UPSTASH_MCP_REST_* credentials.
 redis-cli -u $UPSTASH_MCP_REST_URL DEL mcp:radar:circuit-open
 # Or via @upstash/redis console (MCP DB)
 ```

--- a/mcp-server/src/docs/operations/RATE_LIMITS.md
+++ b/mcp-server/src/docs/operations/RATE_LIMITS.md
@@ -211,11 +211,11 @@ In practice usage is far below the per-key caps (analytical sessions, not bot lo
 The breaker auto-closes after 6 hours via TTL. Because nothing repopulates the radar cache while it is open (BL-091 — every read surface is cache-only, and the cron skips), **manual reset is the only way to recover before the TTL expires** if Inoreader comes back early. Check `/status` (or `/health`'s `circuitOpen`) to confirm the breaker is what's holding radar on stale data:
 
 ```bash
-# Connect to Upstash via the CLI or REST API and delete the key. The
-# circuit-breaker flag lives in the sole MCP DB (`gst-mcp`, mcp:* namespace) —
-# use the UPSTASH_MCP_REST_* credentials.
-redis-cli -u $UPSTASH_MCP_REST_URL DEL mcp:radar:circuit-open
-# Or via @upstash/redis console (MCP DB)
+# Delete the key over the Upstash REST API. The circuit-breaker flag lives
+# in the sole MCP DB (`gst-mcp`, mcp:* namespace) — use the
+# UPSTASH_MCP_REST_* credentials (set as env vars; never inline the token).
+curl -H "Authorization: Bearer $UPSTASH_MCP_REST_TOKEN" "$UPSTASH_MCP_REST_URL/del/mcp:radar:circuit-open"
+# Or via the Upstash console: gst-mcp DB -> CLI tab -> DEL mcp:radar:circuit-open
 ```
 
 **Don't manually reset reflexively** — if Inoreader is still degraded, you'll just trigger another circuit-open seconds later, burning more budget. Wait for Inoreader's status page to show "operational" first.
@@ -240,4 +240,4 @@ The general tier still applies to radar calls — they count toward the general 
 
 ---
 
-_Last updated: 2026-05-31 (BL-038 — radar tier shipped)_
+_Last updated: 2026-07-27 (stale gst-radar-tokens references retired; circuit-breaker reset command corrected to the REST API)_

--- a/mcp-server/src/lib/upstash-cache-store.ts
+++ b/mcp-server/src/lib/upstash-cache-store.ts
@@ -11,9 +11,10 @@
  *
  * **Namespace discipline (Q13 / Path 2)**: this store talks ONLY to the MCP
  * DB via `createMcpClient(env)`. All keys written here use the `mcp:` prefix
- * (cache snapshots, rate-limit counters, circuit-breaker flags); the Worker
- * never reads `inoreader:*` through this store — that path goes through
- * `inoreader-token-store.ts` against the Inoreader DB's Read-Only client.
+ * (cache snapshots, rate-limit counters, circuit-breaker flags); Inoreader
+ * OAuth token state is never touched through this store — that path goes
+ * through `inoreader-token-store.ts` (`mcp:inoreader:*` in the same MCP DB;
+ * the legacy website Inoreader DB was retired in BL-032.8 Phase B).
  */
 
 import { safeLog } from '../auth/safe-logger';


### PR DESCRIPTION
## Why

The legacy `gst-radar-tokens` Upstash database was permanently destroyed 2026-05-27 (BL-032.8 Phase B). A full sweep of both workspaces (triggered by the operator catching a stale reference) found the doc tree almost entirely correct — every other mention is a past-tense historical record — except two spots that still presented the destroyed DB as live infrastructure, plus one broken runbook command found during review.

## What

- **`mcp-server/src/lib/upstash-cache-store.ts`** — header docstring claimed Inoreader token reads go "against the Inoreader DB's Read-Only client". That client, its bindings, and the DB itself no longer exist; tokens live in the sole MCP DB (`mcp:inoreader:*` via `inoreader-token-store.ts`). Comment corrected.
- **`mcp-server/src/docs/operations/RATE_LIMITS.md`** (circuit-breaker manual-reset runbook):
  - Dropped the instruction contrasting MCP-DB credentials with "the Inoreader-DB Read-Only token" — a credential an operator mid-incident could waste time hunting for.
  - Replaced `redis-cli -u $UPSTASH_MCP_REST_URL …` (redis-cli cannot speak to a REST endpoint — the command could never connect) with the equivalent Upstash REST `curl` call, consistent with the same key's deletion procedure in DEPLOY.md, secrets via env vars.
  - Bumped the `_Last updated:_` footer.

## Verification

- `npm -w @gst/mcp-server run typecheck` — green (comment-only .ts change)
- `npm run test:docs` — green (11/11)
- Impl-review gate: code-reviewer APPROVE ×2 (initial + incremental re-review after the runbook-command fix), marker bound to HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)
