### PR TITLE
refactor(seo): give the six hub tool pages one WebApplication schema (BL-099)

### DIFF
--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -291,24 +291,6 @@ None of these are currently load-bearing for active partners. Revisit when (a) C
 
 ## Infrastructure
 
-### BL-099: Extract the shared `WebApplication` JSON-LD block from the six hub tool pages
-
-**Source**: noticed while adding the missing schema to the IRL generator (2026-07-31, `fix/seo-indexability-radar-ssr`) | **Effort**: Small | **Status**: Open
-
-**As a** maintainer, **I want** one helper emitting the tool-page `WebApplication` schema **so that** the shared `author` / `publisher` / `offers` blocks cannot drift apart across six copies.
-
-All six pages under `src/pages/hub/tools/` inline a near-identical literal differing only in `name`, `description`, `featureList` and the two dates. The drift is already real rather than hypothetical: the IRL generator's copy shipped without the `knowsAbout` array its five siblings carry (fixed on landing), and a guessed `datePublished` that post-dated the page by five weeks (corrected against `git log`).
-
-Deliberately **not** done in the branch that noticed it: a six-page refactor of unrelated tool pages would have expanded an indexability fix into five pages that have nothing to do with it (Directive 13). Filed rather than carried silently — that is the difference between out-of-scope and deferred debt.
-
-#### Acceptance Criteria
-
-- [ ] A helper in `src/utils/` takes `{ name, description, featureList, datePublished, dateModified }` and emits the schema
-- [ ] All six tool pages use it; the shared `author` / `publisher` / `offers` / `knowsAbout` blocks exist once
-- [ ] A test asserts every **tool** page — `src/pages/hub/tools/*/index.astro` — emits `WebApplication`, the gap that let the IRL generator ship without one. Note `tools/index.astro` is the listing page and correctly emits `ItemList`; a test scoped to `tools/` rather than `tools/*/` would either fail or invite "fixing" that page's schema to the wrong type
-
----
-
 ### BL-098: Radar negative caching — a failed revalidation is cached as a 200
 
 **Source**: accepted trade-off of inlining the Radar feed (2026-07-31, `fix/seo-indexability-radar-ssr`) | **Effort**: Medium — the naive fix is worse than the problem | **Status**: Open, do not implement without the trigger

--- a/src/docs/seo/JSON_LD_SCHEMA.md
+++ b/src/docs/seo/JSON_LD_SCHEMA.md
@@ -533,7 +533,7 @@ When creating a new hub tool:
 1. Import `hubToolSchema` from `src/utils/hub-tool-schema.ts` and call it inside the page's `set:html` — do **not** copy another page's JSON-LD literal
 2. Set tool-specific `name`, `description`, and `featureList`
 3. Set `datePublished` to the launch date, `dateModified` to today
-4. Customize the `knowsAbout` array for the tool's domain (4–5 items, always including "Technical Due Diligence" and "M&A Tech Strategy")
+4. Customize the `knowsAbout` array for the tool's domain (4–5 distinct items, always including "Technical Due Diligence" and "M&A Tech Strategy" — enforced by `tests/unit/hub-tool-schema.test.ts`)
 5. Add the tool to the `ItemList` on the tools landing page
 6. Update this document with the new tool's details, and the expected-page list in `tests/unit/hub-tool-schema.test.ts`
 7. Validate with Google Structured Data Testing Tool

--- a/src/docs/seo/JSON_LD_SCHEMA.md
+++ b/src/docs/seo/JSON_LD_SCHEMA.md
@@ -36,7 +36,7 @@ ProfessionalService (Organization)
 ├── knowsAbout: [10 expertise areas]
 └── address: PostalAddress
 
-WebApplication (per hub tool — 5 tools)
+WebApplication (per hub tool — 6 tools, built by src/utils/hub-tool-schema.ts)
 ├── name, description, applicationCategory
 ├── operatingSystem: "Web"
 ├── offers: Free
@@ -47,7 +47,7 @@ WebApplication (per hub tool — 5 tools)
 
 ItemList (hub tools landing page)
 ├── name: GST Strategic Intelligence Tools
-├── numberOfItems: 5
+├── numberOfItems: 6
 └── itemListElement: [ListItem with position, name, url]
 
 BreadcrumbList (per-page, non-homepage only)
@@ -401,7 +401,24 @@ Describes each hub tool as a free, browser-based web application with author exp
 
 Google supports both types for rich results (price, ratings). `WebApplication` additionally supports `browserRequirements` if needed in the future.
 
+### Where it comes from
+
+Tool pages do **not** hand-write this block. `src/utils/hub-tool-schema.ts` exports `hubToolSchema()`,
+which owns every shared field; each page passes only its six per-tool values:
+
+```astro
+set:html={JSON.stringify(
+  hubToolSchema({ name, description, featureList, knowsAbout, datePublished, dateModified })
+)}
+```
+
+Before BL-099 the block was copy-pasted into all six pages and drifted — one page shipped with no
+`knowsAbout` array and a `datePublished` five weeks off. `tests/unit/hub-tool-schema.test.ts` now
+asserts every `src/pages/hub/tools/*/index.astro` renders its JSON-LD script from the helper.
+
 ### Schema Template
