### PR TITLE
docs(seo): drop the "50+ engagements" figure from three descriptions

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -36,5 +36,5 @@ GST publishes free browser-based diligence tools, a reference library, and an MC
 
 - [Services](https://globalstrategic.tech/services/)
 - [About](https://globalstrategic.tech/about/)
-- [M&A portfolio](https://globalstrategic.tech/ma-portfolio/): 50+ technology diligence and value creation engagements
+- [M&A portfolio](https://globalstrategic.tech/ma-portfolio/): the track record across technology buy-side, sell-side and value creation engagements
 - [Sitemap](https://globalstrategic.tech/sitemap-index.xml)

--- a/src/pages/hub/radar/index.astro
+++ b/src/pages/hub/radar/index.astro
@@ -47,7 +47,7 @@ import { CATEGORIES } from '../../../lib/inoreader/transform';
 
 <BaseLayout
   title="The Radar — Technology & M&A Intelligence | GST"
-  description="Curated intelligence on technology trends, M&A dynamics, and enterprise technology shifts. Practitioner perspectives from technology buy-side, sell-side and value creation engagements."
+  description="Curated intelligence on technology trends and M&A dynamics, with practitioner perspectives from buy-side, sell-side and value creation engagements."
   ogTitle="The Radar - Perspectives | GST"
   ogDescription="Curated technology and M&A intelligence for PE investors and portfolio company leaders."
   ogImage="/og-image.png"

--- a/src/pages/hub/radar/index.astro
+++ b/src/pages/hub/radar/index.astro
@@ -47,7 +47,7 @@ import { CATEGORIES } from '../../../lib/inoreader/transform';
 
 <BaseLayout
   title="The Radar — Technology & M&A Intelligence | GST"
-  description="Curated intelligence on technology trends, M&A dynamics, and enterprise technology shifts. Practitioner perspectives from 50+ PE technology engagements."
+  description="Curated intelligence on technology trends, M&A dynamics, and enterprise technology shifts. Practitioner perspectives from technology buy-side, sell-side and value creation engagements."
   ogTitle="The Radar - Perspectives | GST"
   ogDescription="Curated technology and M&A intelligence for PE investors and portfolio company leaders."
   ogImage="/og-image.png"

--- a/src/pages/ma-portfolio.astro
+++ b/src/pages/ma-portfolio.astro
@@ -34,7 +34,7 @@ const portfolioType = 'ma';
   title="M&A | GST"
   description="Explore GST's track record of 57 M&A advisory and implementation projects across healthcare, logistics, software, finance, and more."
   ogTitle="M&A Portfolio | GST"
-  ogDescription="Explore GST's track record across 50+ technology due diligence and value creation engagements."
+  ogDescription="Explore GST's track record across technology buy-side, sell-side and value creation engagements."
   ogImage="/og-image.png"
   ogImageAlt="GST M&A Portfolio - Technology Due Diligence Track Record"
 >


### PR DESCRIPTION
## Summary

Three descriptions carried a "50+ engagements" count: the portfolio page's Open Graph description, the Radar's meta description, and the portfolio line in `llms.txt`. The portfolio data holds 68 entries and every other page says "100+", so the three surfaces had already drifted apart, and any count in a description rots on the next entry. Each now names the engagement types instead: technology buy-side, sell-side and value creation.

The Radar description is also folded into one sentence, since the first rewrite ran to 184 characters and search engines show about 160.

## Validation

- No test asserts on the old strings (grepped `tests/` and `src/pages`)
- `tests/unit/llms-txt.test.ts` and the MCP marketing parity guard pass; `astro check` 0 errors
- code-reviewer APPROVE marker bound to HEAD

Not touched: the portfolio page's own meta description still says "57 M&A advisory and implementation projects", a separate figure this PR was not asked to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
