### PR TITLE
docs(testing): name two CI failures that both got misdiagnosed on 2026-08-06

### DIFF
--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -848,6 +848,8 @@ Open the run on the Actions tab and expand the **Detect Code Changes** job's "Lo
 - **`duplicate=true` but you wanted a re-run**: trigger via "Re-run all jobs" in the Actions UI (uses `workflow_dispatch`, bypasses dedup) rather than pushing a no-op commit
 - **PR blocked with a cancelled push-event check alongside a successful pull_request-event check**: the workflow's concurrency group must be scoped by `github.event_name` — without it, the two events collide in the same group and `cancel-in-progress: true` cancels the first-started run. Immediate fix: `gh run rerun <cancelled-run-id>` on the cancelled run (safe because the sibling has already completed). Durable fix: confirm the workflow's `concurrency.group` includes `github.event_name`
 
+- **A check sits `in_progress` with no logs, or `queued` with no jobs at all**: not a paths-filter problem — check [githubstatus.com](https://www.githubstatus.com) first, then see [TROUBLESHOOTING.md § "A check is stuck"](../testing/TROUBLESHOOTING.md#a-check-is-stuck--running-for-minutes-with-no-logs-or-queued-with-no-job-at-all). Runs wedged during an Actions incident can report contradictory states to `gh run list`/`cancel`/`rerun` and may be unrecoverable; close+reopen is the remedy
+
 Never remove the positive `**` catch-all when adding more negations — with `predicate-quantifier: 'every'`, a negation-only list always produces `code=false` regardless of the actual changeset.
 
 ### "I need to temporarily skip the hook"

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -847,10 +847,15 @@ Open the run on the Actions tab and expand the **Detect Code Changes** job's "Lo
 - **`duplicate=false` when a prior successful run had the same content**: the prior run may have failed or been cancelled (only `success` conclusions dedupe), or the tree hash differs (one file changed that you didn't realize — check `git diff <prior-sha>..HEAD --stat`). Manual re-runs via the UI intentionally bypass dedup via `do_not_skip: ["workflow_dispatch", ...]`
 - **`duplicate=true` but you wanted a re-run**: trigger via "Re-run all jobs" in the Actions UI (uses `workflow_dispatch`, bypasses dedup) rather than pushing a no-op commit
 - **PR blocked with a cancelled push-event check alongside a successful pull_request-event check**: the workflow's concurrency group must be scoped by `github.event_name` — without it, the two events collide in the same group and `cancel-in-progress: true` cancels the first-started run. Immediate fix: `gh run rerun <cancelled-run-id>` on the cancelled run (safe because the sibling has already completed). Durable fix: confirm the workflow's `concurrency.group` includes `github.event_name`
-
-- **A check sits `in_progress` with no logs, or `queued` with no jobs at all**: not a paths-filter problem — check [githubstatus.com](https://www.githubstatus.com) first, then see [TROUBLESHOOTING.md § "A check is stuck"](../testing/TROUBLESHOOTING.md#a-check-is-stuck--running-for-minutes-with-no-logs-or-queued-with-no-job-at-all). Runs wedged during an Actions incident can report contradictory states to `gh run list`/`cancel`/`rerun` and may be unrecoverable; close+reopen is the remedy
-
 Never remove the positive `**` catch-all when adding more negations — with `predicate-quantifier: 'every'`, a negation-only list always produces `code=false` regardless of the actual changeset.
+
+### "A check never finishes — no logs, or no job at all"
+
+Distinct from the gate-decision symptoms above: the check does not report a wrong _answer_, it reports **no** answer. Check [githubstatus.com](https://www.githubstatus.com) before investigating anything in this repo — during an Actions incident no config change helps.
+
+Full triage (step-name vs step-count, the three job shapes, and why re-running during an incident is counterproductive) lives in [TROUBLESHOOTING.md § "A check is stuck"](../testing/TROUBLESHOOTING.md#a-check-is-stuck--running-for-minutes-with-no-logs-or-queued-with-no-job-at-all).
+
+**This is not the `gh run rerun` case above.** That remedy applies to a check that ran and was _cancelled by a concurrency collision_, where a sibling run has already completed. A run wedged by an incident may instead report contradictory states to `gh run list` / `cancel` / `rerun` and be unrecoverable — there, close+reopen the PR is the remedy, since `reopened` creates fresh runs.
 
 ### "I need to temporarily skip the hook"
 

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -847,6 +847,7 @@ Open the run on the Actions tab and expand the **Detect Code Changes** job's "Lo
 - **`duplicate=false` when a prior successful run had the same content**: the prior run may have failed or been cancelled (only `success` conclusions dedupe), or the tree hash differs (one file changed that you didn't realize — check `git diff <prior-sha>..HEAD --stat`). Manual re-runs via the UI intentionally bypass dedup via `do_not_skip: ["workflow_dispatch", ...]`
 - **`duplicate=true` but you wanted a re-run**: trigger via "Re-run all jobs" in the Actions UI (uses `workflow_dispatch`, bypasses dedup) rather than pushing a no-op commit
 - **PR blocked with a cancelled push-event check alongside a successful pull_request-event check**: the workflow's concurrency group must be scoped by `github.event_name` — without it, the two events collide in the same group and `cancel-in-progress: true` cancels the first-started run. Immediate fix: `gh run rerun <cancelled-run-id>` on the cancelled run (safe because the sibling has already completed). Durable fix: confirm the workflow's `concurrency.group` includes `github.event_name`
+
 Never remove the positive `**` catch-all when adding more negations — with `predicate-quantifier: 'every'`, a negation-only list always produces `code=false` regardless of the actual changeset.
 
 ### "A check never finishes — no logs, or no job at all"

--- a/src/docs/testing/TROUBLESHOOTING.md
+++ b/src/docs/testing/TROUBLESHOOTING.md
@@ -243,7 +243,7 @@ curl -s https://www.githubstatus.com/api/v2/status.json          # overall indic
 curl -s https://www.githubstatus.com/api/v2/incidents/unresolved.json  # open incidents
 ```
 
-**Read the job's step count and runner — together they separate "slow" from "never started":**
+**Read the job's step names and runner — together they separate "slow" from "never started":**
 
 ```bash
 gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
@@ -252,17 +252,17 @@ gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
 
 Add `/attempts/<n>` before `/jobs` to inspect an earlier attempt — a re-run overwrites the top-level view, so the original evidence is only reachable that way.
 
-**Read the step _names_, not the count.** A non-zero `steps` does not mean the job did any of your work: `Set up job` is the runner's own provisioning step and is counted like any other. Attempt 1 below had `steps=1`, and that one step was `Set up job` — checkout and everything after it never appeared. A count alone cannot tell that apart from an ordinary cancelled job, which is why the command prints names.
+**Read the step _names_, not the count.** A non-zero step count does not mean the job did any of your work: `Set up job` is the runner's own provisioning step and appears in the list alongside real steps on every job, successful ones included. The 2m42s attempt below had exactly one step, and it was `Set up job` — checkout and everything after it never appeared. A count alone cannot tell that apart from an ordinary cancelled job, which is why the command prints names.
 
-Three shapes, all observed on run `31117388132` during the 2026-08-06 outage:
+Three shapes, all observed on run `31117388132` during the 2026-08-06 outage. Bracketed lists are what the command above prints:
 
-| shape                           | meaning                                                                 |
-| ------------------------------- | ----------------------------------------------------------------------- |
-| `steps=0`, `runner_id` non-zero | a runner was allocated but handed no work — no logs because no step ran |
-| `steps=0`, `runner_id=0`        | no runner was ever assigned                                             |
-| steps are **only** `Set up job` | a runner picked it up but never got past provisioning                   |
+| shape                            | meaning                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `[]`, `runner_id` non-zero       | a runner was allocated but handed no work — no logs because no step ran |
+| `[]`, `runner_id=0`              | no runner was ever assigned                                             |
+| `[Set up job]` and nothing after | a runner picked it up but never got past provisioning                   |
 
-`runner_id=null` is a fourth, benign case — the downstream jobs that report `skipped` because their gate never produced outputs. The command lists every job, so expect nulls in the same output.
+`runner_id=null` with `[]` is a fourth, benign case — the downstream jobs that report `skipped` because their gate never produced outputs. The command lists every job, so expect these in the same output.
 
 **Do not read the durations as a timeout constant.** The same job's three attempts were cancelled after **2m42s, 7m48s and 15m04s**. Expect minutes rather than seconds, expect `cancelled`, and expect downstream jobs `skipped` — but do not wait on a specific number.
 

--- a/src/docs/testing/TROUBLESHOOTING.md
+++ b/src/docs/testing/TROUBLESHOOTING.md
@@ -247,25 +247,29 @@ curl -s https://www.githubstatus.com/api/v2/incidents/unresolved.json  # open in
 
 ```bash
 gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
-  --jq '.jobs[] | "\(.status)/\(.conclusion // "-") steps=\(.steps|length) runner_id=\(.runner_id) \(.name)"'
+  --jq '.jobs[] | "\(.status)/\(.conclusion // "-") runner_id=\(.runner_id) \(.name) [\(.steps|map(.name)|join(", "))]"'
 ```
 
 Add `/attempts/<n>` before `/jobs` to inspect an earlier attempt — a re-run overwrites the top-level view, so the original evidence is only reachable that way.
 
+**Read the step _names_, not the count.** A non-zero `steps` does not mean the job did any of your work: `Set up job` is the runner's own provisioning step and is counted like any other. Attempt 1 below had `steps=1`, and that one step was `Set up job` — checkout and everything after it never appeared. A count alone cannot tell that apart from an ordinary cancelled job, which is why the command prints names.
+
 Three shapes, all observed on run `31117388132` during the 2026-08-06 outage:
 
-| shape                               | meaning                                                                 |
-| ----------------------------------- | ----------------------------------------------------------------------- |
-| `steps=0`, `runner_id` non-zero     | a runner was allocated but handed no work — no logs because no step ran |
-| `steps=0`, `runner_id=0`            | no runner was ever assigned                                             |
-| `steps` non-zero, still `cancelled` | started, then killed mid-flight                                         |
+| shape                           | meaning                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `steps=0`, `runner_id` non-zero | a runner was allocated but handed no work — no logs because no step ran |
+| `steps=0`, `runner_id=0`        | no runner was ever assigned                                             |
+| steps are **only** `Set up job` | a runner picked it up but never got past provisioning                   |
+
+`runner_id=null` is a fourth, benign case — the downstream jobs that report `skipped` because their gate never produced outputs. The command lists every job, so expect nulls in the same output.
 
 **Do not read the durations as a timeout constant.** The same job's three attempts were cancelled after **2m42s, 7m48s and 15m04s**. Expect minutes rather than seconds, expect `cancelled`, and expect downstream jobs `skipped` — but do not wait on a specific number.
 
 **A `queued` run with no jobs at all is a separate failure** from a push that produced no run at all:
 
-- **Run exists, no job records** — job creation failed inside the Actions backend. Runs `31117340328` and `31117389676` sat this way for over a day.
-- **No run at all** — the triggering webhook was dropped. GitHub's 2026-08-06T20:34Z update (while processing ~15% of webhooks) states these cannot be replayed: "Customers may need to repeat the triggering action by pushing a new commit, updating the pull request, or manually re-running."
+- **Run exists, no job records** — job creation failed inside the Actions backend. Runs `31117340328` and `31117389676` sat this way for the better part of a day (still `queued`, zero jobs, 23h later).
+- **No run at all** — the triggering webhook was dropped. GitHub's 2026-08-06T20:34Z `investigating` update reported "processing approximately 15% of webhooks, so many events such as pushes and pull requests are not triggering workflow runs". The 2026-08-07T02:03Z `monitoring` update states such triggers are not replayed automatically: "Customers may need to repeat the triggering action by pushing a new commit, updating the pull request, or manually re-running the workflow where applicable."
 
 **Do not keep re-running during an incident.** Attempts cost minutes and end the same way; while webhooks are throttled a re-run may also be dropped before it starts. Wait for the incident to reach `monitoring`/`resolved`, then re-run once.
 
@@ -274,8 +278,6 @@ Three shapes, all observed on run `31117388132` during the 2026-08-06 outage:
 **Remedy: close and reopen the PR.** This does _not_ cancel the wedged runs — they stay `queued` indefinitely — but `reopened` triggers **fresh** `pull_request` runs with new IDs, which is what unblocks the checks. It is the same fix documented for a PR stuck BLOCKED after "Update branch" (see [DEVELOPER_TOOLING.md](../development/DEVELOPER_TOOLING.md)). It works only for workflows whose `pull_request:` trigger lists `reopened` — the repo's CI workflows do. Prefer it over pushing an empty commit, which moves HEAD and invalidates the implementation-review marker the push gate requires.
 
 **Useful control:** a green Vercel check on the same commit confirms the site still **builds** on independent infrastructure. It does not run the test suite, lint, or type-check (`vercel.json` sets no `buildCommand`, so the Astro preset runs `astro build` only), so on a docs-only diff it proves little beyond "not a build break".
-
-**Useful control:** if Vercel's checks are green on the same commit while Actions is stuck, that is strong evidence the diff is fine — Vercel builds on its own infrastructure.
 
 ---
 

--- a/src/docs/testing/TROUBLESHOOTING.md
+++ b/src/docs/testing/TROUBLESHOOTING.md
@@ -102,16 +102,19 @@ See [TEST_BEST_PRACTICES.md #26](./TEST_BEST_PRACTICES.md#26--source-side-readin
 
 **Symptom:** A vitest command that passed moments ago returns `Test Files N failed (N)` / `Tests no tests`, with a `TypeError: Cannot read properties of undefined (reading 'config')` at the top-level `describe`. **Files your change never touched fail identically.**
 
-**Likely cause:** Two vitest processes running concurrently in the same working directory. They share the vite transform cache under `node_modules/.vite`, and a collision there kills collection before any test is registered. Common when an agent, an IDE test runner, or a second terminal starts a run while one is already going.
+**Likely cause:** A second vitest process running concurrently — an agent, an IDE test runner, or another terminal starting a run while one is already going.
 
-**How to tell it apart from a real failure** — all four hold for contention, none hold for content:
+**The mechanism is not established.** Candidates include Vite's dep-optimizer rewriting `node_modules/.vite/deps` mid-run, and two vitest instances leaving the runner's worker state undefined (which is what a `reading 'config'` TypeError at `describe` usually smells like). Note the two workspaces have **separate** caches — `node_modules/.vite` and `mcp-server/node_modules/.vite` — so a root `npm run test:run` concurrent with `npm run test:mcp` shares no cache at all, and a shared-cache story cannot explain that pairing. Treat concurrency as the observed trigger and the rest as explanation, not evidence.
 
-1. **The phase.** Failure is at _collection_ — zero tests gathered, so no assertion ever executed. A broken import or bad config fails the same way, but see 2–4.
-2. **The blast radius.** Files unrelated to your change fail too. Content defects are selective; cache collisions are not.
-3. **Reproducibility.** Content fails deterministically on every run. Re-run the same command with nothing else running — contention clears, content does not.
-4. **No test name exists to capture.** That is a consequence of 1, and it is why the usual "capture the failing test name before you re-run" rule needs a substitute here.
+**Phase first:** the failure is at _collection_ — zero tests gathered, so no assertion ever executed. A broken import or a bad config does the same, so the phase narrows it without settling it. These three do the discriminating:
+
+1. **Blast radius.** Files unrelated to your change fail too. Content defects are selective; this is not.
+2. **Reproducibility.** Content fails deterministically. Re-run with nothing else running — contention clears, content does not.
+3. **No test name exists to capture.** A consequence of the phase, and the reason the usual "capture the failing test name" rule needs a substitute here.
 
 **Solution:** Ensure only one vitest process is running, then re-run. If it persists across serial runs, it is not this — treat it as a real failure and debug the import graph.
+
+**Related:** ["npm run test:all hangs or times out"](#npm-run-testall-hangs-or-times-out) covers resource exhaustion _within_ one run; this entry is contention _between_ runs.
 
 **Record it even though it's benign.** [CLAUDE.md](../../../.claude/CLAUDE.md) requires capturing evidence before a re-run, because a green re-run destroys it (this is why BL-106's unreproduced flake stayed open). When collection fails there is no test name, so capture the **signature** instead: the phase, the full set of failing files, and what else was running. Observed 2026-08-06, where it was first misdiagnosed as a permanently broken local vitest install — the misdiagnosis was corrected only when the same command later passed in the same shell.
 
@@ -229,7 +232,9 @@ cat .github/workflows/test.yml
 
 ### "A check is stuck — running for minutes with no logs, or queued with no job at all"
 
-**Symptom:** A job that normally takes seconds sits `in_progress` for many minutes and its log page is empty; or a run stays `queued` while `gh run view` shows no jobs. Downstream jobs report `skipping` because the job they gate on never produced its outputs.
+**Symptom:** A job that normally takes seconds sits `in_progress` for many minutes and its log page is empty; or a run stays `queued` while `gh run view` shows no jobs. Downstream jobs report `skipped` because the job they gate on never produced its outputs.
+
+Distinct from ["Workflow shows red X but tests passed locally"](#workflow-shows-red-x-but-tests-passed-locally), which is about a _red result_. This entry is about _no result_.
 
 **First: is it your repo or GitHub?** Check the incident feed before investigating anything local — during an Actions incident this is not a repo problem and no config change will help:
 
@@ -238,21 +243,37 @@ curl -s https://www.githubstatus.com/api/v2/status.json          # overall indic
 curl -s https://www.githubstatus.com/api/v2/incidents/unresolved.json  # open incidents
 ```
 
-**Read the job's step count — it separates "slow" from "never started":**
+**Read the job's step count and runner — together they separate "slow" from "never started":**
 
 ```bash
 gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
-  --jq '.jobs[] | "\(.status)/\(.conclusion // "-") steps=\(.steps|length) \(.name)"'
+  --jq '.jobs[] | "\(.status)/\(.conclusion // "-") steps=\(.steps|length) runner_id=\(.runner_id) \(.name)"'
 ```
 
-- `steps=0` **with a runner assigned** — the job was allocated but handed no work. There are no logs because no step ran. GitHub reaps these at **~15 minutes** with conclusion `cancelled`.
-- **No jobs at all** on a `queued` run — worse. Job creation is event-driven, so a throttled webhook layer leaves a bare run object nothing ever materialises. Observed 2026-08-06 while GitHub was processing ~15% of webhooks.
+Add `/attempts/<n>` before `/jobs` to inspect an earlier attempt — a re-run overwrites the top-level view, so the original evidence is only reachable that way.
 
-**Do not keep re-running during an incident.** Each attempt costs ~15 minutes and ends the same way; if webhooks are throttled it is also likely to be dropped before it starts. Wait for the incident to reach `monitoring`/`resolved`, then re-run once.
+Three shapes, all observed on run `31117388132` during the 2026-08-06 outage:
 
-**Runs wedged by an incident may be unrecoverable.** After the 2026-08-06 outage the same run reported three contradictory states — `gh run list` said `queued`, `gh run cancel` said "Cannot cancel a workflow run that is completed", and `gh run rerun` said "cannot be rerun; This workflow is already running". No retry fixes that.
+| shape                               | meaning                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| `steps=0`, `runner_id` non-zero     | a runner was allocated but handed no work — no logs because no step ran |
+| `steps=0`, `runner_id=0`            | no runner was ever assigned                                             |
+| `steps` non-zero, still `cancelled` | started, then killed mid-flight                                         |
 
-**Remedy: close and reopen the PR.** This abandons the corrupted runs and triggers fresh `pull_request` runs with new IDs — the same fix documented for a PR stuck BLOCKED after "Update branch" (see [DEVELOPER_TOOLING.md](../development/DEVELOPER_TOOLING.md)). Prefer it over pushing an empty commit, which moves HEAD and invalidates the implementation-review marker the push gate requires.
+**Do not read the durations as a timeout constant.** The same job's three attempts were cancelled after **2m42s, 7m48s and 15m04s**. Expect minutes rather than seconds, expect `cancelled`, and expect downstream jobs `skipped` — but do not wait on a specific number.
+
+**A `queued` run with no jobs at all is a separate failure** from a push that produced no run at all:
+
+- **Run exists, no job records** — job creation failed inside the Actions backend. Runs `31117340328` and `31117389676` sat this way for over a day.
+- **No run at all** — the triggering webhook was dropped. GitHub's 2026-08-06T20:34Z update (while processing ~15% of webhooks) states these cannot be replayed: "Customers may need to repeat the triggering action by pushing a new commit, updating the pull request, or manually re-running."
+
+**Do not keep re-running during an incident.** Attempts cost minutes and end the same way; while webhooks are throttled a re-run may also be dropped before it starts. Wait for the incident to reach `monitoring`/`resolved`, then re-run once.
+
+**Runs wedged by an incident may be unrecoverable.** After the 2026-08-06 outage one run reported three contradictory states — `gh run list` said `queued`, `gh run cancel` said "Cannot cancel a workflow run that is completed", and `gh run rerun` said "cannot be rerun; This workflow is already running". No retry fixes that.
+
+**Remedy: close and reopen the PR.** This does _not_ cancel the wedged runs — they stay `queued` indefinitely — but `reopened` triggers **fresh** `pull_request` runs with new IDs, which is what unblocks the checks. It is the same fix documented for a PR stuck BLOCKED after "Update branch" (see [DEVELOPER_TOOLING.md](../development/DEVELOPER_TOOLING.md)). It works only for workflows whose `pull_request:` trigger lists `reopened` — the repo's CI workflows do. Prefer it over pushing an empty commit, which moves HEAD and invalidates the implementation-review marker the push gate requires.
+
+**Useful control:** a green Vercel check on the same commit confirms the site still **builds** on independent infrastructure. It does not run the test suite, lint, or type-check (`vercel.json` sets no `buildCommand`, so the Astro preset runs `astro build` only), so on a docs-only diff it proves little beyond "not a build break".
 
 **Useful control:** if Vercel's checks are green on the same commit while Actions is stuck, that is strong evidence the diff is fine — Vercel builds on its own infrastructure.
 
@@ -502,16 +523,16 @@ npx playwright install --with-deps
 
 ## Quick Reference
 
-| Problem           | Command                                                                           |
-| ----------------- | --------------------------------------------------------------------------------- |
-| Run all tests     | `npm run test:all`                                                                |
-| Run specific test | `npx playwright test -g "test name"`                                              |
-| Debug test        | `npx playwright test --debug`                                                     |
-| View headed       | `npx playwright test --headed`                                                    |
-| Check coverage    | `npm run test:coverage`                                                           |
-| Clear Playwright  | `rm -rf ~/.cache/ms-playwright`                                                   |
-| Run on Firefox    | `npx playwright test --project=firefox`                                           |
-| Is GitHub down?   | `curl -s https://www.githubstatus.com/api/v2/status.json`                         |
-| Stuck CI job?     | `gh api repos/<owner>/<repo>/actions/runs/<id>/jobs --jq '.jobs[].steps\|length'` |
+| Problem           | Command                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| Run all tests     | `npm run test:all`                                                                                           |
+| Run specific test | `npx playwright test -g "test name"`                                                                         |
+| Debug test        | `npx playwright test --debug`                                                                                |
+| View headed       | `npx playwright test --headed`                                                                               |
+| Check coverage    | `npm run test:coverage`                                                                                      |
+| Clear Playwright  | `rm -rf ~/.cache/ms-playwright`                                                                              |
+| Run on Firefox    | `npx playwright test --project=firefox`                                                                      |
+| Is GitHub down?   | `curl -s https://www.githubstatus.com/api/v2/status.json`                                                    |
+| Stuck CI job?     | [Diagnosing a stuck check](#a-check-is-stuck--running-for-minutes-with-no-logs-or-queued-with-no-job-at-all) |
 
 See [README.md](./README.md) for more commands.

--- a/src/docs/testing/TROUBLESHOOTING.md
+++ b/src/docs/testing/TROUBLESHOOTING.md
@@ -252,7 +252,7 @@ gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
 
 Add `/attempts/<n>` before `/jobs` to inspect an earlier attempt — a re-run overwrites the top-level view, so the original evidence is only reachable that way.
 
-**Read the step _names_, not the count.** A non-zero step count does not mean the job did any of your work: `Set up job` is the runner's own provisioning step and appears in the list alongside real steps on every job, successful ones included. The 2m42s attempt below had exactly one step, and it was `Set up job` — checkout and everything after it never appeared. A count alone cannot tell that apart from an ordinary cancelled job, which is why the command prints names.
+**Read the step _names_, not the count.** A non-zero step count does not mean the job did any of your work: `Set up job` is the runner's own provisioning step, and whenever the step list is non-empty it is the **first** entry — including on successful jobs, where it sits alongside the real steps. The 2m42s attempt below had exactly one step, and it was `Set up job` — checkout and everything after it never appeared. A count alone cannot tell that apart from an ordinary cancelled job, which is why the command prints names.
 
 Three shapes, all observed on run `31117388132` during the 2026-08-06 outage. Bracketed lists are what the command above prints:
 

--- a/src/docs/testing/TROUBLESHOOTING.md
+++ b/src/docs/testing/TROUBLESHOOTING.md
@@ -98,6 +98,25 @@ See [TEST_BEST_PRACTICES.md #26](./TEST_BEST_PRACTICES.md#26--source-side-readin
 
 ---
 
+### "Every vitest suite fails at once, at `describe`, with zero tests collected"
+
+**Symptom:** A vitest command that passed moments ago returns `Test Files N failed (N)` / `Tests no tests`, with a `TypeError: Cannot read properties of undefined (reading 'config')` at the top-level `describe`. **Files your change never touched fail identically.**
+
+**Likely cause:** Two vitest processes running concurrently in the same working directory. They share the vite transform cache under `node_modules/.vite`, and a collision there kills collection before any test is registered. Common when an agent, an IDE test runner, or a second terminal starts a run while one is already going.
+
+**How to tell it apart from a real failure** — all four hold for contention, none hold for content:
+
+1. **The phase.** Failure is at _collection_ — zero tests gathered, so no assertion ever executed. A broken import or bad config fails the same way, but see 2–4.
+2. **The blast radius.** Files unrelated to your change fail too. Content defects are selective; cache collisions are not.
+3. **Reproducibility.** Content fails deterministically on every run. Re-run the same command with nothing else running — contention clears, content does not.
+4. **No test name exists to capture.** That is a consequence of 1, and it is why the usual "capture the failing test name before you re-run" rule needs a substitute here.
+
+**Solution:** Ensure only one vitest process is running, then re-run. If it persists across serial runs, it is not this — treat it as a real failure and debug the import graph.
+
+**Record it even though it's benign.** [CLAUDE.md](../../../.claude/CLAUDE.md) requires capturing evidence before a re-run, because a green re-run destroys it (this is why BL-106's unreproduced flake stayed open). When collection fails there is no test name, so capture the **signature** instead: the phase, the full set of failing files, and what else was running. Observed 2026-08-06, where it was first misdiagnosed as a permanently broken local vitest install — the misdiagnosis was corrected only when the same command later passed in the same shell.
+
+---
+
 ### "Single test fails randomly (flaky test)"
 
 **Likely cause:** Race condition or timing-dependent assertion
@@ -207,6 +226,37 @@ cat .github/workflows/test.yml
 # 2. Select "Test" workflow
 # 3. Click "Run workflow" → select your branch
 ```
+
+### "A check is stuck — running for minutes with no logs, or queued with no job at all"
+
+**Symptom:** A job that normally takes seconds sits `in_progress` for many minutes and its log page is empty; or a run stays `queued` while `gh run view` shows no jobs. Downstream jobs report `skipping` because the job they gate on never produced its outputs.
+
+**First: is it your repo or GitHub?** Check the incident feed before investigating anything local — during an Actions incident this is not a repo problem and no config change will help:
+
+```bash
+curl -s https://www.githubstatus.com/api/v2/status.json          # overall indicator
+curl -s https://www.githubstatus.com/api/v2/incidents/unresolved.json  # open incidents
+```
+
+**Read the job's step count — it separates "slow" from "never started":**
+
+```bash
+gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
+  --jq '.jobs[] | "\(.status)/\(.conclusion // "-") steps=\(.steps|length) \(.name)"'
+```
+
+- `steps=0` **with a runner assigned** — the job was allocated but handed no work. There are no logs because no step ran. GitHub reaps these at **~15 minutes** with conclusion `cancelled`.
+- **No jobs at all** on a `queued` run — worse. Job creation is event-driven, so a throttled webhook layer leaves a bare run object nothing ever materialises. Observed 2026-08-06 while GitHub was processing ~15% of webhooks.
+
+**Do not keep re-running during an incident.** Each attempt costs ~15 minutes and ends the same way; if webhooks are throttled it is also likely to be dropped before it starts. Wait for the incident to reach `monitoring`/`resolved`, then re-run once.
+
+**Runs wedged by an incident may be unrecoverable.** After the 2026-08-06 outage the same run reported three contradictory states — `gh run list` said `queued`, `gh run cancel` said "Cannot cancel a workflow run that is completed", and `gh run rerun` said "cannot be rerun; This workflow is already running". No retry fixes that.
+
+**Remedy: close and reopen the PR.** This abandons the corrupted runs and triggers fresh `pull_request` runs with new IDs — the same fix documented for a PR stuck BLOCKED after "Update branch" (see [DEVELOPER_TOOLING.md](../development/DEVELOPER_TOOLING.md)). Prefer it over pushing an empty commit, which moves HEAD and invalidates the implementation-review marker the push gate requires.
+
+**Useful control:** if Vercel's checks are green on the same commit while Actions is stuck, that is strong evidence the diff is fine — Vercel builds on its own infrastructure.
+
+---
 
 ### "Tests pass locally but fail in CI on specific browser (Firefox or Safari)"
 
@@ -452,14 +502,16 @@ npx playwright install --with-deps
 
 ## Quick Reference
 
-| Problem           | Command                                 |
-| ----------------- | --------------------------------------- |
-| Run all tests     | `npm run test:all`                      |
-| Run specific test | `npx playwright test -g "test name"`    |
-| Debug test        | `npx playwright test --debug`           |
-| View headed       | `npx playwright test --headed`          |
-| Check coverage    | `npm run test:coverage`                 |
-| Clear Playwright  | `rm -rf ~/.cache/ms-playwright`         |
-| Run on Firefox    | `npx playwright test --project=firefox` |
+| Problem           | Command                                                                           |
+| ----------------- | --------------------------------------------------------------------------------- |
+| Run all tests     | `npm run test:all`                                                                |
+| Run specific test | `npx playwright test -g "test name"`                                              |
+| Debug test        | `npx playwright test --debug`                                                     |
+| View headed       | `npx playwright test --headed`                                                    |
+| Check coverage    | `npm run test:coverage`                                                           |
+| Clear Playwright  | `rm -rf ~/.cache/ms-playwright`                                                   |
+| Run on Firefox    | `npx playwright test --project=firefox`                                           |
+| Is GitHub down?   | `curl -s https://www.githubstatus.com/api/v2/status.json`                         |
+| Stuck CI job?     | `gh api repos/<owner>/<repo>/actions/runs/<id>/jobs --jq '.jobs[].steps\|length'` |
 
 See [README.md](./README.md) for more commands.


### PR DESCRIPTION
Two failures hit this repo on 2026-08-06. Neither was a test or repo problem, both were first misdiagnosed, and neither was written down anywhere. This adds an entry for each.

Docs-only: `src/docs/testing/TROUBLESHOOTING.md` and `src/docs/development/DEVELOPER_TOOLING.md`.

## 1. Every vitest suite fails at once, with zero tests collected

A second vitest process running concurrently kills collection before a single test registers — every suite red at the top-level `describe`, `TypeError: Cannot read properties of undefined (reading 'config')`, and **files your change never touched fail identically**.

It was first called a permanently broken local vitest install. That reading survived four reproductions and was only corrected when the same command later passed in the same shell.

The entry gives three discriminators (blast radius, reproducibility, absence of a test name) and — because the repo's rule is _capture the failing test name before you re-run_ — explains what to capture when there is no test name: the signature. Phase, full failing file set, and what else was running.

**The mechanism is explicitly not established.** The obvious shared-`node_modules/.vite` story fails outright for the likeliest collision here: root `test:run` against `test:mcp` use *separate* caches. So concurrency is labelled the observed trigger, and the cache / worker-state explanations are named as candidates rather than causes.

## 2. A check never finishes — no logs, or no job at all

During the outage, jobs were assigned runners and executed nothing. The log page was empty because no step ran.

The transferable finding is that **a step _count_ is not a did-it-start proxy — the step _names_ are.** `Set up job` is the runner's own provisioning step and appears alongside real steps on any job with a non-empty list, so `steps=1` looks like progress and means none. The supplied `jq` prints names, and was executed verbatim before being written down.

Four shapes, all observed:

| shape | meaning |
| --- | --- |
| `[]`, `runner_id` non-zero | runner allocated, handed no work |
| `[]`, `runner_id=0` | no runner ever assigned |
| `[Set up job]` and nothing after | picked up, never got past provisioning |
| `runner_id=null` with `[]` | benign — downstream jobs `skipped` because their gate produced no outputs |

Also recorded: check githubstatus.com **first**; don't re-run during an incident; and runs wedged by one may be **unrecoverable** — the same run reported `queued` to `gh run list`, "already completed" to `cancel`, and "already running" to `rerun`. Close and reopen the PR instead. That does not cancel the wedged runs; it works because `reopened` creates fresh ones, which depends on the workflow listing that trigger (all four required checks do — verified).

`DEVELOPER_TOOLING.md` gains a matching H3 that points here and distinguishes this from its neighbouring `gh run rerun` remedy, which applies to a concurrency-cancelled check whose sibling already completed.

## What review corrected

Three rounds. Every finding was a claim stated more confidently than its evidence, and none were catchable by a test:

| claim as written | what the data said |
| --- | --- |
| "GitHub reaps these at ~15 minutes" | the same job's three attempts: **2m42s, 7m48s, 15m04s** |
| `steps=0` "with a runner assigned" | the 15-minute attempt had `runner_id=0` — no runner ever assigned |
| quote from the 20:34Z update | it is from the **02:03Z** update, a day and a status later, and was truncated mid-sentence |
| "started, then killed mid-flight" | its only step was `Set up job` — it never started |
| "`Set up job` appears on every job" | refuted by this entry's own table nine lines below: three of four shapes have no steps at all |
| the corrected Vercel sentence | was added without deleting the original, so the file carried both |

One fix also introduced a rendering regression: promoting the bullet to an H3 consumed a blank line, turning a load-bearing paths-filter warning into a lazy continuation that rendered *inside* a bullet. Prettier accepts both forms and the docs guard doesn't render markdown, so nothing would have caught it. Verified fixed through GitHub's `POST /markdown` — one list, warning outside it.

The final `Set up job` invariant was verified across **27 jobs, 16 with non-empty step lists, zero violations** — with the check built to exit non-zero if no non-empty list was found, since "0 violations" is meaningless if the implication was never exercised.

## Verification

`npm run test:docs` 20/20 — meaningful here, since the entries add same-file anchors and a cross-doc link the guard evaluates (confirmed by temporarily breaking one and watching it fail). `prettier --check` clean on both files.

**Disclosed:** while writing the vitest entry, a `test:docs` run went red at collection — both files, zero tests, including `docs-variables-sync.test.ts`, which this branch does not touch — then passed four consecutive serial runs. That is discriminators 1 and 2 of the entry, observed on the entry itself. Second occurrence of the signature; captured rather than re-run past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