+
+The shape the helper emits:
 
 ```json
 {
@@ -450,7 +467,10 @@ Google supports both types for rich results (price, ratings). `WebApplication` a
 | `featureList` | Array[String] | Key capabilities of the tool | Recommended |
 | `author` | Person | Reid Peryam with tool-specific `knowsAbout` | Yes |
 
-### Current Tool Schemas (5 Tools)
+Only `name`, `description`, `featureList`, `knowsAbout`, `datePublished` and `dateModified` are
+per-tool parameters. Everything else is a constant inside the helper.
+
+### Current Tool Schemas (6 Tools)
 
 #### 1. The Diligence Machine
 
@@ -497,16 +517,25 @@ Google supports both types for rich results (price, ratings). `WebApplication` a
 | **featureList** | 120+ regulations across 4 categories, Interactive D3 world map, Jurisdiction-specific compliance details, Data privacy/AI governance/cybersecurity/industry compliance |
 | **knowsAbout** | Regulatory Compliance, Data Privacy, AI Governance, Technical Due Diligence, M&A Tech Strategy |
 
+#### 6. Information Request List Generator
+
+| Field | Value |
+|-------|-------|
+| **File** | `src/pages/hub/tools/information-request-list-generator/index.astro` |
+| **datePublished** | 2026-05-25 |
+| **featureList** | Fillable .xlsx workbook generated client-side, Per-section selection mirroring VDR folder structure, Engagement-specific custom requests, Context-aware request removal |
+| **knowsAbout** | Technical Due Diligence, Information Request Lists, Virtual Data Room Structure, M&A Tech Strategy |
+
 ### Adding a New Tool
 
 When creating a new hub tool:
 
-1. Copy the WebApplication JSON-LD template into the tool's `index.astro`
+1. Import `hubToolSchema` from `src/utils/hub-tool-schema.ts` and call it inside the page's `set:html` — do **not** copy another page's JSON-LD literal
 2. Set tool-specific `name`, `description`, and `featureList`
 3. Set `datePublished` to the launch date, `dateModified` to today
-4. Customize the `knowsAbout` array for the tool's domain (keep 5 items, always include "Technical Due Diligence" and "M&A Tech Strategy")
+4. Customize the `knowsAbout` array for the tool's domain (4–5 items, always including "Technical Due Diligence" and "M&A Tech Strategy")
 5. Add the tool to the `ItemList` on the tools landing page
-6. Update this document with the new tool's details
+6. Update this document with the new tool's details, and the expected-page list in `tests/unit/hub-tool-schema.test.ts`
 7. Validate with Google Structured Data Testing Tool
 
 ### Updating dateModified
@@ -531,41 +560,50 @@ Describes the tools collection page as an ordered list of web applications, enab
   "@type": "ItemList",
   "name": "GST Strategic Intelligence Tools",
   "description": "Interactive calculators and generators to quantify risk and value in technology investments",
-  "numberOfItems": 5,
+  "numberOfItems": 6,
   "itemListElement": [
     {
       "@type": "ListItem",
       "position": 1,
       "name": "Regulatory Map",
-      "url": "https://globalstrategic.tech/hub/tools/regulatory-map"
+      "url": "https://globalstrategic.tech/hub/tools/regulatory-map/"
     },
     {
       "@type": "ListItem",
       "position": 2,
       "name": "The Diligence Machine",
-      "url": "https://globalstrategic.tech/hub/tools/diligence-machine"
+      "url": "https://globalstrategic.tech/hub/tools/diligence-machine/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "Technical Debt Cost Calculator",
-      "url": "https://globalstrategic.tech/hub/tools/tech-debt-calculator"
+      "url": "https://globalstrategic.tech/hub/tools/tech-debt-calculator/"
     },
     {
       "@type": "ListItem",
       "position": 4,
       "name": "Infrastructure Cost Governance",
-      "url": "https://globalstrategic.tech/hub/tools/infrastructure-cost-governance"
+      "url": "https://globalstrategic.tech/hub/tools/infrastructure-cost-governance/"
     },
     {
       "@type": "ListItem",
       "position": 5,
       "name": "TechPar",
-      "url": "https://globalstrategic.tech/hub/tools/techpar"
+      "url": "https://globalstrategic.tech/hub/tools/techpar/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "name": "Information Request List Generator",
+      "url": "https://globalstrategic.tech/hub/tools/information-request-list-generator/"
     }
   ]
 }
 ```
+
+URLs carry a trailing slash, matching the site's `trailingSlash: true` canonicalization in
+`vercel.json`.
 
 ### File Location
 
@@ -783,6 +821,7 @@ Example:
 - [ ] publisher organizations have proper @type
 - [ ] Hub tools use `WebApplication` (not `SoftwareApplication`)
 - [ ] Hub tools have `author`, `datePublished`, `dateModified`, and `featureList`
+- [ ] Hub tool schemas come from `hubToolSchema()`, not a pasted literal
 - [ ] ItemList `numberOfItems` matches actual tool count
 - [ ] ItemList positions match visual page order
 
@@ -831,7 +870,8 @@ npm run test:all
 
 #### Step 1: Edit the Appropriate File
 - **Organization/Person**: `src/components/SEO.astro`
-- **Hub Tools**: `src/pages/hub/tools/[tool-name]/index.astro`
+- **Hub Tools — shared fields** (`offers`, `publisher`, `author`, `applicationCategory`, `operatingSystem`): `src/utils/hub-tool-schema.ts` — one edit changes all six tools
+- **Hub Tools — per-tool fields** (`name`, `description`, `featureList`, `knowsAbout`, dates): `src/pages/hub/tools/[tool-name]/index.astro`
 - **Tools Landing**: `src/pages/hub/tools/index.astro`
 
 #### Step 2: Validate
