### PR TITLE
fix(styles): strip the inert primary/secondary class tokens (BL-114)

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -56,7 +56,7 @@ const { title, subtitle, description, primaryCTA, secondaryCTA, trustLine } = As
                 {primaryCTA && (
                   <a
                     href={primaryCTA.href}
-                    class="cta-button primary"
+                    class="cta-button"
                     onclick="trackCTA('calendarbridge', 'hero')"
                     {...(primaryCTA.href.startsWith('http')
                       ? { target: '_blank', rel: 'noopener noreferrer' }
@@ -68,7 +68,7 @@ const { title, subtitle, description, primaryCTA, secondaryCTA, trustLine } = As
                 {secondaryCTA && (
                   <a
                     href={secondaryCTA.href}
-                    class="cta-button secondary"
+                    class="cta-button"
                     onclick="trackCTA('services', 'hero')"
                   >
                     {secondaryCTA.text}

--- a/src/components/brand/BrandComponents.astro
+++ b/src/components/brand/BrandComponents.astro
@@ -34,9 +34,10 @@
       <div class="brand-component-item">
         <a class="cta-button" href="#components">CTA Button</a>
         <code class="brand-code"
-          >.cta-button — single variant: filled primary, translateX hover. The `primary` /
-          `secondary` words seen in page markup are inert (no rule defines them); use
-          .brutal-btn--primary / --secondary for a two-variant pair</code
+          >.cta-button — single variant: filled primary, translateX hover. No rule ever defined the
+          bare `primary` / `secondary` words that used to ride alongside it in page markup; the last
+          of them were removed 2026-08-09. Use .brutal-btn--primary / --secondary for a two-variant
+          pair</code
         >
       </div>
     </div>

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -287,7 +287,8 @@ So: **filter chips, segmented controls, drawer/search closes, header nav links, 
 - [x] The 10 remaining bare `primary` / `secondary` tokens are stripped (or deliberately defined — see below). Counted rather than estimated, as of 2026-08-08: `Hero.astro` (2), the three `hub/library/*` article pages, `hub/radar/`, three tool pages' back-links, and the IRL generator's submit button (`information-request-list-generator/index.astro:272`) — the one that is not a back-link. **Done 2026-08-09**: the inventory was exact — all 10 found where predicted, stripped, none defined.
   - **An 11th was found and fixed, outside the count**: [STYLES_REMEDIATION_ROADMAP.md § 7](../styles/STYLES_REMEDIATION_ROADMAP.md) carried `class="cta-button secondary"` inside a **prescriptive** template for future tool pages. The stanza only ever counted rendered markup, but a doc that tells the next author to write the phantom variant is the same defect one step upstream — and it would have regrown the count.
   - **Verified inert before deleting, not assumed**: no rule in `src/styles/**` or any Astro scoped `<style>` selects `.primary` / `.secondary`, and nothing in `tests/` selects them (the one hit is prose in a `brand-page.test.ts` docblock describing this exact debt). So the strip is provably a no-op on rendered appearance.
-  - **Not built**: a repo-wide every-class-has-a-rule guard. `brand-page.test.ts`'s `ALLOWED_UNSTYLED` check — which caught the `/brand` half of this debt in 2026-07 — covers `/brand` only. Extending it site-wide would catch the next phantom variant, but it is machinery this stanza did not ask for and would need its own JS-hook allowlist per route.
+  - **Not built**: a repo-wide every-class-has-a-rule guard — filed as [BL-116](#bl-116-site-wide-orphan-class-guard) rather than left in this stanza, which is on a prune path.
+  - **A caption on `/brand` had to move with the markup.** `BrandComponents.astro`'s `.cta-button` code label read "the `primary` / `secondary` words **seen in page markup** are inert" — true when written, false the moment the last occurrence went. `/brand` is the in-repo control surface, so a caption keeping the phantom names alive in the present tense is the same defect the roadmap fix addressed, one step upstream. Reworded to the past tense.
 
 #### Technical Context
 
@@ -295,6 +296,27 @@ So: **filter chips, segmented controls, drawer/search closes, header nav links, 
 - **Stripping is mechanical and behaviour-free; _defining_ them is not** — `.cta-button.secondary` would restyle every "Back to …" link at once and needs a design decision first. Bare unnamespaced globals are also a collision hazard: prefer `.brutal-btn--primary` / `--secondary` when a real two-variant pair is wanted.
 
 ---
+
+### BL-116: Site-wide orphan-class guard
+
+**Source**: split out of [BL-114](#bl-114-strip-the-10-inert-primary--secondary-class-tokens) on its closure 2026-08-09 — the observation was written inside a stanza already marked CLOSED, where the next prune wave would have deleted it | **Effort**: Small-Medium — the guard is a port; the per-route JS-hook allowlist is the work | **Status**: Open
+
+**As a** developer reading page markup anywhere on the site, **I want** a class with no rule behind it to fail CI **so that** phantom variants are caught when written rather than by a live DOM audit three months later.
+
+**Why it is filed rather than done.** The same defect has now been found and hand-fixed **three times**: 28 orphan classes on `/brand` (2026-07-29, which also surfaced a live TechPar defect from the identical cause), the 9 on the two hub gateway indexes (BL-105, 2026-08-03), and BL-114's 10 across 8 page files plus a prescriptive doc template (2026-08-09). A defect class that recurs on that cadence is a guard's job, not an audit's.
+
+**Prior art to port, not re-derive**: `tests/e2e/brand-page.test.ts`'s "No orphan classes" check already does this for `/brand`, with an `ALLOWED_UNSTYLED` list for classes that are genuinely JS hooks. Adding to that list is deliberately an explicit act.
+
+#### Acceptance Criteria
+
+- [ ] Every class in the rendered DOM of each scanned route has a CSS rule behind it, or sits in a per-route allowlist with a stated reason
+- [ ] The allowlist follows `ALLOWED_UNSTYLED`'s posture — a JS-hook declaration, not a place to silence findings — and a stale entry fails the suite, per the `FLOOR_EXCEPTIONS` precedent from BL-096
+- [ ] Route coverage is stated, and whatever is excluded says why
+
+#### Technical Context
+
+- **Carry forward the existing guard's documented precision limit**: it counts a class as defined if the name appears in any selector anywhere, including as a descendant qualifier. A site-wide version inherits that, so it will not catch a class defined only under a parent it never actually sits inside.
+- Scope question to settle first: reuse the 22-route axe list from BL-096, or scan a narrower set. The 22 routes are already paid for as a Playwright fixture.
 
 ### BL-094: Off-scale font-size literals — type-scale ruling + sweep (deferred)
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -278,13 +278,16 @@ So: **filter chips, segmented controls, drawer/search closes, header nav links, 
 
 ### BL-114: Strip the 10 inert `.primary` / `.secondary` class tokens
 
-**Source**: relocated from BL-095's technical context when that initiative closed (2026-08-08) — the record predates the closeout and remains a real obligation | **Effort**: Small (the strip); the _define_ path needs a design decision first | **Status**: Open
+**Source**: relocated from BL-095's technical context when that initiative closed (2026-08-08) — the record predates the closeout and remains a real obligation | **Effort**: Small (the strip); the _define_ path needs a design decision first | **Status**: **CLOSED 2026-08-09** — stripped, not defined
 
 **As a** developer reading page markup, **I want** every class on an element to do something **so that** markup doesn't teach phantom variants.
 
 #### Acceptance Criteria
 
-- [ ] The 10 remaining bare `primary` / `secondary` tokens are stripped (or deliberately defined — see below). Counted rather than estimated, as of 2026-08-08: `Hero.astro` (2), the three `hub/library/*` article pages, `hub/radar/`, three tool pages' back-links, and the IRL generator's submit button (`information-request-list-generator/index.astro:272`) — the one that is not a back-link.
+- [x] The 10 remaining bare `primary` / `secondary` tokens are stripped (or deliberately defined — see below). Counted rather than estimated, as of 2026-08-08: `Hero.astro` (2), the three `hub/library/*` article pages, `hub/radar/`, three tool pages' back-links, and the IRL generator's submit button (`information-request-list-generator/index.astro:272`) — the one that is not a back-link. **Done 2026-08-09**: the inventory was exact — all 10 found where predicted, stripped, none defined.
+  - **An 11th was found and fixed, outside the count**: [STYLES_REMEDIATION_ROADMAP.md § 7](../styles/STYLES_REMEDIATION_ROADMAP.md) carried `class="cta-button secondary"` inside a **prescriptive** template for future tool pages. The stanza only ever counted rendered markup, but a doc that tells the next author to write the phantom variant is the same defect one step upstream — and it would have regrown the count.
+  - **Verified inert before deleting, not assumed**: no rule in `src/styles/**` or any Astro scoped `<style>` selects `.primary` / `.secondary`, and nothing in `tests/` selects them (the one hit is prose in a `brand-page.test.ts` docblock describing this exact debt). So the strip is provably a no-op on rendered appearance.
+  - **Not built**: a repo-wide every-class-has-a-rule guard. `brand-page.test.ts`'s `ALLOWED_UNSTYLED` check — which caught the `/brand` half of this debt in 2026-07 — covers `/brand` only. Extending it site-wide would catch the next phantom variant, but it is machinery this stanza did not ask for and would need its own JS-hook allowlist per route.
 
 #### Technical Context
 

--- a/src/docs/development/BACKLOG.md
+++ b/src/docs/development/BACKLOG.md
@@ -317,6 +317,9 @@ So: **filter chips, segmented controls, drawer/search closes, header nav links, 
 
 - **Carry forward the existing guard's documented precision limit**: it counts a class as defined if the name appears in any selector anywhere, including as a descendant qualifier. A site-wide version inherits that, so it will not catch a class defined only under a parent it never actually sits inside.
 - Scope question to settle first: reuse the 22-route axe list from BL-096, or scan a narrower set. The 22 routes are already paid for as a Playwright fixture.
+- **Count files, then count routes — they diverge.** BL-114's 10 tokens sat in 8 files, but one was `Hero.astro`, a shared component rendering on five routes (`index`, `about`, `services`, `404`, `500`). A file-count reading of that recurrence understates the reach, and this guard is scoped by route, not by file.
+
+---
 
 ### BL-094: Off-scale font-size literals — type-scale ruling + sweep (deferred)
 

--- a/src/docs/styles/STYLES_REMEDIATION_ROADMAP.md
+++ b/src/docs/styles/STYLES_REMEDIATION_ROADMAP.md
@@ -267,7 +267,7 @@ Tracked initiatives to close the gap between documented conventions and actual i
         <!-- Tool-specific content -->
       </div>
     </div>
-    <a href="/hub/tools" class="cta-button secondary">Return to Tools</a>
+    <a href="/hub/tools" class="cta-button">Return to Tools</a>
   </div>
 </section>
 ```

--- a/src/pages/hub/library/business-architectures/index.astro
+++ b/src/pages/hub/library/business-architectures/index.astro
@@ -1434,7 +1434,7 @@ import TableOfContents from '../../../../components/TableOfContents.astro';
         </div>
       </div>
 
-      <a href="/hub/library/" class="cta-button secondary back-link">Back to The Library</a>
+      <a href="/hub/library/" class="cta-button back-link">Back to The Library</a>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/hub/library/information-request-list/index.astro
+++ b/src/pages/hub/library/information-request-list/index.astro
@@ -39,7 +39,7 @@ const tocItems = getHeadings()
         </article>
       </div>
 
-      <a href="/hub/library/" class="cta-button secondary back-link">Back to The Library</a>
+      <a href="/hub/library/" class="cta-button back-link">Back to The Library</a>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/hub/library/vdr-structure/index.astro
+++ b/src/pages/hub/library/vdr-structure/index.astro
@@ -958,7 +958,7 @@ import TableOfContents from '../../../../components/TableOfContents.astro';
         </div>
       </div>
 
-      <a href="/hub/library/" class="cta-button secondary back-link">Back to The Library</a>
+      <a href="/hub/library/" class="cta-button back-link">Back to The Library</a>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/hub/radar/index.astro
+++ b/src/pages/hub/radar/index.astro
@@ -66,7 +66,7 @@ import { CATEGORIES } from '../../../lib/inoreader/transform';
         <RadarFeedSkeleton slot="fallback" />
       </RadarFeed>
 
-      <a href="/hub/" class="cta-button secondary">Return to Hub</a>
+      <a href="/hub/" class="cta-button">Return to Hub</a>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/hub/tools/information-request-list-generator/index.astro
+++ b/src/pages/hub/tools/information-request-list-generator/index.astro
@@ -269,12 +269,12 @@ const irlSections = parseIrlArticle(articleBodyRaw).sections.map((s) => ({
           <span>Include canonical reference link in the workbook header</span>
         </label>
 
-        <button type="submit" class="cta-button primary irl-gen__cta">Download IRL (.xlsx)</button>
+        <button type="submit" class="cta-button irl-gen__cta">Download IRL (.xlsx)</button>
 
         <p id="irl-gen-status" class="irl-gen__status" role="status" aria-live="polite"></p>
       </form>
 
-      <a href="/hub/tools/" class="cta-button secondary irl-gen__back">Back to Tools</a>
+      <a href="/hub/tools/" class="cta-button irl-gen__back">Back to Tools</a>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/hub/tools/regulatory-map/index.astro
+++ b/src/pages/hub/tools/regulatory-map/index.astro
@@ -266,7 +266,7 @@ import { hubToolSchema } from '../../../../utils/hub-tool-schema';
           requirements with qualified counsel.
         </p>
       </div>
-      <a href="/hub/tools/" class="cta-button secondary back-link">Back to Tools</a>
+      <a href="/hub/tools/" class="cta-button back-link">Back to Tools</a>
     </div>
   </section>
   <link rel="preload" href="/data/reg-index.json" as="fetch" crossorigin />

--- a/src/pages/hub/tools/tech-debt-calculator/index.astro
+++ b/src/pages/hub/tools/tech-debt-calculator/index.astro
@@ -608,7 +608,7 @@ import { hubToolSchema } from '../../../../utils/hub-tool-schema';
         </div>
       </div>
 
-      <a href="/hub/tools/" class="cta-button secondary back-link">Return to Tools</a>
+      <a href="/hub/tools/" class="cta-button back-link">Return to Tools</a>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
Closes BL-114.

## What

`buttons.css` defines exactly one CTA appearance, `.cta-button`. The bare `primary` / `secondary` tokens riding alongside it match no rule anywhere in the repo, so `class="cta-button secondary"` documents a variant that does not exist — anyone reading it reasonably concludes there is a pair to pick from.

BL-114's inventory turned out to be exact: all 10 were where it predicted, and all 10 are **stripped rather than defined**. Defining them stays out of scope on purpose — `.cta-button.secondary` would restyle every "Back to …" link on the site at once, which is a design decision, not a cleanup.

- `Hero.astro` ×2
- Three `hub/library/*` back-links (business-architectures, information-request-list, vdr-structure)
- `hub/radar/` "Return to Hub"
- Three tool back-links (tech-debt-calculator, regulatory-map, IRL generator)
- The IRL generator's submit button — the one that is not a back-link

## Two things found on the way in

**An 11th occurrence, outside the count.** `STYLES_REMEDIATION_ROADMAP.md § 7` carried the same token inside a **prescriptive** template for future tool pages. The stanza only ever counted rendered markup, but a doc telling the next author to write the phantom variant is the same defect one step upstream — and would have regrown the count after this PR.

**A `/brand` caption that went false as the strip landed.** `BrandComponents.astro` read "the `primary` / `secondary` words **seen in page markup** are inert" — true when written, false the moment the last occurrence went. `/brand` is the control surface every session is told to copy from, so a caption holding phantom names in the present tense is the same failure again. Reworded to past tense.

## Why this is safe without visual review

Proved inert before deleting rather than assumed: no rule in `src/styles/**` or any Astro scoped `<style>` selects `.primary` / `.secondary`, no external stylesheet can supply one, and nothing in `tests/` selects them — the only grep hit is prose in a `brand-page.test.ts` docblock describing this exact debt. Removing a class cannot alter the specificity of selectors that still match, so the strip is provably a no-op on rendered appearance.

Worth noting the blast radius is wider than 8 files suggests: `Hero.astro` renders on five routes (`index`, `about`, `services`, `404`, `500`). Every live selector aimed at a touched element keys off a retained class.

## Also filed

**BL-116** — a site-wide orphan-class guard. This defect class has now been hand-fixed three times (28 classes on `/brand`, 9 on the hub gateway indexes under BL-105, 10 here). `brand-page.test.ts`'s existing `ALLOWED_UNSTYLED` check does the job for `/brand` only; the stanza names it as the thing to port and carries forward its documented precision limit. Filed rather than built — it is machinery BL-114 did not ask for.

## Verification

`npx astro check` 0 errors / 0 warnings / 0 hints · `npm run lint` clean · `npm run lint:css` 0 errors (138 pre-existing BL-094 font-size warnings; no CSS touched) · `npm run test:run` 1370 passed across 54 files · `npm run test:docs` 20/20. E2E not run per Directive 5.

Reviewed by the `code-reviewer` agent across three rounds; all findings fixed in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
