### PR TITLE
chore(tooling): force LF in the working tree so prettier --check means something locally

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,36 @@
+# Line endings — LF in the repo AND in the working tree, on every platform.
+#
+# WHY THIS IS NOT LEFT TO core.autocrlf: .prettierrc.json sets
+# `endOfLine: "lf"`, so a CRLF working file fails `prettier --check` even
+# though its committed content is byte-correct. On a Windows checkout with
+# `core.autocrlf=true` (git's Windows default), that described 607 of the
+# repo's files — every local `prettier --check` run was red while CI, which
+# checks out on Linux, was green. The mismatch also made `git checkout -- <file>`
+# a trap: it rewrote the file to CRLF, after which prettier failed on it
+# locally while `git status` stayed clean.
+#
+# `eol=lf` overrides core.autocrlf for the working tree, so the checkout no
+# longer depends on each operator's git config. The index was already LF, so
+# this normalizes the working tree only — it does not rewrite history and
+# produces no content diff.
+#
+# Shell scripts additionally REQUIRE LF (a CRLF shebang line breaks execution).
+# The .ps1 scripts are run with PowerShell 7+ (`pwsh`), which reads LF fine.
+* text=auto eol=lf
+
+# Binary — never normalize, never diff as text. `text=auto` detects these
+# heuristically; declaring them is explicit and cheaper.
+*.png binary
+*.jpg binary
+*.ico binary
+
 # Generated files — written by tooling, force LF in the repo regardless of
 # the checkout platform. Without this, Windows operators see persistent
 # `LF will be replaced by CRLF` warnings + git showing the files as
 # modified after every `npm run build` / `npm run test` (which invokes
 # `prebuild` / `pretest` hooks that regenerate them).
 #
