### PR TITLE
docs(design-sync): record the ADR-0028 token sync, and retire two papercuts it surfaced

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -427,12 +427,19 @@ Everything authored is committed; everything machine-owned is gitignored. On a n
   bundle. This is the concrete case the standing rule ("the `finalize_plan` write set must
   include `components/chrome/*/*`") exists for: nothing tracks those files, so no verdict can
   list them, and reading the verdict alone ships a stale footer and a stale StatsBar.
-- Uploaded 48 paths: README, `styles.css`, `_ds_bundle.css`/`.js`, `_ds_sync.json`, the four
-  guidelines + index, and all 19 chrome cards ×2 files. **Deliberately NOT re-uploaded**:
-  the ten specimens (unchanged per the diff stage), and `fonts/fonts.css` + the woff2 — the
-  font pair was untouched this round, but note Guard 6's warning that the pinned face reaches
-  designs only via `cfg.extraFonts` and fails invisibly when lost, so re-upload it in any sync
-  that touches `fonts.css`.
+- **Upload the FULL 103-file set. Do not scope writes to what changed** — I did, and it was
+  wrong. The first pass here uploaded 48 paths (the styling/aux files plus all 19 chrome cards)
+  and skipped 55 as "unchanged": the ten specimens ×4, the ten `_preview/*.js`, the two
+  `_vendor` files, the font pair and `_ds_needs_recompile`. Nothing went stale — specimen HTML
+  LINKS `styles.css` and `_ds_bundle.css` rather than inlining them, and `_preview/*.js` carry
+  no token text — but the skill is explicit that this is luck, not method:
+  `.ds-sync/storybook/SKILL.md:279` ("Writes — everything, always … an under-scoped writes list
+  silently and permanently desyncs the project") and `:335` ("never scope writes by the
+  verification partition"), and `lib/remote-diff.mjs:31-37` says the `components` array is NOT
+  a write scope. The remaining 55 were uploaded immediately after, so the project holds the
+  full set — but the correct plan is the one-line glob list from SKILL.md:279, first time.
+  Note especially `fonts/` in that list: Guard 6 records that the pinned face reaches designs
+  only via `cfg.extraFonts` and fails invisibly when lost.
 - Verified after upload rather than assumed: re-read
   `guidelines/src/docs/styles/VARIABLES_REFERENCE.md` off the REMOTE and confirmed both new
   rows sit in the Spacing Scale table at the right ladder positions.
@@ -441,9 +448,12 @@ Everything authored is committed; everything machine-owned is gitignored. On a n
   twin whose background differs from its light sibling. `dark-probe` and `palette-probe` are
   **single-card** — both hardcode `DataSpecimen.html`. `dark-probe` read 4/7 switched; the three
   that did not are `--border-light` and `--color-primary` (both correct — VARIABLES_REFERENCE
-  documents them as deliberately not theme-switched) and `_bodyBg`, a RENDERED proxy, which is
-  expected here because a specimen card cannot go dark at all (the root-only constraint above).
-  `palette-probe`: all six as expected, on that one card.
+  documents them as deliberately not theme-switched) and `_bodyBg`, a RENDERED proxy, expected
+  to stay put because the converter's card scaffold hardcodes `body{background:#fff}` in a
+  `<style>` that FOLLOWS both stylesheet links — reason one of the two under "Dark-mode
+  converter cards are not buildable" above. The card's tokens themselves do switch; the
+  root-only reason is NOT why, since the probe puts `.dark-theme` on `documentElement` and four
+  values moved. `palette-probe`: all six as expected, on that one card.
 - **Run the probes from the repo root — this is intrinsic, not a papercut.** Both resolve a bare
   relative `ds-bundle/...` against `process.cwd()`. A leftover `cd ds-bundle` earlier in a
   session makes them fail with `MODULE_NOT_FOUND` on a path under `ds-bundle/.design-sync/`,

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -404,3 +404,48 @@ Everything authored is committed; everything machine-owned is gitignored. On a n
   the fix is stronger doc copy, not removing the exports (the `[BUNDLE_EXPORT]` gate needs them).
 - The four `guidelinesGlob` docs ship **verbatim** and contain repo-internal references
   (test paths, BL-### ids, `/brand` URLs). Acceptable context, but they leave the repo.
+
+## Sync 2026-09-02 — ADR-0028 spacing tokens (tokens + docs only, no specimen change)
+
+- **Every addition is invisible to the name-parity guard, and a new CLASS is the worst case —
+  not a new token.** Guard 1 in `design-sync-guards.test.ts` resolves docs→src only, so nothing
+  ever fails for a thing that exists in `src/styles` but is missing from the published
+  vocabulary. Tokens have a backstop that classes do not: `docs-variables-sync.test.ts` asserts
+  bidirectionally (":291 — every `:root` token is documented in VARIABLES_REFERENCE.md"), and
+  that file is one of the four uploaded guidelines, so CI drags a new token onto a shipped
+  surface. Nothing forces a new `.brutal-*` class or BEM modifier into `conventions.md` at all.
+  Neither forces the UPLOAD. If you are here after adding a class, you have less coverage than
+  this sync had, not more.
+- **Resync verdict: all ten specimens `unchanged`, zero components in the upload list** — the
+  correct result for a tokens-and-prose change, not a skipped upload. What moved was
+  `styling: true` (the flattened bundle) and `aux: true` (README + the four guideline docs).
+  An empty `components` array is still a real upload. ("Unchanged" is the diff stage's verdict
+  keyed on `sourceKeys`; do not describe it as a hash comparison — the artifacts do not say.)
+- **THREE chrome cards changed, and the verdict could not show any of them** — `SiteFooter`,
+  `SiteFooterDark` (`--spacing-1_25`, from `Footer.astro:17,67` and `FooterLinks.astro:162`)
+  and `StatsBar` (`--spacing-1_75`, from `StatsBar.astro:170`). Both new tokens reached the
+  bundle. This is the concrete case the standing rule ("the `finalize_plan` write set must
+  include `components/chrome/*/*`") exists for: nothing tracks those files, so no verdict can
+  list them, and reading the verdict alone ships a stale footer and a stale StatsBar.
+- Uploaded 48 paths: README, `styles.css`, `_ds_bundle.css`/`.js`, `_ds_sync.json`, the four
+  guidelines + index, and all 19 chrome cards ×2 files. **Deliberately NOT re-uploaded**:
+  the ten specimens (unchanged per the diff stage), and `fonts/fonts.css` + the woff2 — the
+  font pair was untouched this round, but note Guard 6's warning that the pinned face reaches
+  designs only via `cfg.extraFonts` and fails invisibly when lost, so re-upload it in any sync
+  that touches `fonts.css`.
+- Verified after upload rather than assumed: re-read
+  `guidelines/src/docs/styles/VARIABLES_REFERENCE.md` off the REMOTE and confirmed both new
+  rows sit in the Spacing Scale table at the right ladder positions.
+- **Probe scope, so a future run compares like with like.** `extract-chrome --check` is the
+  broad one: 19/19 cards, each asserted for height, a byte floor, zero page errors, and a dark
+  twin whose background differs from its light sibling. `dark-probe` and `palette-probe` are
+  **single-card** — both hardcode `DataSpecimen.html`. `dark-probe` read 4/7 switched; the three
+  that did not are `--border-light` and `--color-primary` (both correct — VARIABLES_REFERENCE
+  documents them as deliberately not theme-switched) and `_bodyBg`, a RENDERED proxy, which is
+  expected here because a specimen card cannot go dark at all (the root-only constraint above).
+  `palette-probe`: all six as expected, on that one card.
+- **Run the probes from the repo root — this is intrinsic, not a papercut.** Both resolve a bare
+  relative `ds-bundle/...` against `process.cwd()`. A leftover `cd ds-bundle` earlier in a
+  session makes them fail with `MODULE_NOT_FOUND` on a path under `ds-bundle/.design-sync/`,
+  which reads like a broken probe. `palette-probe` already had a header comment and an
+  `existsSync` guard that exits with a clear message; `dark-probe` did not, and now does.

--- a/.design-sync/dark-probe.mjs
+++ b/.design-sync/dark-probe.mjs
@@ -3,13 +3,21 @@
 // Opens a real preview card, reads the computed values of the tokens that are
 // supposed to switch, then adds the dark-theme class and reads them again.
 // If light-dark() survived the lightningcss flattening, these differ.
+//
+// Needs a prior full package-build (ds-bundle/ is gitignored). Run from the
+// repo root: node .design-sync/dark-probe.mjs
 /* global document, getComputedStyle -- the page.evaluate() callbacks below are
    serialised and run inside the browser, where these are defined. */
 import { chromium } from 'playwright';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 
 const card = resolve('ds-bundle/components/specimens/DataSpecimen/DataSpecimen.html');
+if (!existsSync(card)) {
+  console.error(`[DARK_PROBE] ${card} not found — run a full package-build first (see NOTES.md).`);
+  process.exit(1);
+}
 const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1200, height: 700 } });
 await page.goto(pathToFileURL(card).href, { waitUntil: 'networkidle' });

