### PR TITLE
fix(ci): assert the MCP deploy chain, and retire four stale CI doc claims

### DIFF
--- a/.github/workflows/deploy-mcp-production.yml
+++ b/.github/workflows/deploy-mcp-production.yml
@@ -27,8 +27,11 @@ name: Deploy MCP Worker — production
 #      Issue, production silently drifting behind master. That is the failure
 #      class that once left production a month behind.
 #   5. `workflows: ['MCP Server Test Suite']` is a literal string match against
-#      that workflow's `name:`. A rename breaks the chain silently, and nothing
-#      asserts the two agree.
+#      that workflow's `name:`. A rename breaks the chain silently — which is
+#      why `tests/integration/workflow-chain-integrity.test.ts` now asserts the
+#      two agree, and further asserts that the name resolves to the same FILE
+#      that `scripts/await-mcp-test-run.sh` polls below. That test was written
+#      because this comment sat here for months describing an unguarded gap.
 #
 # Reviewer gate: GitHub Settings → Environments → `mcp-production` must be
 # configured with Required reviewers ≥ 1 BEFORE this workflow can deploy.

--- a/.github/workflows/deploy-mcp-staging.yml
+++ b/.github/workflows/deploy-mcp-staging.yml
@@ -35,6 +35,14 @@ on:
     # surfaced two gaps: `feature-*` didn't match slash-style branches, and
     # `master` was missing so the merge commit never got staging validation).
     # `dev` retired 2026-05-31 (CLAUDE.md § Branch Strategy) — dropped BL-111.
+    #
+    # Guarded by `tests/integration/workflow-chain-integrity.test.ts` (assertion C):
+    # `master` must be present, and this list must stay a SUBSET of the suite's push
+    # branches. The subset half is what keeps `dependabot/**` deliberately absent here
+    # from being "fixed" into a list that deploys from branches the suite never tested.
+    # A miss on this filter produces NO run record at all — nothing red, nothing in the
+    # Actions list, staging simply frozen — which is how the BL-038 regression above
+    # went unnoticed in the first place.
     branches: [master, 'feat/**', 'fix/**', 'feature/**']
 
 permissions:

--- a/.github/workflows/test-mcp-server.yml
+++ b/.github/workflows/test-mcp-server.yml
@@ -23,6 +23,14 @@ on:
     # 'docs/**' + 'chore/**' added 2026-07-15: GitHub "Update branch" pushes also
     # arrive as `synchronize`, so these families need push-trigger coverage or
     # updated PRs stall BLOCKED (observed on PR #316). Lockstep with test.yml.
+    #
+    # `master` in this list is load-bearing beyond CI: `scripts/await-mcp-test-run.sh`
+    # gates every production deploy on a `?event=push` run for the exact SHA, so
+    # dropping it here would fail the pre-flight on every merge.
+    # `tests/integration/workflow-chain-integrity.test.ts` (assertion B) asserts both
+    # halves — master here, and `event=push` there. It reads this list TRIGGER-SCOPED,
+    # because the `pull_request` block below also carries `branches: [master]` and a
+    # union would stay green after master was dropped from exactly this list.
     branches:
       [master, dev, 'feat/**', 'fix/**', 'feature/**', 'dependabot/**', 'docs/**', 'chore/**']
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,16 @@ concurrency:
   # same ref do NOT cross-cancel. A push to dev with an open PR previously
   # had both events fire with identical group keys; cancel-in-progress
   # then killed the push run, leaving branch protection with a cancelled