-# Narrowly scoped to the .generated.ts files in mcp-server/src/content/
-# (regulations + library indices) to keep this rule's blast radius small.
-# Extend if/when other generated files appear with the same pattern.
+# Retained explicitly even though the `*` rule above now covers it: it
+# documents a distinct reason (regeneration churn, not prettier), and it
+# should survive any future narrowing of the blanket rule.
 mcp-server/src/content/*.generated.ts text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,9 @@
 # produces no content diff.
 #
 # Shell scripts additionally REQUIRE LF (a CRLF shebang line breaks execution).
-# The .ps1 scripts are run with PowerShell 7+ (`pwsh`), which reads LF fine.
+# The .ps1 scripts are safe regardless of host: both Windows PowerShell 5.1 and
+# PowerShell 7 parse LF-only script files, here-strings included. No .bat/.cmd
+# are tracked — those are the one class where CRLF is genuinely load-bearing.
 * text=auto eol=lf
 
 # Binary — never normalize, never diff as text. `text=auto` detects these

--- a/mcp-server/scripts/generate-regulations-index.mjs
+++ b/mcp-server/scripts/generate-regulations-index.mjs
@@ -218,8 +218,10 @@ async function writeFormatted(filePath, content) {
       const path = resolve(sourceDir, slug, 'article.md');
       try {
         // Normalize CRLF→LF so the generated TS string literals round-trip
-        // identically across platforms. `core.autocrlf=true` on Windows
-        // checks markdown out as CRLF; prettier's TS formatter doesn't
+        // identically across platforms. Belt-and-braces since `.gitattributes`
+        // began forcing `eol=lf` repo-wide — it still protects a stale clone
+        // checked out before that rule. Historically `core.autocrlf=true` on
+        // Windows checked markdown out as CRLF; prettier's TS formatter doesn't
         // touch escape sequences inside string literals, so without this
         // the regenerator embeds `\r\n` on Windows and `\n` on CI, and
         // git-status churns between machines.

--- a/mcp-server/src/lib/inoreader-refresh-health.ts
+++ b/mcp-server/src/lib/inoreader-refresh-health.ts
@@ -57,10 +57,7 @@ const KEY_LAST_ROTATION = 'mcp:inoreader:last-rotation-at';
 const COUNTER_TTL_SECONDS = 90_000; // 25 hours
 
 export type RefreshFailureReason =
-  | 'invalid-refresh-token'
-  | 'token-missing'
-  | 'upstash-write-failed'
-  | 'inoreader-error';
+  'invalid-refresh-token' | 'token-missing' | 'upstash-write-failed' | 'inoreader-error';
 
 const FAILURE_REASONS: readonly RefreshFailureReason[] = [
   'invalid-refresh-token',

--- a/mcp-server/tests/integration/golden-snapshots.test.ts
+++ b/mcp-server/tests/integration/golden-snapshots.test.ts
@@ -30,10 +30,11 @@ function promptToSlug(name: string): string {
 const REQUIRED_FRONTMATTER_KEYS = ['promptName', 'version', 'recordedAt', 'model'] as const;
 
 function parseFrontmatter(body: string): Record<string, string> | null {
-  // Normalize CRLF → LF so this works on Windows checkouts where git's
-  // `core.autocrlf=true` (the default) rewrites text files to CRLF on
-  // disk. Without this, every assertion fails on Windows even though
-  // the goldens are correctly formatted.
+  // Normalize CRLF → LF. Belt-and-braces since `.gitattributes` began forcing
+  // `eol=lf` repo-wide: it still protects a stale clone checked out before
+  // that rule, where git's `core.autocrlf=true` (the Windows default) had
+  // rewritten text files to CRLF on disk and every assertion here failed even
+  // though the goldens were correctly formatted.
   const normalized = body.replace(/\r\n/g, '\n');
   if (!normalized.startsWith('---\n')) return null;
   const end = normalized.indexOf('\n---\n', 4);

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -304,7 +304,10 @@ the working tree on every platform**, regardless of the operator's `core.autocrl
 This is load-bearing, not cosmetic. Prettier's `endOfLine: "lf"` means a CRLF working file fails
 `prettier --check` even when its committed content is byte-correct. Before this rule, a Windows
 checkout with git's default `core.autocrlf=true` left **607 files** failing `prettier --check`
-locally while CI — which checks out on Linux — stayed green. It also made `git checkout -- <file>`
+locally while CI — which checks out on Linux — stayed green. (Three different denominators appear
+in this section: ~873 files were CRLF on disk, 805 of them tracked-and-counted at the time of the
+fix, and 607 is the subset Prettier actually checks — the rest are `.prettierignore`d or not file
+types it handles.) It also made `git checkout -- <file>`
 a trap: the restored file came back CRLF, prettier then failed on it, and `git status` showed
 nothing wrong.
 
@@ -321,11 +324,13 @@ git rm --cached -r -q .   # drop the index's stat cache
 git reset --hard          # re-materializes every file per .gitattributes
 ```
 
-> Do **not** substitute `git checkout-index -a -f`. It honors git's stat cache and silently skips
-> every file it considers up to date — on this repo it rewrote **1 of 805** CRLF files, then exited
-> 0 printing nothing. (In a small scratch repo it often appears to work, which is what makes it
-> such a convincing trap.) Whether it does anything depends on stat-cache state you can't see, so
-> the "success" it reports means nothing. The sequence above is deterministic.
+> Do **not** substitute `git checkout-index -a -f`. It skips any file whose index stat-cache entry
+> still matches what is on disk — which is **exactly the stale-clone case**, because those CRLF
+> files were *written by* a git checkout that recorded their stat as it went. On this repo it
+> rewrote **1 of 805**, then exited 0 printing nothing. It *does* act on files that are missing or
+> whose size changed since staging, so a scratch repo where you hand-write CRLF content will show
+> it "working" — that is what makes it a convincing trap rather than an obviously broken command.
+> Its exit code tells you nothing. The sequence above is deterministic.
 
 `.sh` scripts and `.husky/pre-commit` *require* LF — a CRLF shebang breaks execution. The `.ps1`
 scripts under `mcp-server/scripts/` are safe because **both Windows PowerShell 5.1 and PowerShell 7

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -261,6 +261,7 @@ concurrency:
 | [package.json](../../../package.json)                             | `scripts`, `devDependencies`, `lint-staged`, `overrides`, `prepare`                             |
 | [.prettierrc.json](../../../.prettierrc.json)                     | Prettier formatting rules (2-space, single quotes, 100-char line width, etc.)                   |
 | [.prettierignore](../../../.prettierignore)                       | Files and directories Prettier will not touch (generated output, lock files, hand-curated data) |
+| [.gitattributes](../../../.gitattributes)                         | `* text=auto eol=lf` — forces LF in the working tree on every platform, so `prettier --check` behaves the same locally as in CI. See § Line endings |
 | [eslint.config.mjs](../../../eslint.config.mjs)                   | ESLint flat config — recommended rules + overrides for tests, node scripts, and browser globals |
 | [.stylelintrc.json](../../../.stylelintrc.json)                   | CSS lint rules                                                                                  |
 | [tsconfig.json](../../../tsconfig.json)                           | TypeScript config, including the `@/*` → `src/*` path alias                                     |
@@ -308,15 +309,32 @@ a trap: the restored file came back CRLF, prettier then failed on it, and `git s
 nothing wrong.
 
 Because the index was already LF, adding the rule normalized the working tree only — no content
-diff, no history rewrite. If you have a stale clone with CRLF files, renormalize with:
+diff, no history rewrite. A fresh clone needs nothing. If you have a **stale clone** whose files are
+still CRLF, renormalize with:
 
 ```bash
-git add --renormalize .    # should stage nothing; the index is already LF
-git checkout-index -a -f   # rewrites the working tree per .gitattributes
+git add --renormalize .   # sanity check — stages nothing; the index is already LF
+
+# WARNING: the next two lines discard uncommitted work. Commit or stash first.
+# Between them `git status` shows every file as deleted — that is expected.
+git rm --cached -r -q .   # drop the index's stat cache
+git reset --hard          # re-materializes every file per .gitattributes
 ```
 
-`.sh` scripts *require* LF (a CRLF shebang breaks execution). The `.ps1` scripts under
-`mcp-server/scripts/` are run with PowerShell 7+ (`pwsh`), which reads LF fine.
+> Do **not** substitute `git checkout-index -a -f`. It honors git's stat cache and silently skips
+> every file it considers up to date — on this repo it rewrote **1 of 805** CRLF files, then exited
+> 0 printing nothing. (In a small scratch repo it often appears to work, which is what makes it
+> such a convincing trap.) Whether it does anything depends on stat-cache state you can't see, so
+> the "success" it reports means nothing. The sequence above is deterministic.
+
+`.sh` scripts and `.husky/pre-commit` *require* LF — a CRLF shebang breaks execution. The `.ps1`
+scripts under `mcp-server/scripts/` are safe because **both Windows PowerShell 5.1 and PowerShell 7
+parse LF-only script files**, including the here-strings in `Verify-AeEmission.ps1`; this does not
+depend on which host an operator happens to use.
+
+One consequence for macOS/Linux contributors, who were already unaffected in the working tree:
+`text=auto` now also normalizes CRLF→LF **on commit**. If a fixture ever needs literal CRLF on disk,
+give it an explicit `-text` override rather than relying on verbatim storage.
 
 ### What Prettier will NOT format
 
@@ -739,6 +757,19 @@ npm run format
 ```
 
 Be aware this will produce a large diff against the current state. The expected place to do this is as a single standalone commit during the Phase 9 sweep, not piecemeal during feature work.
+
+### "`prettier --check` fails locally but CI is green"
+
+Almost certainly line endings, and it is the harder direction to diagnose because CI never tells you
+anything is wrong. Confirm with:
+
+```bash
+git ls-files --eol | grep -c "w/crlf"   # expect 0
+```
+
+Any count above zero means your working tree predates the `* text=auto eol=lf` rule (or something
+rewrote files behind git's back). Fix it with the renormalization sequence in § Line endings, and
+re-run the count to confirm — do not trust a command's exit code here.
 
 ### "My commit was rejected by the pre-commit hook"
 

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -293,7 +293,30 @@ Configured in [.prettierrc.json](../../../.prettierrc.json):
 | `semi`           | `true`     | Always use semicolons                                                        |
 | `arrowParens`    | `"always"` | `(x) => x`, not `x => x`                                                     |
 | `bracketSpacing` | `true`     | `{ a: 1 }`, not `{a: 1}`                                                     |
-| `endOfLine`      | `"lf"`     | Unix line endings (matters on Windows — git's autocrlf should not undo this) |
+| `endOfLine`      | `"lf"`     | Unix line endings — enforced in the working tree by `.gitattributes`, see below |
+
+### Line endings (`.gitattributes`)
+
+[`.gitattributes`](../../../.gitattributes) sets `* text=auto eol=lf`, so **every text file is LF in
+the working tree on every platform**, regardless of the operator's `core.autocrlf`.
+
+This is load-bearing, not cosmetic. Prettier's `endOfLine: "lf"` means a CRLF working file fails
+`prettier --check` even when its committed content is byte-correct. Before this rule, a Windows
+checkout with git's default `core.autocrlf=true` left **607 files** failing `prettier --check`
+locally while CI — which checks out on Linux — stayed green. It also made `git checkout -- <file>`
+a trap: the restored file came back CRLF, prettier then failed on it, and `git status` showed
+nothing wrong.
+
+Because the index was already LF, adding the rule normalized the working tree only — no content
+diff, no history rewrite. If you have a stale clone with CRLF files, renormalize with:
+
+```bash
+git add --renormalize .    # should stage nothing; the index is already LF
+git checkout-index -a -f   # rewrites the working tree per .gitattributes
+```
+
+`.sh` scripts *require* LF (a CRLF shebang breaks execution). The `.ps1` scripts under
+`mcp-server/scripts/` are run with PowerShell 7+ (`pwsh`), which reads LF fine.
 
 ### What Prettier will NOT format
 

--- a/tests/integration/docs-link-integrity.test.ts
+++ b/tests/integration/docs-link-integrity.test.ts
@@ -148,7 +148,8 @@ function slugify(headingText: string): string {
 
 // --- Markdown parsing helpers --------------------------------------------
 
-/** Split into lines, EOL-agnostic (repo docs are CRLF). */
+/** Split into lines, EOL-agnostic. Repo files are LF (`.gitattributes` forces
+ * `eol=lf`), but stale clones predating that rule can still be CRLF on disk. */
 function toLines(content: string): string[] {
   return content.split(/\r?\n/);
 }