--- a/tests/integration/design-sync-guards.test.ts
+++ b/tests/integration/design-sync-guards.test.ts
@@ -564,8 +564,10 @@ function tagHasClassToken(source: string, tag: string, cls: string): boolean {
 
 describe('conventions.md stays under the README inline ceiling', () => {
   // The converter PREPENDS conventions.md to the uploaded README, and the
-  // consumer truncates that README inline at 32,000 characters, cutting the
-  // TAIL (NOTES.md § re-sync risks). Slice 2 hit 31.8 KB when prettier padded
+  // consumer truncates that README inline at 32,000 characters, cutting its
+  // TAIL — which is the converter's own boilerplate (the Components list), NOT
+  // NOTES.md: NOTES.md is never part of the uploaded README, and an earlier
+  // version of this comment said it was. Slice 2 hit 31.8 KB when prettier padded
   // three enumerations into tables — nothing in CI noticed. 28,000 leaves the
   // converter's own boilerplate tail ~4 KB of room; if the header outgrows it,
   // move the overflow into a shipped guideline doc, do not raise the number.


### PR DESCRIPTION
Records the design-sync upload that shipped ADR-0028's two spacing tokens to claude.ai/design, and fixes two probe/guard papercuts found while doing it.

The sync itself is already done — the project holds the full 103-file bundle, and `guidelines/src/docs/styles/VARIABLES_REFERENCE.md` was re-read off the remote to confirm both new rows sit at the right ladder positions. This PR is the in-repo record, which the repo treats as part of the sync rather than optional.

## What the note captures

- **Which addition is actually riskiest.** Guard 1 resolves docs→src only, so *any* src-side addition is invisible to it. A **new class is the worst case, not a new token** — `docs-variables-sync` asserts bidirectionally and `VARIABLES_REFERENCE.md` is an uploaded guideline, so CI drags a new token onto a shipped surface, while nothing forces a class into `conventions.md`. Neither forces the upload. (My first draft had this backwards, in the direction that would have caused the harm the note exists to prevent.)
- **Three chrome cards changed while the resync verdict reported zero components** — `SiteFooter`, `SiteFooterDark` and `StatsBar`. Nothing tracks those files, which is exactly why the standing rule uploads all 19 regardless. Reading the verdict alone would have shipped a stale footer.
- **Upload the full 103-file set; do not scope writes to what changed.** I scoped to 48 and had to correct it. Nothing went stale — specimen HTML links the stylesheets rather than inlining them — but the skill is explicit that this is luck, not method, and the note now carries the glob list to use first time.
- **Probe scope, honestly stated.** `extract-chrome --check` covers all 19 cards; `dark-probe` and `palette-probe` are single-card. All three of dark-probe's unswitched values are named, including `_bodyBg`, which stays light because the card scaffold hardcodes `body{background:#fff}` after both stylesheet links — not because a specimen card "cannot go dark", which the same bullet's 4/7 result would have contradicted.

## Two fixes rather than two more notes

- **`dark-probe.mjs` gains the cwd guard `palette-probe.mjs` already had.** Both resolve a bare relative `ds-bundle/...` against `process.cwd()`, so repo-root is intrinsic. Without the guard, running from elsewhere gives a raw `MODULE_NOT_FOUND` that reads like a broken probe. Verified from `C:/tmp`: it now prints the path it looked for and names the fix.
- **Guard 5's comment contradicted itself** — it said the README truncation cuts "the TAIL (NOTES.md § re-sync risks)" while the same comment three lines later correctly calls that tail the converter's boilerplate. NOTES.md is never in the uploaded README. Comment-only; `CEILING` untouched.

## Verification

`astro check` 0 errors · `lint` clean · `prettier --check` clean · `test:docs` 5 files / 54 tests · `design-sync-guards.test.ts` 19/19.

Note `.design-sync/NOTES.md` is an input to no test, which is why every claim in it was hand-verified against source rather than resting on a green suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