-  # required check. Separating the groups lets push run to completion
-  # while skip-duplicate-actions short-circuits the concurrent PR run.
+  # required check. Separating the groups lets both run to completion.
+  #
+  # This comment used to end "...while skip-duplicate-actions short-circuits
+  # the concurrent PR run." That is no longer true and the distinction
+  # matters: the `skip_dup` step that replaced that action queries
+  # `status=success` runs only, and an in-flight run is never `success`, so
+  # nothing short-circuits a CONCURRENT sibling any more. Both events now do
+  # the work when they fire together; this group key is the only thing
+  # keeping them from cancelling each other. See DEVELOPER_TOOLING.md
+  # § Duplicate-run dedup.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -875,7 +875,7 @@ gh api "repos/:owner/:repo/actions/workflows/deploy-mcp-staging.yml/runs?per_pag
   --jq '.workflow_runs[] | "#\(.run_number) \(.conclusion)"'
 ```
 
-As of 2026-08-16 that workflow has **0 cancelled runs in 339**, and 21 skipped. (Cancelled runs on `deploy-mcp-production.yml` are a different, expected thing — see § MCP production deploy.)
+As of 2026-08-16 that workflow has **0 cancelled runs in 339**, and 21 skipped. (Cancelled runs on `deploy-mcp-production.yml` are a different, expected thing — see § Production deploy is latest-wins.)
 
 A skipped run means one clause of the job `if:` in [deploy-mcp-staging.yml](../../../.github/workflows/deploy-mcp-staging.yml) was false. It is a **three-clause AND**, and the arms are not equally benign:
 

--- a/src/docs/development/DEVELOPER_TOOLING.md
+++ b/src/docs/development/DEVELOPER_TOOLING.md
@@ -125,11 +125,12 @@ The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workfl
 │    │ Two independent checks gate the expensive jobs:            │
 │    │  1. dorny/paths-filter@v4 — does this push/PR touch any   │
 │    │     non-docs files? Outputs `code: true | false`.          │
-│    │  2. fkirc/skip-duplicate-actions@v5 — has a prior run     │
-│    │     already completed successfully with the same TREE     │
-│    │     hash? Outputs `duplicate: true | false`. Catches       │
-│    │     push→PR redundancy: push to dev passes, PR dev→master │
-│    │     fires on a different commit SHA but identical tree.   │
+│    │  2. `skip_dup` — a hand-rolled `gh api` query: does any   │
+│    │     of the last 10 SUCCESSFUL runs of this workflow have  │
+│    │     the same TREE hash? Outputs `duplicate: true|false`.  │
+│    │     Catches push→PR redundancy: push to a branch passes,  │
+│    │     the PR fires on a different commit SHA but identical  │
+│    │     tree.                                                  │
 │    │                                                            │
 │    │ Combined output `should_run = code && !duplicate`.         │
 │    │ Downstream jobs key off should_run.                        │
@@ -169,10 +170,9 @@ The GitHub Actions workflow [.github/workflows/test.yml](../../../.github/workfl
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-All three jobs are **required status checks** on two branch rulesets:
+All three of these jobs are **required status checks** on the `master` ruleset (12237842) — PRs cannot merge until they pass, and `strict_required_status_checks_policy: true` additionally requires the branch to be up to date. A fourth required context, **Verify doc links**, comes from [docs-integrity.yml](../../../.github/workflows/docs-integrity.yml) rather than `test.yml` (see the config table below), so the ruleset lists four contexts while `test.yml` supplies three of them.
 
-- **`master`** (ruleset 12237842) — PRs cannot merge until all checks pass
-- **`feat/**` and `fix/**`** (ruleset 15011377) — pushes to feature/fix branches are blocked until checks pass, shifting test failures left instead of deferring to PR time
+> **A second ruleset used to exist and no longer does.** This section previously documented ruleset `15011377` covering `feat/**` and `fix/**`, which blocked pushes to feature branches until checks passed — shifting test failures left instead of deferring them to PR time. `GET /repos/{owner}/{repo}/rulesets` now returns only `12237842`. Whether that was removed deliberately is **not recorded anywhere**, so this note states the observation rather than a conclusion: if you want push-time gating on feature branches back, it has to be re-created, and if it was retired on purpose, replace this paragraph with that decision.
 
 #### Paths-filter syntax notes (load-bearing)
 
@@ -196,22 +196,24 @@ filters: |
     - '!.claude/**'
 ```
 
-The job also sets `permissions: { contents: read, pull-requests: read }` so paths-filter can use the GitHub API on PR events instead of falling back to git-based detection.
+The job sets `permissions: { contents: read, pull-requests: read, actions: read }`. The first two let paths-filter use the GitHub API on PR events instead of falling back to git-based detection; `actions: read` is what the duplicate-run query below needs to list prior runs of this workflow.
 
 If the gate misbehaves, check the **"Log gate decision"** step output — it prints `code=true/false`, `duplicate=true/false`, `should_run=true/false`, and the JSON-formatted list of matched files, so you can see exactly what the gate saw without having to re-derive the evaluation. If the matched-file count looks suspiciously large (e.g. dozens of files for a single-file push), the `base` configuration is wrong — paths-filter is diffing against the default branch instead of the previous commit.
 
-#### Duplicate-run dedup (fkirc/skip-duplicate-actions)
+#### Duplicate-run dedup (hand-rolled tree-hash query)
 
-The gate job also runs [`fkirc/skip-duplicate-actions@v5`](https://github.com/fkirc/skip-duplicate-actions) before paths-filter, which dedupes on **tree hash** (content) rather than commit SHA. The canonical case it catches: push to `dev` passes all three checks → PR `dev→master` fires the same workflow on a synthetic merge-ref SHA whose tree is identical (since master hasn't moved), so the second run is redundant work on content that's already been validated. The action returns `should_skip=true` and the gate's `duplicate` output is `true`; each downstream job's real steps skip and the "Skipped (docs-only or duplicate run)" step runs instead, reporting success to satisfy branch protection.
+The gate job's `skip_dup` step dedupes on **tree hash** (content) rather than commit SHA. The canonical case it catches: a push to a branch passes all three checks → the PR fires the same workflow on a synthetic merge-ref SHA whose tree is identical (since `master` hasn't moved), so the second run is redundant work on content that's already been validated. When a match is found the gate's `duplicate` output is `true`; each downstream job's real steps skip and the "Skipped (docs-only or duplicate run)" step runs instead, reporting success to satisfy branch protection.
 
-Key configuration choices:
+> **This used to be [`fkirc/skip-duplicate-actions@v5`](https://github.com/fkirc/skip-duplicate-actions)** and is now about 20 lines of shell — the action pinned Node 20, which GitHub deprecated. The replacement is deliberately dumber than what it replaced, and the differences below are behavioural, not cosmetic.
 
-- `concurrent_skipping: 'same_content_newer'` — when push and PR events fire simultaneously on the same commit (e.g. commit to a branch that already has an open PR), the action sees two concurrent runs with identical tree hashes and skips whichever started second. Combined with the event-scoped concurrency group below, this means exactly one run does the work while the other short-circuits; neither cancels the other, so required status checks don't end up in a cancelled state.
-- Workflow-level `concurrency.group` is scoped by `github.event_name` so push and pull_request runs on the same ref don't share a group — they no longer cross-cancel. Previously a push to `dev` with an open PR was cancelled the moment the PR run started, leaving branch protection with a cancelled required check even though the PR run succeeded.
-- `skip_after_successful_duplicate: 'true'` (default) — only skip when the duplicate has a **successful** conclusion. A duplicate of a failed run still triggers a fresh test run.
-- `do_not_skip: '["workflow_dispatch", "schedule", "merge_group"]'` — manual re-runs via the UI use `workflow_dispatch` and intentionally want to re-test; scheduled runs are cron-driven and shouldn't skip; merge-queue runs must run fresh because the queue may have updated `master` between the PR and the merge-queue entry. Notably `push` and `pull_request` are NOT in this list — they dedupe as expected.
+What the shell version actually does ([test.yml](../../../.github/workflows/test.yml), step `skip_dup`): query `actions/workflows/test.yml/runs?status=success&per_page=10`, fetch each run's commit tree hash, and compare against `git rev-parse HEAD^{tree}`. That is the whole mechanism. Consequences worth knowing:
 
-The `actions: write` permission on the gate job is required by skip-duplicate-actions to query prior workflow runs via the REST API.
+- **No concurrency awareness.** The old `concurrent_skipping: 'same_content_newer'` option deduped two _in-flight_ runs against each other. An in-flight run is never `status=success`, so the shell version cannot see one. Simultaneous push and PR events on the same commit now both do the work. What keeps them from cross-cancelling is the workflow-level `concurrency.group`, which is scoped by `github.event_name` — that is still in force ([test.yml](../../../.github/workflows/test.yml)) and is what stopped a push to a branch with an open PR being cancelled the moment the PR run started, leaving branch protection with a cancelled required check.
+- **Only successful runs dedupe** — the `status=success` filter. A duplicate of a failed run still triggers a fresh run. (The old `skip_after_successful_duplicate: 'true'` gave the same behaviour; the option is gone, the behaviour isn't.)
+- **No event exemptions.** The old `do_not_skip: '["workflow_dispatch", "schedule", "merge_group"]'` list does not exist. Nothing is specially exempt now, including manual re-runs — see the troubleshooting section for what that does and does not imply.
+- **Only the last 10 successful runs are examined.** An older duplicate outside that window is simply not found.
+
+Note the archived initiative doc [`_archive/MCP_SERVER_CI_CD_DEPLOY_BL-037.md`](_archive/MCP_SERVER_CI_CD_DEPLOY_BL-037.md) still describes the `fkirc` action. That is **intentional** — archived docs are kept verbatim as a record of what was true when the initiative closed. Do not "correct" them.
 
 ---
 
@@ -858,11 +860,41 @@ Open the run on the Actions tab and expand the **Detect Code Changes** job's "Lo
 - **`should_run=true`, large `matched-files` list (dozens of files for a one-file push)**: paths-filter is diffing against the wrong base. Confirm `base: ${{ github.ref_name }}` is present on the paths-filter step; without it, the action defaults to the repo's default branch (`master`) and the filter sees every unmerged commit on the current branch
 - **`should_run=false` but jobs still ran full flow**: a step is missing the `if: needs.changes.outputs.should_run == 'true'` guard somewhere
 - **`code=true`, sensible file list on a pure docs push**: the filter matched a file you didn't expect — inspect the list. Adjust the negations or add a new one (docs directory? config file? auto-generated artifact? lock file?)
-- **`duplicate=false` when a prior successful run had the same content**: the prior run may have failed or been cancelled (only `success` conclusions dedupe), or the tree hash differs (one file changed that you didn't realize — check `git diff <prior-sha>..HEAD --stat`). Manual re-runs via the UI intentionally bypass dedup via `do_not_skip: ["workflow_dispatch", ...]`
-- **`duplicate=true` but you wanted a re-run**: trigger via "Re-run all jobs" in the Actions UI (uses `workflow_dispatch`, bypasses dedup) rather than pushing a no-op commit
+- **`duplicate=false` when a prior successful run had the same content**: the prior run may have failed or been cancelled (only `success` conclusions dedupe), or the tree hash differs (one file changed that you didn't realize — check `git diff <prior-sha>..HEAD --stat`), or the matching run has fallen outside the 10 most recent successful runs the query examines
+- **`duplicate=true` but you wanted a re-run**: there is **no event exemption any more.** The `do_not_skip` list belonged to `fkirc/skip-duplicate-actions` and did not survive the move to the hand-rolled query, so nothing — including "Re-run all jobs" — is specially exempt. What a UI re-run does is therefore not a special case, it is the ordinary rule applied again: the step re-queries the last 10 successful runs and skips only if one of them still carries this tree hash. Do not assume either outcome; read the `duplicate=` line in the re-run's own gate log. If you need the work to definitely happen, change the tree (this is the one case where a no-op commit is the honest tool, not a workaround)
 - **PR blocked with a cancelled push-event check alongside a successful pull_request-event check**: the workflow's concurrency group must be scoped by `github.event_name` — without it, the two events collide in the same group and `cancel-in-progress: true` cancels the first-started run. Immediate fix: `gh run rerun <cancelled-run-id>` on the cancelled run (safe because the sibling has already completed). Durable fix: confirm the workflow's `concurrency.group` includes `github.event_name`
 
 Never remove the positive `**` catch-all when adding more negations — with `predicate-quantifier: 'every'`, a negation-only list always produces `code=false` regardless of the actual changeset.
+
+### "There are cancelled MCP staging deploys on every PR"
+
+**They are almost certainly `skipped`, not `cancelled`.** GitHub draws both with a grey circle-slash icon and they are indistinguishable at list density. Check before diagnosing:
+
+```bash
+gh api "repos/:owner/:repo/actions/workflows/deploy-mcp-staging.yml/runs?per_page=20" \
+  --jq '.workflow_runs[] | "#\(.run_number) \(.conclusion)"'
+```
+
+As of 2026-08-16 that workflow has **0 cancelled runs in 339**, and 21 skipped. (Cancelled runs on `deploy-mcp-production.yml` are a different, expected thing — see § MCP production deploy.)
+
+A skipped run means one clause of the job `if:` in [deploy-mcp-staging.yml](../../../.github/workflows/deploy-mcp-staging.yml) was false. It is a **three-clause AND**, and the arms are not equally benign:
+
+- **`event == 'push'` failed** — the upstream run was a `pull_request` event. Routine: the MCP suite fires on both `push` and `pull_request`, both runs are named `MCP Server Test Suite`, and `workflow_run` has no filter for the triggering run's event type, so GitHub creates the consumer run and the job `if:` (BL-111 fork-trust guard) then skips it. Nothing deployed because nothing should have.
+- **`conclusion == 'success'` failed** — and this is **not one thing**. `failure` means the MCP suite went red and the deploy was correctly withheld: that is a real signal, not noise. `cancelled` is benign when it occurs — [test-mcp-server.yml](../../../.github/workflows/test-mcp-server.yml) runs `cancel-in-progress: true`, so a superseded run is cancelled and the *winning* push deploys (verified empirically 2026-05-31). `timed_out` and `action_required` land on the same arm; treat the list as open, not closed. For calibration: of the 21 skips to date, 15 are the `pull_request` arm and 6 are `failure` — **none has yet come from a cancellation**, so do not assume that reading.
+- **`head_repository` failed** — a fork. Unexercised; the repo has no forks.
+
+**Do not diagnose from the consumer run alone.** Its own conclusion is just `skipped`, and you cannot cross-reference by SHA: a `workflow_run` consumer is attributed to the **default branch**, so its `head_sha` and `head_branch` are master's, not the triggering run's (the real SHA is read from the event payload at the checkout step). Read the *triggering* run:
+
+```bash
+gh api "repos/:owner/:repo/actions/runs/<consumer-run-id>" \
+  --jq '.referenced_workflows, .triggering_actor.login'
+gh api "repos/:owner/:repo/actions/workflows/test-mcp-server.yml/runs?per_page=20" \
+  --jq '.workflow_runs[] | "\(.created_at) ev=\(.event) concl=\(.conclusion) br=\(.head_branch)"'
+```
+
+and match on timestamp — the consumer is created 1–3 seconds after the run that triggered it.
+
+**A `branches:` mismatch is not a skip cause.** If the triggering branch isn't in the consumer's `branches:` list, GitHub creates **no run record at all** — there is nothing grey to see. Positive evidence: `dependabot/**`, `docs/**` and `chore/**` upstream runs, including failed ones, produce zero staging rows because those families are deliberately absent from the consumer's list. A silent absence is the failure mode to worry about here, which is why `tests/integration/workflow-chain-integrity.test.ts` asserts `master` is in both branch lists.
 
 ### "A check never finishes — no logs, or no job at all"
 
@@ -924,4 +956,4 @@ Two manual steps are required to complete Phase 2:
 
 ---
 
-**Last Updated**: August 5, 2026 (BL-111 — the production deploy's pre-flight guard extracted to `scripts/await-mcp-test-run.sh` with an exit-code contract, staging refuses fork-triggered runs, and the deploy-failure notification was made to actually fire)
+**Last Updated**: August 16, 2026 (MCP deploy-chain integrity asserted in `tests/integration/workflow-chain-integrity.test.ts`; the duplicate-run dedup section corrected to describe the hand-rolled tree-hash query that replaced `fkirc/skip-duplicate-actions`; ruleset `15011377` recorded as no longer existing; new troubleshooting entry for skipped-vs-cancelled staging deploys)

--- a/tests/integration/helpers/workflow-parse.ts
+++ b/tests/integration/helpers/workflow-parse.ts
@@ -7,24 +7,38 @@
  *
  * **Equivalence checked, not assumed.** Across all 12 workflow files these extractors and the
  * real `yaml` parser agree exactly — 12 names, 5 `paths` blocks, 10 trigger-scoped `branches`
- * lists, 1 `workflow_run.workflows` list, **zero disagreements** (measured 2026-08-16, not
- * estimated). That agreement is what justifies not taking the dependency; **re-run the
- * differential if any extractor changes.** The method is the one `workflow-secret-scope.test.ts`
- * (lines 79-84) records as the only one that actually worked there: vigilance produced ten
- * fail-open paths, running the hand parser against `yaml` and diffing produced a fact.
+ * lists, 1 `workflow_run.workflows` list, **zero disagreements** (measured, not estimated).
+ * That agreement is what justifies not taking the dependency; **re-run the differential if any
+ * extractor changes.** The method is the one `workflow-secret-scope.test.ts` (lines 79-84)
+ * records as the only one that actually worked there: vigilance produced ten fail-open paths,
+ * running the hand parser against `yaml` and diffing produced a fact.
  *
  * **THESE PARSERS MUST NOT FAIL OPEN.** A parser that returns `[]` or `undefined` for input it
  * cannot read makes every downstream assertion pass vacuously — the caller cannot tell "nothing
  * matched" from "nothing to match". So every function here THROWS on unreadable input rather
  * than returning an empty result, and callers pair each assertion with a non-zero probe.
  *
- * Two shapes bit the sibling file and are handled here from the start:
+ * **The differential is necessary but not sufficient, and that cost a real defect.** It compares
+ * this parser against `yaml` on the CURRENT tree, so it can only see shapes the repo happens to
+ * contain today. It passed clean while `triggerBranches` still had a fail-open: its accumulation
+ * loop was bounded by end-of-file rather than by the trigger block, so rewriting a `branches:`
+ * list in **block-sequence form** (legal YAML, accepted by GitHub) made the reader run past the
+ * trigger and adopt the NEXT trigger's list. A mutation dropping `master` from the push list
+ * then parsed as `['master']` — borrowed from the `pull_request` trigger below it — and the
+ * assertion guarding that exact regression stayed green. Caught in code review, not by the
+ * differential and not by the mutation matrix, because both only exercised shapes already in the
+ * tree. **The structural answer is `workflow-parse-guards.test.ts`**, which drives every throw
+ * path in this file over synthetic fixtures, including shapes the repo does not currently use.
+ * Add a case there for any parsing rule you add here.
+ *
+ * Shapes handled from the start, each because it bit the sibling file or this one:
  *   - trailing comments are legal after any scalar (`name: Foo # note`);
- *   - quoted and bare scalars are the same value (`'master'` === `master`).
- * A third is specific to this repo: `branches:` values are written as **flow sequences on the
- * line after the key**, and `.github/**` is not in `.prettierignore`, so a list that grows past
- * `printWidth: 100` reflows across several lines. Single-line anchoring would silently stop
- * matching on a routine edit, so the flow-sequence reader is multi-line.
+ *   - quoted and bare scalars are the same value (`'master'` === `master`);
+ *   - `branches:` flow sequences reflow across lines once they pass `printWidth: 100`, and
+ *     `.github/**` is not in `.prettierignore`, so single-line anchoring would silently stop
+ *     matching on a routine edit — the reader is multi-line but **bounded to its trigger**;
+ *   - the block-sequence form of `branches:` and the inline form of `paths:` are legal YAML
+ *     that these parsers do NOT read, so they throw rather than return a partial answer.
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -41,18 +55,31 @@ export function readWorkflow(file: string): string[] {
   return readFileSync(join(WORKFLOWS_DIR, file), 'utf8').split(/\r?\n/);
 }
 
-/** Drop whole-line comments. Restated rather than imported: the sibling file's `stripComments`
- *  is a module-local `const` with no `export`, and importing a `.test.ts` would re-register its
- *  `describe` blocks in whichever suite imported it. */
+/** Drop whole-line comments. Restated rather than imported from `workflow-secret-scope.test.ts`,
+ *  where it began life as a module-local `const` — importing a `.test.ts` would re-register its
+ *  `describe` blocks in whichever suite imported it. That file now imports THIS one. */
 export const stripComments = (lines: string[]): string[] =>
   lines.filter((l) => !l.trimStart().startsWith('#'));
 
 /** `'master'` -> `master`. Trailing comments are NOT stripped here — callers that must fail
- *  closed (see `workflowVar`) anchor them out instead. */
+ *  closed anchor them out instead. */
 const unquote = (s: string): string => s.trim().replace(/^['"]|['"]$/g, '');
 
+/** A line still inside a 2-space-keyed block (blank lines count as inside). The bound that
+ *  keeps a multi-line read from escaping into the next sibling key. */
+const insideBlock = (lines: string[], idx: number): boolean =>
+  idx < lines.length &&
+  (lines[idx].trim() === '' || lines[idx].length - lines[idx].trimStart().length > 2);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure, line-based cores. Split out from the file-reading wrappers so
+// `workflow-parse-guards.test.ts` can drive every throw path over synthetic
+// fixtures — including YAML shapes this repo does not currently contain, which
+// is precisely what the `yaml` differential cannot cover.
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
- * Extract EVERY `paths:` list from a workflow.
+ * Extract EVERY `paths:` block from a workflow's lines.
  *
  * All of them, not the first: a workflow with both a push and a pull_request trigger has two,
  * and a drift between the two blocks of one file is a real defect class.
@@ -63,8 +90,7 @@ const unquote = (s: string): string => s.trim().replace(/^['"]|['"]$/g, '');
  * makes vitest print `Test Files 1 failed | Tests no tests` and **exit 1**. The "no tests" line
  * reads like a skip; the exit code is what gates, and it is non-zero.
  */
-export function extractPathBlocks(file: string): string[][] {
-  const lines = readWorkflow(file);
+export function parsePathBlocks(lines: string[], label = '<lines>'): string[][] {
   const blocks: string[][] = [];
 
   for (let i = 0; i < lines.length; i++) {
@@ -78,7 +104,7 @@ export function extractPathBlocks(file: string): string[][] {
         // A list item we could not read is a parser bug, not the end of the block.
         // Ending the loop here would silently truncate and pass vacuously downstream.
         if (/^\s+-\s/.test(line)) {
-          throw new Error(`unparseable list item in ${file}: ${JSON.stringify(line)}`);
+          throw new Error(`unparseable list item in ${label}: ${JSON.stringify(line)}`);
         }
         break; // dedent or a different key — genuinely the end of the list
       }
@@ -87,21 +113,8 @@ export function extractPathBlocks(file: string): string[][] {
     blocks.push(out);
   }
 
-  if (blocks.length === 0) throw new Error(`no 4-space-indented \`paths:\` block in ${file}`);
+  if (blocks.length === 0) throw new Error(`no 4-space-indented \`paths:\` block in ${label}`);
   return blocks;
-}
-
-/** The union of every trigger block — what the workflow can fire on at all. */
-export function extractPaths(file: string): string[] {
-  return [...new Set(extractPathBlocks(file).flat())];
-}
-
-/** Like `extractPathBlocks`, but for workflows that legitimately have no `paths:` filter.
- *  A DISTINCT return, never a swallowed error: catching around `extractPathBlocks` would also
- *  swallow its unparseable-item throw, which is the one signal that must never be lost. */
-export function extractPathBlocksIfAny(file: string): string[][] {
-  const hasBlock = readWorkflow(file).some((l) => /^\s{4}paths:\s*$/.test(l));
-  return hasBlock ? extractPathBlocks(file) : [];
 }
 
 /**
@@ -111,13 +124,13 @@ export function extractPathBlocksIfAny(file: string): string[][] {
  * 6-space `- name:` on every step. A loose match would return a step label and compare it
  * against the `workflow_run` consumer's expectation, which is a green test over a broken chain.
  */
-export function workflowName(file: string): string {
-  const matches = stripComments(readWorkflow(file))
+export function parseWorkflowName(lines: string[], label = '<lines>'): string {
+  const matches = stripComments(lines)
     .map((l) => /^name:\s*(.+?)\s*(?:#.*)?$/.exec(l))
     .filter((m): m is RegExpExecArray => m !== null);
 
   if (matches.length !== 1) {
-    throw new Error(`expected exactly one column-0 \`name:\` in ${file}, found ${matches.length}`);
+    throw new Error(`expected exactly one column-0 \`name:\` in ${label}, found ${matches.length}`);
   }
   return unquote(matches[0][1]);
 }
@@ -131,18 +144,28 @@ export function workflowName(file: string): string {
  * breakage the caller is guarding, and it is the shape this repo has already shipped once
  * (`deploy-mcp-staging.yml` lost `master` from its consumer list; see its own header comment).
  *
- * Reads a flow sequence whether it sits inline (`branches: [a, b]`) or on the following lines,
- * and whether or not Prettier has reflowed it across several.
+ * Two bounds make the scoping real rather than nominal, and the second was missing on first
+ * write — see the fail-open recorded in this module's header:
+ *   1. the SEARCH stops at a dedent to <= 2 spaces (finding the right key);
+ *   2. the multi-line VALUE accumulation is bounded the same way (reading only that key's
+ *      value). Without 2, a `branches:` whose flow sequence never closes inside its own trigger
+ *      keeps consuming until it finds a `]` — which may belong to the next trigger entirely.
+ *
+ * Only the flow-sequence form is read. The block-sequence form throws rather than returning a
+ * partial or borrowed answer.
  */
-export function triggerBranches(file: string, trigger: string): string[] {
-  const lines = stripComments(readWorkflow(file));
+export function parseTriggerBranches(
+  rawLines: string[],
+  trigger: string,
+  label = '<lines>'
+): string[] {
+  const lines = stripComments(rawLines);
   const triggerRe = new RegExp(`^\\s{2}${trigger}:\\s*$`);
 
   const found: string[][] = [];
   for (let i = 0; i < lines.length; i++) {
     if (!triggerRe.test(lines[i])) continue;
 
-    // Walk the trigger's body: 4-space keys, until a dedent to <= 2 spaces.
     for (let j = i + 1; j < lines.length; j++) {
       const line = lines[j];
       if (line.trim() === '') continue;
@@ -152,15 +175,26 @@ export function triggerBranches(file: string, trigger: string): string[] {
       const inline = /^\s{4}branches:\s*(.*)$/.exec(line);
       if (!inline) continue;
 
-      // Value is either on this line or on the following ones; either way accumulate until
-      // the flow sequence closes. Anchoring to one line would break on a Prettier reflow.
       let buf = inline[1].trim();
       let k = j;
-      while (!buf.includes(']') && k + 1 < lines.length) {
-        buf += ' ' + lines[++k].trim();
+      // Value on the following line(s) — but never past this trigger's block.
+      while (buf === '' && insideBlock(lines, k + 1)) buf = lines[++k].trim();
+
+      if (!buf.startsWith('[')) {
+        throw new Error(
+          `\`branches:\` under \`${trigger}:\` in ${label} is not a flow sequence. The ` +
+            'block-sequence form is legal YAML but is not read here, and continuing would ' +
+            "borrow the NEXT trigger's list — a green test over a broken invariant."
+        );
       }
+      while (!buf.includes(']') && insideBlock(lines, k + 1)) buf += ' ' + lines[++k].trim();
+
       const seq = /\[(.*)\]/s.exec(buf);
-      if (!seq) throw new Error(`unreadable \`branches:\` under ${trigger}: in ${file}`);
+      if (!seq) {
+        throw new Error(
+          `unterminated \`branches:\` flow sequence under \`${trigger}:\` in ${label}`
+        );
+      }
       found.push(
         seq[1]
           .split(',')
@@ -173,7 +207,7 @@ export function triggerBranches(file: string, trigger: string): string[] {
 
   if (found.length !== 1) {
     throw new Error(
-      `expected exactly one \`branches:\` under \`${trigger}:\` in ${file}, found ${found.length}`
+      `expected exactly one \`branches:\` under \`${trigger}:\` in ${label}, found ${found.length}`
     );
   }
   return found[0];
@@ -182,17 +216,68 @@ export function triggerBranches(file: string, trigger: string): string[] {
 /** The `workflow_run` consumer's `workflows: [...]` list — which upstream workflow NAMES it
  *  chains off. A literal string match against those workflows' `name:` values, with nothing on
  *  the GitHub side validating it, which is the whole reason the caller asserts it. */
-export function workflowRunWorkflows(file: string): string[] {
-  const lines = stripComments(readWorkflow(file));
-  const matches = lines
+export function parseWorkflowRunWorkflows(lines: string[], label = '<lines>'): string[] {
+  const matches = stripComments(lines)
     .map((l) => /^\s{4}workflows:\s*\[(.*)\]\s*$/.exec(l))
     .filter((m): m is RegExpExecArray => m !== null);
 
   if (matches.length !== 1) {
-    throw new Error(`expected exactly one \`workflows:\` list in ${file}, found ${matches.length}`);
+    throw new Error(
+      `expected exactly one \`workflows:\` list in ${label}, found ${matches.length}`
+    );
   }
   return matches[0][1]
     .split(',')
     .map(unquote)
     .filter((s) => s.length > 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File-reading wrappers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function extractPathBlocks(file: string): string[][] {
+  return parsePathBlocks(readWorkflow(file), file);
+}
+
+/** The union of every trigger block — what the workflow can fire on at all. */
+export function extractPaths(file: string): string[] {
+  return [...new Set(extractPathBlocks(file).flat())];
+}
+
+/**
+ * Like `extractPathBlocks`, but for workflows that legitimately have no `paths:` filter.
+ *
+ * A DISTINCT return, never a swallowed error: catching around `extractPathBlocks` would also
+ * swallow its unparseable-item throw, which is the one signal that must never be lost.
+ *
+ * "Has no `paths:` filter" is decided by counting `paths:` KEYS, not block-form keys — otherwise
+ * an inline `paths: ['a', 'b']` (legal YAML) is silently classified as "no filter at all" and its
+ * entries never reach the caller's existence check. That is a fail-open, and it is the same
+ * mistake as the `branches:` one recorded in this module's header, one key over.
+ */
+export function extractPathBlocksIfAny(file: string): string[][] {
+  const lines = readWorkflow(file);
+  const anyKey = lines.filter((l) => /^\s{4}paths:/.test(l)).length;
+  const blockKey = lines.filter((l) => /^\s{4}paths:\s*$/.test(l)).length;
+
+  if (anyKey !== blockKey) {
+    throw new Error(
+      `${file} has an inline \`paths:\` value; only the block-sequence form is parsed, so its ` +
+        'entries would be silently skipped rather than checked'
+    );
+  }
+  return blockKey > 0 ? parsePathBlocks(lines, file) : [];
+}
+
+export function workflowName(file: string): string {
+  return parseWorkflowName(readWorkflow(file), file);
+}
+
+export function triggerBranches(file: string, trigger: string): string[] {
+  return parseTriggerBranches(readWorkflow(file), trigger, file);
+}
+
+export function workflowRunWorkflows(file: string): string[] {
+  return parseWorkflowRunWorkflows(readWorkflow(file), file);
 }

--- a/tests/integration/helpers/workflow-parse.ts
+++ b/tests/integration/helpers/workflow-parse.ts
@@ -118,6 +118,31 @@ export function parsePathBlocks(lines: string[], label = '<lines>'): string[][] 
 }
 
 /**
+ * Like `parsePathBlocks`, but for workflows that legitimately have no `paths:` filter.
+ *
+ * A DISTINCT function, never a try/catch around `parsePathBlocks`: catching would also swallow
+ * that parser's unparseable-item throw, which is the one signal that must never be lost.
+ *
+ * "Has no `paths:` filter" is decided by counting `paths:` KEYS against BLOCK-form keys, not by
+ * looking for block form alone — otherwise an inline `paths: ['a', 'b']` (legal YAML) is silently
+ * classified as "no filter at all" and its entries never reach the caller's existence check.
+ * That is a fail-open, and it is the same mistake as the `branches:` one recorded in this
+ * module's header, one key over.
+ */
+export function parsePathBlocksIfAny(lines: string[], label = '<lines>'): string[][] {
+  const anyKey = lines.filter((l) => /^\s{4}paths:/.test(l)).length;
+  const blockKey = lines.filter((l) => /^\s{4}paths:\s*$/.test(l)).length;
+
+  if (anyKey !== blockKey) {
+    throw new Error(
+      `${label} has an inline \`paths:\` value; only the block-sequence form is parsed, so its ` +
+        'entries would be silently skipped rather than checked'
+    );
+  }
+  return blockKey > 0 ? parsePathBlocks(lines, label) : [];
+}
+
+/**
  * The workflow's own `name:` — anchored at **column 0**.
  *
  * Anchoring matters: `test-mcp-server.yml` also carries a 4-space `name:` on its job and
@@ -177,7 +202,13 @@ export function parseTriggerBranches(
 
       let buf = inline[1].trim();
       let k = j;
-      // Value on the following line(s) — but never past this trigger's block.
+      // Value on the following line(s) — but never past this TRIGGER's block. Note the bound
+      // is the trigger, not the `branches:` key itself: an unterminated flow sequence can still
+      // absorb a sibling key inside the same trigger (`branches: [dev,` then `paths: [...]`
+      // yields a junk entry rather than a throw). That shape is invalid YAML which GitHub
+      // rejects outright, so it cannot produce a silently-broken-but-running workflow — it
+      // fails closed. The bound that matters for the fail-open recorded in the header is the
+      // trigger boundary, and that one is exact.
       while (buf === '' && insideBlock(lines, k + 1)) buf = lines[++k].trim();
 
       if (!buf.startsWith('[')) {
@@ -246,28 +277,11 @@ export function extractPaths(file: string): string[] {
 }
 
 /**
- * Like `extractPathBlocks`, but for workflows that legitimately have no `paths:` filter.
- *
- * A DISTINCT return, never a swallowed error: catching around `extractPathBlocks` would also
- * swallow its unparseable-item throw, which is the one signal that must never be lost.
- *
- * "Has no `paths:` filter" is decided by counting `paths:` KEYS, not block-form keys — otherwise
- * an inline `paths: ['a', 'b']` (legal YAML) is silently classified as "no filter at all" and its
- * entries never reach the caller's existence check. That is a fail-open, and it is the same
- * mistake as the `branches:` one recorded in this module's header, one key over.
+ * Like `extractPathBlocks`, but tolerates workflows with no `paths:` filter.
+ * See `parsePathBlocksIfAny` for why that tolerance is key-counted rather than form-sniffed.
  */
 export function extractPathBlocksIfAny(file: string): string[][] {
-  const lines = readWorkflow(file);
-  const anyKey = lines.filter((l) => /^\s{4}paths:/.test(l)).length;
-  const blockKey = lines.filter((l) => /^\s{4}paths:\s*$/.test(l)).length;
-
-  if (anyKey !== blockKey) {
-    throw new Error(
-      `${file} has an inline \`paths:\` value; only the block-sequence form is parsed, so its ` +
-        'entries would be silently skipped rather than checked'
-    );
-  }
-  return blockKey > 0 ? parsePathBlocks(lines, file) : [];
+  return parsePathBlocksIfAny(readWorkflow(file), file);
 }
 
 export function workflowName(file: string): string {

--- a/tests/integration/helpers/workflow-parse.ts
+++ b/tests/integration/helpers/workflow-parse.ts
@@ -1,0 +1,198 @@
+/**
+ * Hand parsers for `.github/workflows/*.yml`, shared by the workflow invariant suites.
+ *
+ * Deliberately a hand parser rather than a YAML dependency, matching the choice already made
+ * in `workflow-paths-parity.test.ts` and `workflow-secret-scope.test.ts`: `yaml` is
+ * transitive-only, and a direct dependency for a handful of assertions is the worse trade.
+ *
+ * **Equivalence checked, not assumed.** Across all 12 workflow files these extractors and the
+ * real `yaml` parser agree exactly — 12 names, 5 `paths` blocks, 10 trigger-scoped `branches`
+ * lists, 1 `workflow_run.workflows` list, **zero disagreements** (measured 2026-08-16, not
+ * estimated). That agreement is what justifies not taking the dependency; **re-run the
+ * differential if any extractor changes.** The method is the one `workflow-secret-scope.test.ts`
+ * (lines 79-84) records as the only one that actually worked there: vigilance produced ten
+ * fail-open paths, running the hand parser against `yaml` and diffing produced a fact.
+ *
+ * **THESE PARSERS MUST NOT FAIL OPEN.** A parser that returns `[]` or `undefined` for input it
+ * cannot read makes every downstream assertion pass vacuously — the caller cannot tell "nothing
+ * matched" from "nothing to match". So every function here THROWS on unreadable input rather
+ * than returning an empty result, and callers pair each assertion with a non-zero probe.
+ *
+ * Two shapes bit the sibling file and are handled here from the start:
+ *   - trailing comments are legal after any scalar (`name: Foo # note`);
+ *   - quoted and bare scalars are the same value (`'master'` === `master`).
+ * A third is specific to this repo: `branches:` values are written as **flow sequences on the
+ * line after the key**, and `.github/**` is not in `.prettierignore`, so a list that grows past
+ * `printWidth: 100` reflows across several lines. Single-line anchoring would silently stop
+ * matching on a routine edit, so the flow-sequence reader is multi-line.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const WORKFLOWS_DIR = join(process.cwd(), '.github', 'workflows');
+
+/** Every workflow file. `.yaml` as well as `.yml` — a `.yml`-only filter was fail-open #1 in
+ *  `workflow-secret-scope.test.ts`, where a rogue `.yaml` was invisible to the guard. */
+export function workflowFiles(): string[] {
+  return readdirSync(WORKFLOWS_DIR).filter((f) => /\.ya?ml$/.test(f));
+}
+
+export function readWorkflow(file: string): string[] {
+  return readFileSync(join(WORKFLOWS_DIR, file), 'utf8').split(/\r?\n/);
+}
+
+/** Drop whole-line comments. Restated rather than imported: the sibling file's `stripComments`
+ *  is a module-local `const` with no `export`, and importing a `.test.ts` would re-register its
+ *  `describe` blocks in whichever suite imported it. */
+export const stripComments = (lines: string[]): string[] =>
+  lines.filter((l) => !l.trimStart().startsWith('#'));
+
+/** `'master'` -> `master`. Trailing comments are NOT stripped here — callers that must fail
+ *  closed (see `workflowVar`) anchor them out instead. */
+const unquote = (s: string): string => s.trim().replace(/^['"]|['"]$/g, '');
+
+/**
+ * Extract EVERY `paths:` list from a workflow.
+ *
+ * All of them, not the first: a workflow with both a push and a pull_request trigger has two,
+ * and a drift between the two blocks of one file is a real defect class.
+ *
+ * An unparseable list item **throws** rather than ending the loop. A partially-parsed list makes
+ * a subset assertion pass on the entries it dropped — the throw is load-bearing, not defensive
+ * decoration. Verified, not assumed: double-quoting one entry in `deploy-mcp-production.yml`
+ * makes vitest print `Test Files 1 failed | Tests no tests` and **exit 1**. The "no tests" line
+ * reads like a skip; the exit code is what gates, and it is non-zero.
+ */
+export function extractPathBlocks(file: string): string[][] {
+  const lines = readWorkflow(file);
+  const blocks: string[][] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s{4}paths:\s*$/.test(lines[i])) continue;
+
+    const out: string[] = [];
+    for (const line of lines.slice(i + 1)) {
+      if (/^\s*#/.test(line) || line.trim() === '') continue;
+      const match = /^\s{6}- '(.+)'\s*$/.exec(line);
+      if (!match) {
+        // A list item we could not read is a parser bug, not the end of the block.
+        // Ending the loop here would silently truncate and pass vacuously downstream.
+        if (/^\s+-\s/.test(line)) {
+          throw new Error(`unparseable list item in ${file}: ${JSON.stringify(line)}`);
+        }
+        break; // dedent or a different key — genuinely the end of the list
+      }
+      out.push(match[1]);
+    }
+    blocks.push(out);
+  }
+
+  if (blocks.length === 0) throw new Error(`no 4-space-indented \`paths:\` block in ${file}`);
+  return blocks;
+}
+
+/** The union of every trigger block — what the workflow can fire on at all. */
+export function extractPaths(file: string): string[] {
+  return [...new Set(extractPathBlocks(file).flat())];
+}
+
+/** Like `extractPathBlocks`, but for workflows that legitimately have no `paths:` filter.
+ *  A DISTINCT return, never a swallowed error: catching around `extractPathBlocks` would also
+ *  swallow its unparseable-item throw, which is the one signal that must never be lost. */
+export function extractPathBlocksIfAny(file: string): string[][] {
+  const hasBlock = readWorkflow(file).some((l) => /^\s{4}paths:\s*$/.test(l));
+  return hasBlock ? extractPathBlocks(file) : [];
+}
+
+/**
+ * The workflow's own `name:` — anchored at **column 0**.
+ *
+ * Anchoring matters: `test-mcp-server.yml` also carries a 4-space `name:` on its job and
+ * 6-space `- name:` on every step. A loose match would return a step label and compare it
+ * against the `workflow_run` consumer's expectation, which is a green test over a broken chain.
+ */
+export function workflowName(file: string): string {
+  const matches = stripComments(readWorkflow(file))
+    .map((l) => /^name:\s*(.+?)\s*(?:#.*)?$/.exec(l))
+    .filter((m): m is RegExpExecArray => m !== null);
+
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one column-0 \`name:\` in ${file}, found ${matches.length}`);
+  }
+  return unquote(matches[0][1]);
+}
+
+/**
+ * The `branches:` list belonging to ONE named trigger (`push`, `pull_request`, `workflow_run`).
+ *
+ * Trigger-scoped on purpose. `test-mcp-server.yml` has two `branches:` lists — the push list and
+ * `branches: [master]` on its `pull_request` trigger — so a union, or a first-match, still finds
+ * `master` after `master` is dropped from the push list. That is a green suite over the exact
+ * breakage the caller is guarding, and it is the shape this repo has already shipped once
+ * (`deploy-mcp-staging.yml` lost `master` from its consumer list; see its own header comment).
+ *
+ * Reads a flow sequence whether it sits inline (`branches: [a, b]`) or on the following lines,
+ * and whether or not Prettier has reflowed it across several.
+ */
+export function triggerBranches(file: string, trigger: string): string[] {
+  const lines = stripComments(readWorkflow(file));
+  const triggerRe = new RegExp(`^\\s{2}${trigger}:\\s*$`);
+
+  const found: string[][] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!triggerRe.test(lines[i])) continue;
+
+    // Walk the trigger's body: 4-space keys, until a dedent to <= 2 spaces.
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (line.trim() === '') continue;
+      const indent = line.length - line.trimStart().length;
+      if (indent <= 2) break; // dedented out of this trigger
+
+      const inline = /^\s{4}branches:\s*(.*)$/.exec(line);
+      if (!inline) continue;
+
+      // Value is either on this line or on the following ones; either way accumulate until
+      // the flow sequence closes. Anchoring to one line would break on a Prettier reflow.
+      let buf = inline[1].trim();
+      let k = j;
+      while (!buf.includes(']') && k + 1 < lines.length) {
+        buf += ' ' + lines[++k].trim();
+      }
+      const seq = /\[(.*)\]/s.exec(buf);
+      if (!seq) throw new Error(`unreadable \`branches:\` under ${trigger}: in ${file}`);
+      found.push(
+        seq[1]
+          .split(',')
+          .map(unquote)
+          .filter((s) => s.length > 0)
+      );
+      break;
+    }
+  }
+
+  if (found.length !== 1) {
+    throw new Error(
+      `expected exactly one \`branches:\` under \`${trigger}:\` in ${file}, found ${found.length}`
+    );
+  }
+  return found[0];
+}
+
+/** The `workflow_run` consumer's `workflows: [...]` list — which upstream workflow NAMES it
+ *  chains off. A literal string match against those workflows' `name:` values, with nothing on
+ *  the GitHub side validating it, which is the whole reason the caller asserts it. */
+export function workflowRunWorkflows(file: string): string[] {
+  const lines = stripComments(readWorkflow(file));
+  const matches = lines
+    .map((l) => /^\s{4}workflows:\s*\[(.*)\]\s*$/.exec(l))
+    .filter((m): m is RegExpExecArray => m !== null);
+
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one \`workflows:\` list in ${file}, found ${matches.length}`);
+  }
+  return matches[0][1]
+    .split(',')
+    .map(unquote)
+    .filter((s) => s.length > 0);
+}

--- a/tests/integration/workflow-chain-integrity.test.ts
+++ b/tests/integration/workflow-chain-integrity.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The MCP deploy chain is held together by string literals that nothing validates.
+ *
+ * `deploy-mcp-production.yml` says so in prose, and said it for months with nothing behind it:
+ * *"`workflows: ['MCP Server Test Suite']` is a literal string match against that workflow's
+ * `name:`. A rename breaks the chain silently, and nothing asserts the two agree."* This file is
+ * that assertion, plus the three other links in the same chain that are equally unguarded.
+ *
+ * Every failure mode here is SILENT — that is the whole reason it needs a test. A broken link
+ * does not produce a red run; it produces **no run**, or a run that skips, or a 300-second poll
+ * that blames the wrong thing. Nobody notices until production has been stale for weeks.
+ *
+ *   A. staging's `workflow_run.workflows` entry -> the suite's `name:` -> the filename the
+ *      production pre-flight polls. One derived chain, not three literal comparisons.
+ *   B. the producer's push trigger still reaches `master`.
+ *   C. the consumer's own branch list still reaches `master`.
+ *   D. `.github/workflows/*.yml` literals inside `paths:` lists still name files that exist.
+ *
+ * C is not hypothetical: `deploy-mcp-staging.yml`'s own header records that this exact list
+ * once shipped **without** `master`, "so the merge commit never got staging validation"
+ * (BL-037 follow-up after BL-038). The link that already broke was the unguarded one.
+ *
+ * Separate from `workflow-paths-parity.test.ts` deliberately — that file's docstring is wholly
+ * about the BL-109 paths subset relation, and one invariant per file is the pattern
+ * `workflow-secret-scope.test.ts` already sets. The shared parsers live in
+ * `helpers/workflow-parse.ts`; read its docstring for the fail-closed discipline and the
+ * `yaml` differential that justifies hand-parsing.
+ *
+ * **Every assertion below is paired with a non-zero probe.** A guard that silently matches
+ * nothing reports green forever — this repo has shipped that defect twice (BL-124 bypassed Zod;
+ * BL-125's enum walk threw on all 60 fields into a catch that swallowed it). The probes are the
+ * difference between "the chain agrees" and "I found nothing to disagree about".
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  workflowFiles,
+  workflowName,
+  triggerBranches,
+  workflowRunWorkflows,
+  extractPathBlocksIfAny,
+} from './helpers/workflow-parse';
+
+const STAGING = 'deploy-mcp-staging.yml';
+const SUITE = 'test-mcp-server.yml';
+const PREFLIGHT = join(process.cwd(), 'scripts', 'await-mcp-test-run.sh');
+
+/**
+ * The production pre-flight's `WORKFLOW="…"` value.
+ *
+ * Anchored, and **exactly one assignment required**. A second assignment later in the script
+ * would leave this comparison green while the runtime value differed — precisely the failure
+ * this exists to close. The anchor also forbids a trailing comment, which is stricter than the
+ * helpers' general tolerance: deliberate, because failing closed on `WORKFLOW="x" # note` costs
+ * one obvious test fix, while failing open costs a silently broken production gate.
+ */
+function preflightWorkflowVar(): string {
+  const matches = readFileSync(PREFLIGHT, 'utf8')
+    .split(/\r?\n/)
+    .map((l) => /^WORKFLOW="([^"]+)"$/.exec(l))
+    .filter((m): m is RegExpExecArray => m !== null);
+
+  expect(
+    matches.length,
+    'expected exactly one anchored `WORKFLOW="…"` assignment in scripts/await-mcp-test-run.sh — ' +
+      'a second one makes every assertion in this file compare the wrong value'
+  ).toBe(1);
+  return matches[0][1];
+}
+
+describe('MCP deploy chain integrity', () => {
+  it('A: staging -> suite name -> production pre-flight filename resolves end to end', () => {
+    // 1. What staging chains off. `workflowRunWorkflows` throws unless exactly one
+    //    `workflows:` list exists, so a multi-entry list is a loud failure rather than an
+    //    ambiguous comparison below. Read only from the staging file —
+    //    `deploy-mcp-production.yml:29` quotes the same literal inside a COMMENT, and matching
+    //    that would assert the chain against a piece of prose.
+    const chainedNames = workflowRunWorkflows(STAGING);
+    expect(chainedNames.length, `${STAGING} should chain off exactly one workflow`).toBe(1);
+    const chainedName = chainedNames[0];
+
+    // Probe: the extraction found a real name, not an empty string from a mangled parse.
+    expect(
+      chainedName.length,
+      'parsed an empty workflow name — parser is matching nothing'
+    ).toBeGreaterThan(0);
+
+    // 2. Resolve that NAME to a FILE, and require the resolution to be unique. Two workflows
+    //    sharing a `name:` would both feed the consumer, and which one "the" upstream run is
+    //    becomes undefined.
+    const files = workflowFiles();
+    expect(files.length, 'found no workflow files — parser is matching nothing').toBeGreaterThan(5);
+
+    const resolved = files.filter((f) => workflowName(f) === chainedName);
+    expect(
+      resolved,
+      `${STAGING} chains off "${chainedName}", which must resolve to exactly one workflow file. ` +
+        'Zero means the staging deploy chain is dead and no run will ever fire it; two means ' +
+        'the upstream run is ambiguous.'
+    ).toHaveLength(1);
+
+    // 3. The production pre-flight polls by FILENAME, not by name — so the two halves of the
+    //    chain can drift apart. Deriving the expected filename from step 2 (rather than
+    //    comparing against a literal repeated here) is what makes this catch the real defect:
+    //    adding `test-mcp-server-v2.yml` and pointing WORKFLOW at it would leave a literal
+    //    comparison green while production polled a workflow the deploy chain never runs.
+    expect(
+      preflightWorkflowVar(),
+      'scripts/await-mcp-test-run.sh polls a different workflow file than the one ' +
+        `${STAGING} chains off. Production would wait 300s and then exit 5 — "dead token, ` +
+        'revoked permission, or a GitHub outage" — pointing the operator at the credential ' +
+        'instead of at this rename.'
+    ).toBe(resolved[0]);
+  });
+
+  it('B: the suite still runs on pushes to master, which the pre-flight requires', () => {
+    // Trigger-SCOPED, not a union. `test-mcp-server.yml` also has `branches: [master]` on its
+    // pull_request trigger, so a union (or a first-match) still finds `master` after `master` is
+    // dropped from the PUSH list — green over exactly the breakage this guards. The helper
+    // throws unless exactly one push-scoped list exists.
+    const pushBranches = triggerBranches(SUITE, 'push');
+    expect(
+      pushBranches.length,
+      `parsed an empty push \`branches:\` list from ${SUITE} — parser is matching nothing`
+    ).toBeGreaterThan(0);
+
+    expect(
+      pushBranches,
+      `${SUITE} must run on pushes to master. scripts/await-mcp-test-run.sh queries ` +
+        '`?event=push` for the exact SHA being deployed, so without master in this list every ' +
+        'production deploy fails its pre-flight.'
+    ).toContain('master');
+
+    // The other half of the same pairing, which otherwise lives only in a comment.
+    const preflight = readFileSync(PREFLIGHT, 'utf8');
+    expect(
+      preflight,
+      'the pre-flight no longer filters `event=push`; assertion B is guarding a requirement ' +
+        'that no longer exists, and the push-branch list above is no longer load-bearing'
+    ).toContain('event=push');
+  });
+
+  it('C: the staging consumer still fires on master, and never on more than the suite', () => {
+    // This list shipped WITHOUT master once — deploy-mcp-staging.yml's own header records it:
+    // "master was missing so the merge commit never got staging validation" (BL-038). A
+    // `workflow_run` branch filter that misses is silent: no run record at all, nothing to see
+    // in the Actions list, staging quietly frozen at whatever it last deployed.
+    const consumerBranches = triggerBranches(STAGING, 'workflow_run');
+    expect(
+      consumerBranches.length,
+      `parsed an empty workflow_run \`branches:\` list from ${STAGING} — parser is matching nothing`
+    ).toBeGreaterThan(0);
+
+    expect(
+      consumerBranches,
+      `${STAGING} must fire on master or merge commits get no staging validation — the exact ` +
+        'regression BL-038 found and this list has already shipped with once.'
+    ).toContain('master');
+
+    // Subset, not equality: staging may deliberately deploy on FEWER branch families than the
+    // suite tests (it omits `dependabot/**` on purpose — dependency bumps are validated but
+    // never auto-deployed). It may never fire on MORE, which would mean deploying from a branch
+    // the suite never ran on.
+    const suitePush = triggerBranches(SUITE, 'push');
+    const extra = consumerBranches.filter((b) => !suitePush.includes(b));
+    expect(
+      extra,
+      `${STAGING} lists branch pattern(s) the MCP suite does not test: ${extra.join(', ')}. ` +
+        'Staging would deploy from a branch that never ran the suite.'
+    ).toEqual([]);
+  });
+
+  it('D: every workflow file named inside a `paths:` list exists on disk', () => {
+    // Self-trigger literals like `.github/workflows/test-mcp-server.yml` go stale on a rename
+    // with nothing complaining: `workflow-paths-parity.test.ts` compares the MCP lists only to
+    // EACH OTHER, so a rename that stales both identically keeps the subset relation true and
+    // the suite green while the self-trigger matches no file at all.
+    //
+    // `extractPathBlocksIfAny` returns [] for the 9 workflows that legitimately have no `paths:`
+    // filter. It is a distinct function rather than a try/catch around `extractPathBlocks`
+    // precisely so it cannot also swallow that parser's unparseable-list-item throw — the one
+    // signal that must never be lost.
+    const allEntries = workflowFiles().flatMap((f) => extractPathBlocksIfAny(f).flat());
+
+    // Parser-health probe. Deliberately NOT a count of workflow literals: a legitimate removal
+    // of one self-trigger would turn that red for a non-defect. Total entries proves the
+    // extraction is working; the existence loop below is the actual assertion.
+    expect(
+      allEntries.length,
+      'parsed no `paths:` entries from any workflow — the extractor is matching nothing and ' +
+        'the existence check below would pass vacuously'
+    ).toBeGreaterThan(20);
+
+    const workflowLiterals = allEntries.filter((p) => /^\.github\/workflows\/.+\.ya?ml$/.test(p));
+    expect(
+      workflowLiterals.length,
+      'no `.github/workflows/*.yml` literals found in any `paths:` list — either they were all ' +
+        'removed (update this probe) or the filter regex has stopped matching'
+    ).toBeGreaterThan(0);
+
+    const missing = [...new Set(workflowLiterals)].filter(
+      (p) => !existsSync(join(process.cwd(), p))
+    );
+    expect(
+      missing,
+      `workflow path filter(s) name files that do not exist: ${missing.join(', ')}. ` +
+        'That filter now matches nothing, so the workflow silently stops firing on changes to it.'
+    ).toEqual([]);
+  });
+});

--- a/tests/integration/workflow-parse-guards.test.ts
+++ b/tests/integration/workflow-parse-guards.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The workflow hand parsers, driven over synthetic fixtures — including YAML shapes this repo
+ * does not currently contain.
+ *
+ * **This file exists because two other verification methods both passed over a real fail-open.**
+ * `helpers/workflow-parse.ts` was validated by (a) a differential against the real `yaml` parser
+ * across all 12 workflows and (b) a nine-case mutation matrix against the live tree. Both came
+ * back clean while `parseTriggerBranches` would still adopt the NEXT trigger's list if a
+ * `branches:` value were written in block-sequence form — because neither method can see a shape
+ * the repo does not happen to use today. Code review found it by writing the shape.
+ *
+ * So the discipline here is the complement of the differential, not a duplicate of it: **drive
+ * the throw paths, with inputs chosen for what the parser must REFUSE** rather than for what the
+ * repo currently contains. `workflow-secret-scope.test.ts` catalogues ten fail-open defects in
+ * this same problem domain; every one of them was a parser quietly returning a partial answer
+ * where it should have refused. A parser that returns `[]` cannot be told from one that found
+ * nothing to return, and every assertion built on it is then green by construction.
+ *
+ * Add a case here for any parsing rule added to the helper. "The differential passes" is not
+ * evidence about shapes the differential never saw.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parsePathBlocks,
+  parseWorkflowName,
+  parseTriggerBranches,
+  parseWorkflowRunWorkflows,
+} from './helpers/workflow-parse';
+
+const lines = (s: string): string[] => s.split('\n');
+
+describe('workflow parsers refuse what they cannot read', () => {
+  describe('parseTriggerBranches', () => {
+    // The exact fixture that reproduces the shipped-and-caught fail-open. `push` has NO master
+    // and is written as a block sequence; `pull_request` below it has `[master]`. An unbounded
+    // reader walks past the push trigger, finds the pull_request `]`, and reports ['master'] —
+    // the assertion guarding "push still reaches master" then passes over a broken invariant.
+    const blockSeqThenFlowSeq = `
+on:
+  push:
+    branches:
+      - dev
+      - 'feat/**'
+    paths:
+      - 'src/**'
+  pull_request:
+    branches: [master]
+`;
+
+    it('THROWS on a block-sequence value rather than borrowing the next trigger list', () => {
+      expect(() => parseTriggerBranches(lines(blockSeqThenFlowSeq), 'push', 'fixture')).toThrow(
+        /not a flow sequence/
+      );
+    });
+
+    it('the borrowed value would have been `master` — the fail-open this refuses', () => {
+      // Positive control: the neighbour really does carry the value that made the bug silent.
+      // Without this, the throw above could be passing for an unrelated reason.
+      expect(parseTriggerBranches(lines(blockSeqThenFlowSeq), 'pull_request', 'fixture')).toEqual([
+        'master',
+      ]);
+    });
+
+    it('reads an inline flow sequence', () => {
+      const src = `
+on:
+  push:
+    branches: [master, 'feat/**']
+`;
+      expect(parseTriggerBranches(lines(src), 'push', 'fixture')).toEqual(['master', 'feat/**']);
+    });
+
+    it('reads a flow sequence that Prettier has reflowed across lines', () => {
+      // `.github/**` is not in `.prettierignore` and `printWidth` is 100, so this happens on a
+      // routine branch-family addition. Single-line anchoring would silently match nothing.
+      const src = `
+on:
+  push:
+    branches:
+      [master, dev, 'feat/**', 'fix/**', 'feature/**', 'dependabot/**', 'docs/**',
+        'chore/**']
+`;
+      expect(parseTriggerBranches(lines(src), 'push', 'fixture')).toEqual([
+        'master',
+        'dev',
+        'feat/**',
+        'fix/**',
+        'feature/**',
+        'dependabot/**',
+        'docs/**',
+        'chore/**',
+      ]);
+    });
+
+    it('scopes to the requested trigger when several carry `branches:`', () => {
+      const src = `
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [master]
+`;
+      expect(parseTriggerBranches(lines(src), 'push', 'fixture')).toEqual(['dev']);
+      expect(parseTriggerBranches(lines(src), 'pull_request', 'fixture')).toEqual(['master']);
+    });
+
+    it('THROWS when the trigger has no `branches:` at all', () => {
+      const src = `
+on:
+  push:
+    paths:
+      - 'src/**'
+`;
+      expect(() => parseTriggerBranches(lines(src), 'push', 'fixture')).toThrow(/found 0/);
+    });
+
+    it('THROWS on an unterminated flow sequence', () => {
+      const src = `
+on:
+  push:
+    branches: [master, 'feat/**'
+`;
+      expect(() => parseTriggerBranches(lines(src), 'push', 'fixture')).toThrow(/unterminated/);
+    });
+
+    it('tolerates trailing comments and treats quoted and bare scalars alike', () => {
+      const src = `
+on:
+  # a comment line
+  push:
+    branches: ['master', dev]
+`;
+      expect(parseTriggerBranches(lines(src), 'push', 'fixture')).toEqual(['master', 'dev']);
+    });
+  });
+
+  describe('parseWorkflowName', () => {
+    it('reads the column-0 name, not a job or step name', () => {
+      const src = `
+name: MCP Server Test Suite
+jobs:
+  test:
+    name: Typecheck, Build & Test
+    steps:
+      - name: Checkout code
+`;
+      expect(parseWorkflowName(lines(src), 'fixture')).toBe('MCP Server Test Suite');
+    });
+
+    it('tolerates a trailing comment', () => {
+      expect(parseWorkflowName(lines('name: Foo # note'), 'fixture')).toBe('Foo');
+    });
+
+    it('THROWS when there is no column-0 name', () => {
+      expect(() =>
+        parseWorkflowName(lines('jobs:\n  test:\n    name: Only A Job'), 'fixture')
+      ).toThrow(/found 0/);
+    });
+
+    it('THROWS on two column-0 names rather than picking one', () => {
+      expect(() => parseWorkflowName(lines('name: A\nname: B'), 'fixture')).toThrow(/found 2/);
+    });
+  });
+
+  describe('parseWorkflowRunWorkflows', () => {
+    it('reads the chained workflow names', () => {
+      const src = `
+on:
+  workflow_run:
+    workflows: ['MCP Server Test Suite']
+`;
+      expect(parseWorkflowRunWorkflows(lines(src), 'fixture')).toEqual(['MCP Server Test Suite']);
+    });
+
+    it('ignores the same literal inside a comment', () => {
+      // `deploy-mcp-production.yml` quotes this exact line in prose. Matching it would assert
+      // the deploy chain against a comment.
+      const src = `
+#   5. \`workflows: ['MCP Server Test Suite']\` is a literal string match
+on:
+  workflow_run:
+    workflows: ['Real Name']
+`;
+      expect(parseWorkflowRunWorkflows(lines(src), 'fixture')).toEqual(['Real Name']);
+    });
+
+    it('THROWS when absent', () => {
+      expect(() => parseWorkflowRunWorkflows(lines('on:\n  push:\n'), 'fixture')).toThrow(
+        /found 0/
+      );
+    });
+  });
+
+  describe('parsePathBlocks', () => {
+    it('returns every block, in order', () => {
+      const src = `
+on:
+  push:
+    paths:
+      - 'a/**'
+      - 'b/**'
+  pull_request:
+    paths:
+      - 'a/**'
+`;
+      expect(parsePathBlocks(lines(src), 'fixture')).toEqual([['a/**', 'b/**'], ['a/**']]);
+    });
+
+    it('THROWS on an unparseable list item rather than truncating the block', () => {
+      // Truncation is the dangerous outcome: a subset assertion then passes on the entries the
+      // parser silently dropped.
+      const src = `
+on:
+  push:
+    paths:
+      - 'a/**'
+      - "b/**"
+`;
+      expect(() => parsePathBlocks(lines(src), 'fixture')).toThrow(/unparseable list item/);
+    });
+
+    it('THROWS when there is no block at all', () => {
+      expect(() => parsePathBlocks(lines('on:\n  push:\n'), 'fixture')).toThrow(/no 4-space/);
+    });
+
+    it('skips comments and blank lines inside a block', () => {
+      const src = `
+on:
+  push:
+    paths:
+      - 'a/**'
+      # a note
+
+      - 'b/**'
+`;
+      expect(parsePathBlocks(lines(src), 'fixture')).toEqual([['a/**', 'b/**']]);
+    });
+  });
+});

--- a/tests/integration/workflow-parse-guards.test.ts
+++ b/tests/integration/workflow-parse-guards.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parsePathBlocks,
+  parsePathBlocksIfAny,
   parseWorkflowName,
   parseTriggerBranches,
   parseWorkflowRunWorkflows,
@@ -123,6 +124,31 @@ on:
       expect(() => parseTriggerBranches(lines(src), 'push', 'fixture')).toThrow(/unterminated/);
     });
 
+    it('THROWS rather than borrowing a neighbour `]` to close an open FLOW sequence', () => {
+      // The flow-form sibling of the block-form bug. The `]` that would close this list lives
+      // in the next trigger; only the trigger bound stops the reader reaching it. Nothing else
+      // pinned that bound, so it is pinned here.
+      const src = `
+on:
+  push:
+    branches: [master, 'feat/**'
+  pull_request:
+    branches: [dev]
+`;
+      expect(() => parseTriggerBranches(lines(src), 'push', 'fixture')).toThrow(/unterminated/);
+    });
+
+    it('THROWS on a duplicated trigger rather than picking one list', () => {
+      const src = `
+on:
+  push:
+    branches: [master]
+  push:
+    branches: [dev]
+`;
+      expect(() => parseTriggerBranches(lines(src), 'push', 'fixture')).toThrow(/found 2/);
+    });
+
     it('tolerates trailing comments and treats quoted and bare scalars alike', () => {
       const src = `
 on:
@@ -188,6 +214,71 @@ on:
       expect(() => parseWorkflowRunWorkflows(lines('on:\n  push:\n'), 'fixture')).toThrow(
         /found 0/
       );
+    });
+
+    it('THROWS on two lists rather than picking one', () => {
+      const src = `
+on:
+  workflow_run:
+    workflows: ['A']
+    workflows: ['B']
+`;
+      expect(() => parseWorkflowRunWorkflows(lines(src), 'fixture')).toThrow(/found 2/);
+    });
+  });
+
+  describe('parsePathBlocksIfAny', () => {
+    // This is the rule the fail-open-fixing commit ADDED, and it was the one rule with no
+    // synthetic-fixture coverage — verified only by a live-tree mutation, the method that
+    // commit argues is insufficient. Closing that is the point of this block.
+    it('THROWS on an inline `paths:` rather than reporting "no paths filter"', () => {
+      // The fail-open shape: classified as unfiltered, so its entries — including a stale
+      // workflow filename — never reach the caller's existence check.
+      const src = `
+on:
+  push:
+    paths: ['mcp-server/**', '.github/workflows/DOES-NOT-EXIST.yml']
+`;
+      expect(() => parsePathBlocksIfAny(lines(src), 'fixture')).toThrow(/inline `paths:` value/);
+    });
+
+    it('THROWS when block and inline forms are mixed across triggers', () => {
+      const src = `
+on:
+  push:
+    paths:
+      - 'a/**'
+  pull_request:
+    paths: ['b/**']
+`;
+      expect(() => parsePathBlocksIfAny(lines(src), 'fixture')).toThrow(/inline `paths:` value/);
+    });
+
+    it('returns [] for a workflow that genuinely has no `paths:` filter', () => {
+      // The tolerance this function exists for — 9 of the 12 real workflows are this shape.
+      expect(
+        parsePathBlocksIfAny(lines('on:\n  push:\n    branches: [master]\n'), 'fixture')
+      ).toEqual([]);
+    });
+
+    it('ignores `paths-ignore:`, which is a different key', () => {
+      const src = `
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+`;
+      expect(parsePathBlocksIfAny(lines(src), 'fixture')).toEqual([]);
+    });
+
+    it('reads block form normally when present', () => {
+      const src = `
+on:
+  push:
+    paths:
+      - 'a/**'
+`;
+      expect(parsePathBlocksIfAny(lines(src), 'fixture')).toEqual([['a/**']]);
     });
   });
 

--- a/tests/integration/workflow-paths-parity.test.ts
+++ b/tests/integration/workflow-paths-parity.test.ts
@@ -18,62 +18,16 @@
  * wider (deploy something you did not test).
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-const WORKFLOWS = join(process.cwd(), '.github', 'workflows');
+import { extractPathBlocks, extractPaths } from './helpers/workflow-parse';
 
 /**
- * Extract EVERY `paths:` list from a workflow.
- *
- * All of them, not the first: `test-mcp-server.yml` has two (push + pull_request), and
- * the DEVELOPER_TOOLING instruction is "add it to BOTH blocks" — so a drift between the
- * two blocks of one file is the same defect class this test exists to catch.
- *
- * Deliberately a small hand parser rather than a YAML dependency: adding a parser to the
- * website's dependency tree for one assertion is the worse trade. But a hand parser that
- * gives up quietly is worthless here — a partially-parsed list makes the subset assertion
- * pass on the entries it dropped. So an unparseable list item **throws** rather than
- * ending the loop.
- *
- * **The throw happens at collection time, and that does fail CI** — verified, not assumed:
- * double-quoting one entry in `deploy-mcp-production.yml` makes vitest print
- * `Test Files 1 failed | Tests no tests` and **exit 1**. The "no tests" line reads like a
- * skip; the exit code is what gates, and it is non-zero. Worth knowing before anyone
- * "fixes" this parser to fail soft.
+ * The `paths:` extractors moved to `helpers/workflow-parse.ts` so `workflow-chain-integrity.
+ * test.ts` could reuse them instead of growing a third copy of the same indent assumptions.
+ * Their behaviour is unchanged — including the deliberate throw on an unparseable list item —
+ * and THIS SUITE IS THE REGRESSION PROOF for that move: it still passes with no assertion
+ * edited. Read the helper's docstring for why it is a hand parser and what the differential
+ * against the real `yaml` parser measured.
  */
-function extractPathBlocks(file: string): string[][] {
-  const lines = readFileSync(join(WORKFLOWS, file), 'utf8').split(/\r?\n/);
-  const blocks: string[][] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    if (!/^\s{4}paths:\s*$/.test(lines[i])) continue;
-
-    const out: string[] = [];
-    for (const line of lines.slice(i + 1)) {
-      if (/^\s*#/.test(line) || line.trim() === '') continue;
-      const match = /^\s{6}- '(.+)'\s*$/.exec(line);
-      if (!match) {
-        // A list item we could not read is a parser bug, not the end of the block.
-        // Ending the loop here would silently truncate and pass vacuously downstream.
-        if (/^\s+-\s/.test(line)) {
-          throw new Error(`unparseable list item in ${file}: ${JSON.stringify(line)}`);
-        }
-        break; // dedent or a different key — genuinely the end of the list
-      }
-      out.push(match[1]);
-    }
-    blocks.push(out);
-  }
-
-  if (blocks.length === 0) throw new Error(`no 4-space-indented \`paths:\` block in ${file}`);
-  return blocks;
-}
-
-/** The union of every trigger block — what the workflow can fire on at all. */
-function extractPaths(file: string): string[] {
-  return [...new Set(extractPathBlocks(file).flat())];
-}
 
 describe('MCP workflow paths parity', () => {
   const testPaths = extractPaths('test-mcp-server.yml');

--- a/tests/integration/workflow-secret-scope.test.ts
+++ b/tests/integration/workflow-secret-scope.test.ts
@@ -84,10 +84,7 @@
  * the diff is what to re-run.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-
-const WORKFLOWS = join(process.cwd(), '.github', 'workflows');
+import { workflowFiles, readWorkflow, stripComments } from './helpers/workflow-parse';
 
 /**
  * Secrets that grant deploy authority over the Worker. A job holding any of these is a job
@@ -112,8 +109,8 @@ interface Job {
   environments: string[];
 }
 
-/** Strip comment-only lines so a `secrets.X` mention inside a comment isn't a reference. */
-const stripComments = (lines: string[]) => lines.filter((l) => !l.trimStart().startsWith('#'));
+// `stripComments` (imported above) drops comment-only lines so a `secrets.X` mention inside a
+// comment isn't counted as a reference. It lived here first; it now lives in the shared helper.
 
 /**
  * Does this body read `secret`?
@@ -216,11 +213,13 @@ function parseWorkflows(): Parsed {
   const dynamicIndexUsers: string[] = [];
   const reusableWorkflowCallers: string[] = [];
 
-  // `.ya?ml` — GitHub accepts both, and matching only `.yml` let a rogue `.yaml` workflow
-  // holding an unbound deploy secret pass this suite untouched.
-  for (const workflow of readdirSync(WORKFLOWS).filter((f) => /\.ya?ml$/.test(f))) {
+  // `workflowFiles()` matches `.ya?ml` — GitHub accepts both, and matching only `.yml` let a
+  // rogue `.yaml` workflow holding an unbound deploy secret pass this suite untouched. That is
+  // fail-open #1 in the catalogue above; it now lives in `helpers/workflow-parse.ts` so the
+  // sibling suites inherit the fix rather than re-deriving it.
+  for (const workflow of workflowFiles()) {
     workflows.push(workflow);
-    const lines = readFileSync(join(WORKFLOWS, workflow), 'utf8').split(/\r?\n/);
+    const lines = readWorkflow(workflow);
 
     // `(\s|$)` not `\s*$`: `jobs: # comment` is valid YAML, and the stricter match combined
     // with `continue` silently dropped the whole file. THROW, never skip — every workflow


### PR DESCRIPTION
Started as "why are there cancelled MCP staging deploys on every PR merge?" They are **`skipped`**, not cancelled — `deploy-mcp-staging.yml` has **0 cancelled runs in 339**, and 21 skipped. GitHub draws both with a near-identical grey circle-slash icon.

**No CI behaviour changes here.** Removing the skipped rows would have meant either dropping fork-PR test coverage or building a composite-action split, and neither is worth 21 cosmetic rows. What the investigation turned up instead was a set of genuinely unguarded failure modes and a pile of documentation describing mechanisms that no longer exist.

## The 21 skipped runs are not one thing

`deploy-mcp-staging.yml`'s job `if:` is a three-clause AND, and `conclusion == 'success'` is **not** "the suite passed":

- **15 runs** (2026-08-06 onward) — upstream was a `pull_request` event. The BL-111 fork-trust clause skipped them. Benign.
- **6 runs** (2026-06-01 ×2, 06-05 ×3, 07-08) — predate that clause, which landed 2026-08-05 in `670a643b`. All six pair with an upstream run whose conclusion was **`failure`**. A grey row can mean the MCP suite went red.

A troubleshooting entry now records both arms, plus the fact that you cannot cross-reference by SHA (a `workflow_run` consumer is attributed to the default branch, not the triggering run).

## What is now asserted

`deploy-mcp-production.yml` has stated in prose for months that `workflows: ['MCP Server Test Suite']` is a literal string match and *"a rename breaks the chain silently, and nothing asserts the two agree."* It was right, and three sibling links were equally unguarded. Every failure mode is silent — no red run, just no run, or a skipped one, or a 300-second poll blaming the wrong thing.

| | Guards |
|---|---|
| **A** | staging's `workflow_run.workflows` → the suite's `name:` → the filename `await-mcp-test-run.sh` polls. **Derived**, not compared to literals: adding a `test-mcp-server-v2.yml` and repointing `WORKFLOW` no longer passes. A file rename makes every production deploy burn its full 300s poll then **exit 5** — *"dead token, revoked permission, or a GitHub outage"* — sending the operator to the credentials for what is a rename. |
| **B** | the suite still pushes on `master`, and the pre-flight still filters `?event=push`. Read **trigger-scoped** — the file has a second `branches:` list on its PR trigger that would otherwise mask the break. |
| **C** | the staging consumer still fires on `master`, and never on more branches than the suite tests. Not hypothetical: that file's own header records this list shipping **without** `master`, "so the merge commit never got staging validation" (BL-038). |
| **D** | `.github/workflows/*.yml` literals inside `paths:` lists still name files that exist. `workflow-paths-parity.test.ts` compares the MCP lists only to each other, so a rename staling both identically keeps it green while the self-trigger matches nothing. |

Parsers hoisted to `tests/integration/helpers/workflow-parse.ts`; `workflow-paths-parity.test.ts` and `workflow-secret-scope.test.ts` now share them, and both pass unchanged.

## A fail-open in the fail-open guard, and why it survived

Code review reproduced a defect in the guard written to prevent this exact defect class. `parseTriggerBranches` bounded its multi-line accumulation by end-of-file rather than by the trigger block, so a `branches:` list in **block-sequence form** (legal YAML, accepted by GitHub) made the reader walk out of `push:` and adopt the `pull_request` trigger's `[master]`. Dropping `master` from the push list then parsed as `['master']` and assertion B passed.

It survived a `yaml` differential across all 12 workflows **and** a nine-case mutation matrix. Both are live-tree methods — they only exercise shapes the repo currently contains, and nothing here is written in block form.

So the fix is structural: the parsers split into pure line-based cores plus file-reading wrappers, and `workflow-parse-guards.test.ts` drives every throw path over **synthetic fixtures**, including shapes the repo does not use. The same mistake was found one key over — `extractPathBlocksIfAny` classified an inline `paths: [...]` as "no filter", hiding its entries from D — and is fixed and covered the same way.

## Doc corrections

`fkirc/skip-duplicate-actions@v5` was replaced by ~20 lines of shell when GitHub deprecated Node 20; the doc still described the action and its config keys. Rewritten to what actually runs, scoped precisely — `:210`'s event-scoped concurrency group and "only successful runs dedupe" are still true and are kept; `concurrent_skipping` and `do_not_skip` are gone, which **inverts** the troubleshooting advice about "Re-run all jobs" bypassing dedup. That advice now states only what the mechanism proves and declines to assert the re-run outcome.

Also: `actions: write` → the granted `actions: read`; two documented permissions → the three actually set; and ruleset `15011377` recorded as no longer existing.

## Verification

- **yaml differential** across all 12 workflows: 12 names, 5 paths blocks, 10 branches lists, 1 `workflow_run` list — **zero disagreements**
- **11 mutations** all go red, including the two that previously passed
- Every new fixture assertion proved non-vacuous by reverting its rule
- The secret-scope guard proved still-firing by mutation (rogue `.yaml` with an unbound `CLOUDFLARE_API_TOKEN`), not by a green suite
- `astro check` 0/0/0 · `lint` clean · `lint:css` 0 errors · **1488 tests** · `test:docs` 20

## One thing for you

Ruleset `15011377` — which blocked pushes to `feat/**` and `fix/**` until checks passed — no longer exists; the API returns only the `master` ruleset. Nothing records whether that was deliberate. The doc states it as an observation rather than picking an answer. If it was retired on purpose that paragraph should become the decision; if not, push-time gating on feature branches is currently gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