### PR DESCRIPTION
Fixes a Windows-only footgun that made every local `prettier --check` run meaningless.

## The problem

`.prettierrc.json` sets `endOfLine: "lf"`, so a CRLF working file fails `prettier --check` even when its committed content is byte-correct. With git's Windows default `core.autocrlf=true` and no `.gitattributes` rule covering source files, that described **607 of the repo's files** — every local `prettier --check .` was red while CI, which checks out on Linux, stayed green.

It also made `git checkout -- <file>` a trap: the restored file came back CRLF, prettier then failed on it, and `git status` showed nothing wrong. That cost real time twice while working on PR #368 — once it silently reverted an uncommitted refactor along with the mutation it was meant to undo.

## The fix

`.gitattributes` gains `* text=auto eol=lf`, so every text file is LF in the working tree on every platform regardless of the operator's `core.autocrlf`. Explicit `binary` for the 11 tracked images.

**No content churn, no history rewrite.** The index was already 100% LF — verified by `git add --renormalize .` staging nothing but `.gitattributes` itself, and by `git ls-files --eol` reporting zero CRLF blobs in the index. This normalizes the working tree only.

Measured, by cloning both refs with `core.autocrlf=true`:

| clone | worktree |
|---|---|
| `master` | **873 CRLF**, 3 LF |
| this branch | **0 CRLF**, 876 LF, `git status` clean |