@@ -875,6 +915,6 @@ Recommendation: Keep important credentials even if expired (shows comprehensive 
 
 ---
 
-**Last Updated**: March 22, 2026
-**Schema Version**: 3.0
+**Last Updated**: August 1, 2026
+**Schema Version**: 3.1
 **Validation Status**: ✓ Compliant

--- a/src/docs/seo/README.md
+++ b/src/docs/seo/README.md
@@ -20,7 +20,7 @@ The GST website implements a high-authority SEO foundation designed to maximize 
 
 ## Key Features
 
-- **JSON-LD Structured Data**: ProfessionalService, Person, BreadcrumbList, and FAQPage schemas with complete credential information
+- **JSON-LD Structured Data**: ProfessionalService, Person, BreadcrumbList, FAQPage, WebApplication (per hub tool) and ItemList schemas with complete credential information
 - **Open Graph Tags**: Optimized for social media sharing across LinkedIn, Twitter, and other platforms
 - **Meta Tags**: Title, description, keywords, author, and robots directives
 - **Sitemap & Robots**: Automated crawling configuration for search engines

--- a/src/pages/hub/tools/diligence-machine/index.astro
+++ b/src/pages/hub/tools/diligence-machine/index.astro
@@ -4,6 +4,7 @@ import HubHeader from '../../../../components/hub/HubHeader.astro';
 import { WIZARD_STEPS } from '../../../../data/diligence-machine/wizard-config';
 import DeltaIcon from '../../../../components/DeltaIcon.astro';
 import '../../../../styles/components/progress.css';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 ---
 
 <BaseLayout
@@ -18,32 +19,20 @@ import '../../../../styles/components/progress.css';
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'The Diligence Machine',
-      description:
-        'Generate a customized technology due diligence agenda with 15-20 high-impact questions organized by topic',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2025-06-01',
-      dateModified: '2026-03-22',
-      featureList: [
-        '14-dimension conditional matching',
-        '15-20 prioritized questions per agenda',
-        'Client-side processing — no deal data transmitted',
-        'Attention area risk flagging',
-        'PDF export and clipboard copy',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'The Diligence Machine',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Generate a customized technology due diligence agenda with 15-20 high-impact questions organized by topic',
+        datePublished: '2025-06-01',
+        dateModified: '2026-03-22',
+        featureList: [
+          '14-dimension conditional matching',
+          '15-20 prioritized questions per agenda',
+          'Client-side processing — no deal data transmitted',
+          'Attention area risk flagging',
+          'PDF export and clipboard copy',
+        ],
         knowsAbout: [
           'Technical Due Diligence',
           'M&A Tech Strategy',
@@ -51,8 +40,8 @@ import '../../../../styles/components/progress.css';
           'PE Portfolio Technology',
           'Software Architecture Evaluation',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="diligence-machine">

--- a/src/pages/hub/tools/information-request-list-generator/index.astro
+++ b/src/pages/hub/tools/information-request-list-generator/index.astro
@@ -4,6 +4,7 @@ import HubHeader from '../../../../components/hub/HubHeader.astro';
 import DeltaIcon from '../../../../components/DeltaIcon.astro';
 import articleBodyRaw from '../../../../data/irl/information-request-list.md?raw';
 import { parseIrlArticle } from '../../../../utils/irl/parse-article';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 
 // Parse the IRL generator source at build time so the section checkboxes render
 // server-side. Client-created DOM does NOT receive Astro's scoped-style
@@ -36,39 +37,27 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'Information Request List Generator',
-      description:
-        'Generate a fillable .xlsx Information Request List personalized to a target or client, from the canonical GST IRL',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2026-05-25',
-      dateModified: '2026-07-31',
-      featureList: [
-        'Fillable .xlsx workbook generated client-side',
-        'Per-section selection mirroring VDR folder structure',
-        'Engagement-specific custom requests',
-        'Context-aware request removal',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'Information Request List Generator',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Generate a fillable .xlsx Information Request List personalized to a target or client, from the canonical GST IRL',
+        datePublished: '2026-05-25',
+        dateModified: '2026-07-31',
+        featureList: [
+          'Fillable .xlsx workbook generated client-side',
+          'Per-section selection mirroring VDR folder structure',
+          'Engagement-specific custom requests',
+          'Context-aware request removal',
+        ],
         knowsAbout: [
           'Technical Due Diligence',
           'Information Request Lists',
           'Virtual Data Room Structure',
           'M&A Tech Strategy',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="irl-gen">

--- a/src/pages/hub/tools/infrastructure-cost-governance/index.astro
+++ b/src/pages/hub/tools/infrastructure-cost-governance/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubHeader from '../../../../components/hub/HubHeader.astro';
 import { DOMAINS, TOTAL_QUESTIONS } from '../../../../data/infrastructure-cost-governance/domains';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 
 const domainCount = DOMAINS.length;
 ---
@@ -18,31 +19,19 @@ const domainCount = DOMAINS.length;
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'Infrastructure Cost Governance',
-      description:
-        'Cloud cost maturity assessment across six operational domains for PE diligence, board reviews, and 100-day planning',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2026-03-01',
-      dateModified: '2026-03-21',
-      featureList: [
-        '20 questions across 6 cloud cost domains',
-        'Scored diagnostic with benchmarks',
-        'Prioritized improvement checklist',
-        'Shareable results for board reviews',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'Infrastructure Cost Governance',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Cloud cost maturity assessment across six operational domains for PE diligence, board reviews, and 100-day planning',
+        datePublished: '2026-03-01',
+        dateModified: '2026-03-21',
+        featureList: [
+          '20 questions across 6 cloud cost domains',
+          'Scored diagnostic with benchmarks',
+          'Prioritized improvement checklist',
+          'Shareable results for board reviews',
+        ],
         knowsAbout: [
           'Cloud Cost Optimization',
           'Infrastructure Governance',
@@ -50,8 +39,8 @@ const domainCount = DOMAINS.length;
           'Technical Due Diligence',
           'M&A Tech Strategy',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="icg-section">

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -35,6 +35,7 @@ const faqItems = [
 ];
 
 import DeltaIcon from '../../../../components/DeltaIcon.astro';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 ---
 
 <BaseLayout
@@ -55,31 +56,19 @@ import DeltaIcon from '../../../../components/DeltaIcon.astro';
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'Regulatory Map',
-      description:
-        'Interactive map of 120+ global data privacy, AI governance, cybersecurity, and compliance regulations across jurisdictions',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2026-01-15',
-      dateModified: '2026-03-22',
-      featureList: [
-        '120+ regulations across 4 categories',
-        'Interactive D3 world map',
-        'Jurisdiction-specific compliance details',
-        'Data privacy, AI governance, cybersecurity, and industry compliance',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'Regulatory Map',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Interactive map of 120+ global data privacy, AI governance, cybersecurity, and compliance regulations across jurisdictions',
+        datePublished: '2026-01-15',
+        dateModified: '2026-03-22',
+        featureList: [
+          '120+ regulations across 4 categories',
+          'Interactive D3 world map',
+          'Jurisdiction-specific compliance details',
+          'Data privacy, AI governance, cybersecurity, and industry compliance',
+        ],
         knowsAbout: [
           'Regulatory Compliance',
           'Data Privacy',
@@ -87,8 +76,8 @@ import DeltaIcon from '../../../../components/DeltaIcon.astro';
           'Technical Due Diligence',
           'M&A Tech Strategy',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="regulatory-map-section">

--- a/src/pages/hub/tools/tech-debt-calculator/index.astro
+++ b/src/pages/hub/tools/tech-debt-calculator/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubHeader from '../../../../components/hub/HubHeader.astro';
 import PrintReportHeader from '../../../../components/PrintReportHeader.astro';
 import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engine';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 ---
 
 <BaseLayout
@@ -17,31 +18,19 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'Technical Debt Cost Calculator',
-      description:
-        'Quantify the annual carrying cost of technical debt for PE diligence and portfolio executive conversations',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2025-06-01',
-      dateModified: '2026-03-20',
-      featureList: [
-        'Annual carrying cost quantification',
-        'Team size and salary inputs',
-        'Maintenance burden and delivery metrics',
-        'Defensible estimates for PE conversations',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'Technical Debt Cost Calculator',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Quantify the annual carrying cost of technical debt for PE diligence and portfolio executive conversations',
+        datePublished: '2025-06-01',
+        dateModified: '2026-03-20',
+        featureList: [
+          'Annual carrying cost quantification',
+          'Team size and salary inputs',
+          'Maintenance burden and delivery metrics',
+          'Defensible estimates for PE conversations',
+        ],
         knowsAbout: [
           'Technical Due Diligence',
           'Technical Debt Assessment',
@@ -49,8 +38,8 @@ import { DEPLOY_OPTIONS, DEFAULT_STATE } from '../../../../utils/tech-debt-engin
           'DORA Metrics',
           'Software Engineering Economics',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="tdc-section">

--- a/src/pages/hub/tools/techpar/index.astro
+++ b/src/pages/hub/tools/techpar/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubHeader from '../../../../components/hub/HubHeader.astro';
 import DeltaIcon from '../../../../components/DeltaIcon.astro';
 import PresetInput from '../../../../components/techpar/PresetInput.astro';
+import { hubToolSchema } from '../../../../utils/hub-tool-schema';
 ---
 
 <BaseLayout
@@ -17,31 +18,19 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
   <script
     is:inline
     type="application/ld+json"
-    set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'TechPar',
-      description:
-        'Technology cost structure analysis tool for PE diligence and portfolio company benchmarking',
-      applicationCategory: 'BusinessApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-      publisher: { '@type': 'Organization', name: 'Global Strategic Technologies' },
-      datePublished: '2026-02-01',
-      dateModified: '2026-03-22',
-      featureList: [
-        'Blended technology cost ratio',
-        'Stage-adjusted benchmarking',
-        '36-month trajectory projection',
-        'Infrastructure, personnel, and R&D breakdown',
-      ],
-      author: {
-        '@type': 'Person',
-        name: 'Reid Peryam',
-        jobTitle: 'Strategic Technology Advisor',
-        sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    set:html={JSON.stringify(
+      hubToolSchema({
+        name: 'TechPar',
         description:
-          'Technology advisor with experience across 100+ PE technology diligence engagements',
+          'Technology cost structure analysis tool for PE diligence and portfolio company benchmarking',
+        datePublished: '2026-02-01',
+        dateModified: '2026-03-22',
+        featureList: [
+          'Blended technology cost ratio',
+          'Stage-adjusted benchmarking',
+          '36-month trajectory projection',
+          'Infrastructure, personnel, and R&D breakdown',
+        ],
         knowsAbout: [
           'Technology Cost Benchmarking',
           'SaaS Metrics',
@@ -49,8 +38,8 @@ import PresetInput from '../../../../components/techpar/PresetInput.astro';
           'M&A Tech Strategy',
           'Infrastructure Cost Analysis',
         ],
-      },
-    })}
+      })
+    )}
   />
 
   <section class="techpar-section">

--- a/src/utils/hub-tool-schema.ts
+++ b/src/utils/hub-tool-schema.ts
@@ -1,0 +1,74 @@
+/**
+ * `WebApplication` JSON-LD for the hub tool pages.
+ *
+ * Every page under `src/pages/hub/tools/<tool>/` describes itself to crawlers
+ * with the same schema shape, differing only in the per-tool fields below.
+ * Those literals used to be copy-pasted into all six pages, and they drifted:
+ * the IRL generator shipped without the `knowsAbout` array its five siblings
+ * carried, plus a guessed `datePublished` that post-dated the page by five
+ * weeks (BL-099). This module is the single definition, so the shared blocks
+ * cannot fall out of sync again.
+ *
+ * The emitted key order is deliberate — it reproduces the inline literals this
+ * replaced, so the refactor is provably byte-identical in `dist/`. Reordering
+ * is semantically harmless to JSON-LD but destroys that proof; don't.
+ *
+ * Doc: src/docs/seo/JSON_LD_SCHEMA.md § Hub Tools: WebApplication Schema.
+ */
+
+/** Every tool is free and browser-based, published by GST. */
+const OFFERS = { '@type': 'Offer', price: '0', priceCurrency: 'USD' } as const;
+const PUBLISHER = { '@type': 'Organization', name: 'Global Strategic Technologies' } as const;
+const APPLICATION_CATEGORY = 'BusinessApplication';
+const OPERATING_SYSTEM = 'Web';
+
+/**
+ * The author identity shared by every tool. `knowsAbout` is deliberately NOT
+ * here: it is per-tool expertise signalling and all six arrays differ, so
+ * hoisting it would delete real signal from five pages. BL-099's acceptance
+ * criteria described it as shared — that was wrong about the code, and this
+ * comment is the durable record of why the helper takes it as a parameter.
+ */
+const AUTHOR = {
+  '@type': 'Person',
+  name: 'Reid Peryam',
+  jobTitle: 'Strategic Technology Advisor',
+  sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+  description: 'Technology advisor with experience across 100+ PE technology diligence engagements',
+} as const;
+
+export interface HubToolSchemaInput {
+  /** Tool display name, e.g. `'TechPar'`. */
+  name: string;
+  /** One-sentence description for search results. */
+  description: string;
+  /** Key capabilities — 4-5 short phrases. */
+  featureList: string[];
+  /**
+   * Tool-specific expertise areas. Keep 4-5 items and always include
+   * 'Technical Due Diligence' and 'M&A Tech Strategy'.
+   */
+  knowsAbout: string[];
+  /** Launch date, `YYYY-MM-DD`. */
+  datePublished: string;
+  /** Last significant update, `YYYY-MM-DD`. See the doc for what counts. */
+  dateModified: string;
+}
+
+/** Build the `WebApplication` JSON-LD object for one hub tool page. */
+export function hubToolSchema(tool: HubToolSchemaInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: tool.name,
+    description: tool.description,
+    applicationCategory: APPLICATION_CATEGORY,
+    operatingSystem: OPERATING_SYSTEM,
+    offers: OFFERS,
+    publisher: PUBLISHER,
+    datePublished: tool.datePublished,
+    dateModified: tool.dateModified,
+    featureList: tool.featureList,
+    author: { ...AUTHOR, knowsAbout: tool.knowsAbout },
+  };
+}

--- a/tests/unit/hub-tool-schema.test.ts
+++ b/tests/unit/hub-tool-schema.test.ts
@@ -48,6 +48,17 @@ const ldJsonElements = (src: string) =>
   scriptElements(src).filter((el) => el.includes('type="application/ld+json"'));
 
 /**
+ * The `knowsAbout` entries a page passes to the helper, read out of its JSON-LD
+ * element. Read from source rather than by importing the page, because .astro
+ * components can't be evaluated under vitest's node environment.
+ */
+function knowsAboutOf(src: string): string[] {
+  const [element] = ldJsonElements(src);
+  const block = element?.match(/knowsAbout:\s*\[([\s\S]*?)\]/)?.[1] ?? '';
+  return [...block.matchAll(/'((?:[^'\\]|\\.)*)'/g)].map((m) => m[1].replace(/\\'/g, "'"));
+}
+
+/**
  * Tool pages are `hub/tools/<tool>/index.astro`. The bare `hub/tools/index.astro`
  * is the LISTING page and is deliberately excluded — it correctly emits
  * `ItemList`, so a scan scoped to `tools/` rather than to its subdirectories
@@ -149,6 +160,18 @@ describe('every hub tool page emits WebApplication JSON-LD', () => {
     // appear inside THIS element's `set:html`. Attribute order is not assumed.
     const [element] = ldJsonElements(read(TOOLS_DIR, tool, 'index.astro'));
     expect(element).toMatch(/set:html=\{JSON\.stringify\(\s*hubToolSchema\(/);
+  });
+
+  it.each(TOOL_PAGES)('%s passes a well-formed knowsAbout array', (tool) => {
+    // Makes JSON_LD_SCHEMA.md § Adding a New Tool step 4 executable rather than
+    // merely documented. An OMITTED knowsAbout is already a type error — that
+    // was the original BL-099 defect — but an empty or truncated one is not,
+    // and it degrades the same author-expertise signal just as silently.
+    const knowsAbout = knowsAboutOf(read(TOOLS_DIR, tool, 'index.astro'));
+    expect(knowsAbout.length).toBeGreaterThanOrEqual(4);
+    expect(knowsAbout.length).toBeLessThanOrEqual(5);
+    expect(knowsAbout).toContain('Technical Due Diligence');
+    expect(knowsAbout).toContain('M&A Tech Strategy');
   });
 });
 

--- a/tests/unit/hub-tool-schema.test.ts
+++ b/tests/unit/hub-tool-schema.test.ts
@@ -49,13 +49,27 @@ const ldJsonElements = (src: string) =>
 
 /**
  * The `knowsAbout` entries a page passes to the helper, read out of its JSON-LD
- * element. Read from source rather than by importing the page, because .astro
- * components can't be evaluated under vitest's node environment.
+ * element — or `null` if the array literal could not be located at all. Read
+ * from source rather than by importing the page, because .astro components
+ * can't be evaluated under vitest's node environment.
+ *
+ * `null` rather than `[]` on a parse miss so the caller can report "couldn't
+ * find the array" distinctly from "the array is too short". Otherwise a page
+ * that hoists its array to a named const surfaces as a content defect that
+ * isn't there, sending the next author hunting for the wrong bug.
+ *
+ * BOTH quote styles are matched. `.prettierrc.json` sets `singleQuote: true`,
+ * which flips an apostrophe-bearing string to DOUBLE quotes — so a future
+ * entry like "Founders' Diligence" is double-quoted in a file that is
+ * otherwise uniformly single-quoted.
  */
-function knowsAboutOf(src: string): string[] {
+function knowsAboutOf(src: string): string[] | null {
   const [element] = ldJsonElements(src);
-  const block = element?.match(/knowsAbout:\s*\[([\s\S]*?)\]/)?.[1] ?? '';
-  return [...block.matchAll(/'((?:[^'\\]|\\.)*)'/g)].map((m) => m[1].replace(/\\'/g, "'"));
+  const block = element?.match(/knowsAbout:\s*\[([\s\S]*?)\]/)?.[1];
+  if (block === undefined) return null;
+  return [...block.matchAll(/(['"])((?:\\.|(?!\1)[^\\])*)\1/g)].map((m) =>
+    m[2].replace(/\\(.)/g, '$1')
+  );
 }
 
 /**
@@ -168,10 +182,14 @@ describe('every hub tool page emits WebApplication JSON-LD', () => {
     // was the original BL-099 defect — but an empty or truncated one is not,
     // and it degrades the same author-expertise signal just as silently.
     const knowsAbout = knowsAboutOf(read(TOOLS_DIR, tool, 'index.astro'));
-    expect(knowsAbout.length).toBeGreaterThanOrEqual(4);
-    expect(knowsAbout.length).toBeLessThanOrEqual(5);
+    expect(knowsAbout, 'knowsAbout array literal not found in the JSON-LD element').not.toBeNull();
+    expect(knowsAbout!.length).toBeGreaterThanOrEqual(4);
+    expect(knowsAbout!.length).toBeLessThanOrEqual(5);
     expect(knowsAbout).toContain('Technical Due Diligence');
     expect(knowsAbout).toContain('M&A Tech Strategy');
+    // Padding a short array with a duplicate satisfies the count while adding
+    // no expertise signal, which is the thing the count is a proxy for.
+    expect(new Set(knowsAbout)).toHaveProperty('size', knowsAbout!.length);
   });
 });
 

--- a/tests/unit/hub-tool-schema.test.ts
+++ b/tests/unit/hub-tool-schema.test.ts
@@ -187,9 +187,12 @@ describe('every hub tool page emits WebApplication JSON-LD', () => {
     expect(knowsAbout!.length).toBeLessThanOrEqual(5);
     expect(knowsAbout).toContain('Technical Due Diligence');
     expect(knowsAbout).toContain('M&A Tech Strategy');
-    // Padding a short array with a duplicate satisfies the count while adding
-    // no expertise signal, which is the thing the count is a proxy for.
-    expect(new Set(knowsAbout)).toHaveProperty('size', knowsAbout!.length);
+    // Padding a short array with a duplicate or a blank satisfies the count
+    // while adding no expertise signal, which is the thing the count proxies
+    // for. `toEqual` against the deduped array rather than comparing sizes:
+    // the failure diff points a `+` at the offending entry.
+    expect(knowsAbout).toEqual([...new Set(knowsAbout)]);
+    expect(knowsAbout!.filter((topic) => topic.trim() === '')).toEqual([]);
   });
 });
 

--- a/tests/unit/hub-tool-schema.test.ts
+++ b/tests/unit/hub-tool-schema.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Hub tool `WebApplication` JSON-LD — the helper's contract, and the guarantee
+ * that every tool page actually emits it.
+ *
+ * BL-099: the six tool pages each inlined their own near-identical copy of this
+ * schema, and the copies drifted — the IRL generator shipped with no
+ * `knowsAbout` array and a `datePublished` five weeks off. Nothing caught it,
+ * because no test in the repo asserted on JSON-LD at all.
+ *
+ * The helper is IMPORTED, not string-matched: `src/utils/` is inside
+ * vitest.config.ts's coverage include, so scanning it as text would add an
+ * uncovered file while proving less.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { hubToolSchema } from '../../src/utils/hub-tool-schema';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const TOOLS_DIR = join(REPO_ROOT, 'src', 'pages', 'hub', 'tools');
+
+const read = (...seg: string[]) => readFileSync(join(...seg), 'utf-8');
+
+/**
+ * The `<script …/>` elements in an .astro source, each as one string.
+ *
+ * Splitting into elements is what makes the JSON-LD assertions load-bearing.
+ * Asserting "the page has an ld+json script" and "the page has a set:html
+ * calling hubToolSchema" as two independent facts about the whole FILE is
+ * satisfiable by two different elements — verified by mutation: moving the
+ * helper call to a second, non-ld+json script left both file-level assertions
+ * green while the schema element rendered an unrelated variable. Binding both
+ * facts to the same element string closes that.
+ */
+function scriptElements(src: string): string[] {
+  return src
+    .split(/<script\b/)
+    .slice(1)
+    .map((chunk) => {
+      const ends = [chunk.indexOf('/>'), chunk.indexOf('</script>')].filter((i) => i >= 0);
+      return chunk.slice(0, ends.length ? Math.min(...ends) : chunk.length);
+    });
+}
+
+const ldJsonElements = (src: string) =>
+  scriptElements(src).filter((el) => el.includes('type="application/ld+json"'));
+
+/**
+ * Tool pages are `hub/tools/<tool>/index.astro`. The bare `hub/tools/index.astro`
+ * is the LISTING page and is deliberately excluded — it correctly emits
+ * `ItemList`, so a scan scoped to `tools/` rather than to its subdirectories
+ * would either fail here or invite "fixing" that page's schema to the wrong type.
+ */
+const TOOL_PAGES = readdirSync(TOOLS_DIR, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort();
+
+describe('hubToolSchema — emitted shape', () => {
+  const schema = hubToolSchema({
+    name: 'Test Tool',
+    description: 'A tool for testing',
+    featureList: ['Feature A', 'Feature B'],
+    knowsAbout: ['Technical Due Diligence', 'M&A Tech Strategy'],
+    datePublished: '2026-01-15',
+    dateModified: '2026-07-31',
+  });
+
+  it('is a schema.org WebApplication', () => {
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('WebApplication');
+  });
+
+  it('declares the browser-based, free-of-charge shared block', () => {
+    expect(schema.applicationCategory).toBe('BusinessApplication');
+    expect(schema.operatingSystem).toBe('Web');
+    expect(schema.offers).toEqual({ '@type': 'Offer', price: '0', priceCurrency: 'USD' });
+    expect(schema.publisher).toEqual({
+      '@type': 'Organization',
+      name: 'Global Strategic Technologies',
+    });
+  });
+
+  it('carries the shared author identity', () => {
+    expect(schema.author).toMatchObject({
+      '@type': 'Person',
+      name: 'Reid Peryam',
+      jobTitle: 'Strategic Technology Advisor',
+      sameAs: ['https://www.linkedin.com/in/reidperyam/'],
+    });
+    expect(schema.author.description).toContain('100+ PE technology diligence engagements');
+  });
+
+  it('passes the per-tool fields through untouched', () => {
+    expect(schema.name).toBe('Test Tool');
+    expect(schema.description).toBe('A tool for testing');
+    expect(schema.featureList).toEqual(['Feature A', 'Feature B']);
+    expect(schema.datePublished).toBe('2026-01-15');
+    expect(schema.dateModified).toBe('2026-07-31');
+  });
+
+  it('keeps knowsAbout per-tool rather than collapsing it to a shared array', () => {
+    // The distinction BL-099's acceptance criteria got wrong: all six pages
+    // carry DIFFERENT expertise arrays, so hoisting this into the shared author
+    // constant would delete real signal from five of them.
+    const other = hubToolSchema({
+      name: 'Other',
+      description: 'Other',
+      featureList: [],
+      knowsAbout: ['FinOps'],
+      datePublished: '2026-01-01',
+      dateModified: '2026-01-01',
+    });
+    expect(schema.author.knowsAbout).toEqual(['Technical Due Diligence', 'M&A Tech Strategy']);
+    expect(other.author.knowsAbout).toEqual(['FinOps']);
+  });
+});
+
+describe('every hub tool page emits WebApplication JSON-LD', () => {
+  it('discovers the tool pages rather than trusting a hardcoded list', () => {
+    // Sorted equality, not a count: an empty or over-broad walk fails HERE with
+    // a useful message, instead of silently making every case below vacuous.
+    // It also forces JSON_LD_SCHEMA.md's tool table to be updated when a
+    // seventh tool lands.
+    expect(TOOL_PAGES).toEqual([
+      'diligence-machine',
+      'information-request-list-generator',
+      'infrastructure-cost-governance',
+      'regulatory-map',
+      'tech-debt-calculator',
+      'techpar',
+    ]);
+  });
+
+  it.each(TOOL_PAGES)('%s has exactly one ld+json script', (tool) => {
+    // Reported separately from the assertion below so "no schema element at
+    // all" and "the schema element renders the wrong thing" are distinct
+    // failures rather than one opaque miss.
+    expect(ldJsonElements(read(TOOLS_DIR, tool, 'index.astro'))).toHaveLength(1);
+  });
+
+  it.each(TOOL_PAGES)('%s renders that script from the shared helper', (tool) => {
+    // Deliberately NOT an identifier-presence check over the file. A page
+    // could import hubToolSchema, assign it to a const and never render it —
+    // passing a naive `toContain('hubToolSchema')` while emitting no schema,
+    // which is precisely the failure this test exists to catch. The call must
+    // appear inside THIS element's `set:html`. Attribute order is not assumed.
+    const [element] = ldJsonElements(read(TOOLS_DIR, tool, 'index.astro'));
+    expect(element).toMatch(/set:html=\{JSON\.stringify\(\s*hubToolSchema\(/);
+  });
+});
+
+describe('the tools listing page is not a tool page', () => {
+  const listing = () => read(TOOLS_DIR, 'index.astro');
+
+  it('emits ItemList', () => {
+    expect(listing()).toMatch(/'@type':\s*'ItemList'/);
+  });
+
+  it('does not emit WebApplication', () => {
+    // Guards against someone "fixing" the listing page to satisfy a
+    // mis-scoped version of the check above.
+    expect(listing()).not.toContain('WebApplication');
+    expect(listing()).not.toContain('hubToolSchema');
+  });
+});


### PR DESCRIPTION
Closes BL-099.

Each of the six pages under `src/pages/hub/tools/*/index.astro` inlined its own copy of the same `WebApplication` JSON-LD, and the copies had already drifted — the IRL generator shipped without the `knowsAbout` array its five siblings carried, plus a guessed `datePublished` five weeks off. Neither was caught, because no test in the repo asserted on JSON-LD at all.

`src/utils/hub-tool-schema.ts` now owns every shared field (`offers`, `publisher`, `applicationCategory`, `operatingSystem`, and five of the `author` object's six keys). Each page passes only its six per-tool values.

## Emitted output is unchanged

This is a pure refactor and it's proven, not asserted. The helper reproduces the literals' key insertion order exactly; the `WebApplication` blocks were extracted from `dist/client/hub/tools/*/index.html` before and after and diffed — byte-identical on all six pages, re-confirmed after prettier reformatted on commit. The reviewer verified it independently at both the expression level and end-to-end.

## `knowsAbout` is a per-tool parameter, not a shared constant

BL-099's acceptance criteria described `knowsAbout` as one of the shared blocks and omitted it from the helper's parameter list. That was wrong about the code — all six arrays differ, so hoisting it would have deleted real per-tool expertise signal from five pages. It's a required parameter instead, and since the stanza is removed on completion, the reasoning lives in a docstring beside the parameter rather than in a deleted backlog entry.

## The new test

`tests/unit/hub-tool-schema.test.ts` asserts every `src/pages/hub/tools/*/index.astro` renders its JSON-LD *from* the helper — the gap that let the IRL generator ship with no schema.

Both facts ("has an `ld+json` script" and "that script's `set:html` calls `hubToolSchema`") are bound to a single parsed `<script>` element. An earlier version asserted them independently over the whole file and stayed green under mutation, when the helper call was moved to a second non-`ld+json` script while the schema element rendered an unrelated variable. Mutation testing now confirms the guard catches: the decoy-script case, an identity-fn swap, deleting the script, and adding a duplicate. An omitted `knowsAbout` — the original defect — is now a type error.

The tools *listing* page is deliberately excluded: it correctly emits `ItemList`, and a scan scoped to `tools/` rather than its subdirectories would either fail or invite "fixing" that page's schema to the wrong type. Discovery uses sorted-list equality so it can't go vacuous.

## Doc corrections (pre-existing staleness)

`src/docs/seo/JSON_LD_SCHEMA.md` still described 5 tools and a 5-item `ItemList` with un-slashed URLs — both stale since the IRL generator landed. Its "Adding a New Tool" step 1 instructed copying the JSON-LD literal between pages, which is the drift mechanism this PR removes, and its `knowsAbout` rule said "keep 5 items" against a page that carries 4. Also adds `WebApplication`/`ItemList` to the schema list in `src/docs/seo/README.md`.

## Verification

- `npx astro check` — 0 errors
- `npm run lint` — clean
- `npm run lint:css` — 0 errors (147 pre-existing BL-094 font-size warnings, no CSS touched)
- `npm run test:run` — 1289 passed / 49 files
- `npm run test:docs` — 20 passed
- `npm run test:coverage` — helper at 100% lines/statements/functions
- No E2E (Directive 5). Directive 11 `grep tests/` is a no-op — no visible copy changed, and JSON-LD is invisible to DOM-text assertions.

## Known follow-up

The doc's "4–5 items, always including Technical Due Diligence and M&A Tech Strategy" rule is documented but not executable — emptying a `knowsAbout` array keeps the suite green (omitting it does not; that's a type error). Small, and worth making enforceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