`npx prettier --check .` goes from 607 failures to clean repo-wide. macOS/Linux contributors are unaffected — they already had LF.

## Why one file's formatting changed

`mcp-server/src/lib/inoreader-refresh-health.ts` was the only *genuine* prettier violation among the 607 — a union type reflow, hidden until the line-ending noise cleared. Fixed rather than filed, because a `prettier --check` you can't trust defeats the point of this PR. Formatting only, no semantic change.

## Documentation (Directive 14)

`DEVELOPER_TOOLING.md` gains a § Line endings section with the renormalization sequence for stale clones, a troubleshooting entry for "prettier fails locally but CI is green" (the harder direction — CI never tells you), and `.gitattributes` in the config-file index.

The section carries a specific warning against `git checkout-index -a -f`, which is worth reading before anyone reaches for it. It skips any file whose index stat-cache entry still matches disk — *exactly* the stale-clone case, since those files were written by a checkout that recorded their stat — then exits 0 printing nothing. On this repo it rewrote 1 of 805 files while reporting success. It does act on missing or size-changed entries, so a scratch repo where you hand-write CRLF will show it "working". That combination is what makes it a trap rather than an obviously broken command, and it took three rounds of testing across five stat-cache states to attribute correctly.

Two defensive CRLF normalizations in `mcp-server/` are annotated as belt-and-braces for stale clones rather than removed, and a comment in `docs-link-integrity.test.ts` asserting "repo docs are CRLF" is corrected.

## Verification

- `npx prettier --check .` — clean repo-wide (was 607 failures)
- `npx astro check` — 0 errors · `npm run lint` / `lint:css` — clean
- `npm run test:run` — 1269 passed · `npm run test:docs` — 20 passed
- `npm -w @gst/mcp-server run typecheck` — clean · `npm run test:mcp` — 1917 passed

The mcp-server commands are included per Directive 14 because this touches `mcp-server/`.

## ⚠️ Merging queues an MCP production deploy

Three files match the `mcp-server/**` path filter, so merging will queue a production Worker deploy pending approval in the `mcp-production` environment — for a change that is comments, docs, and one whitespace reflow. Expected, not a defect; splitting the branch would not avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
